### PR TITLE
ensure moderation-config.yaml is preserved in Custom Model updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+- Make sure `moderation-config.yaml` is preserved on Custom Model updates
+
 ## 0.2.3
 
 - Throw error when Deployment fails instead of waiting indefinitely

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1663,56 +1663,54 @@ func (r *CustomModelResource) updateGuardConfigurations(
 ) (
 	err error,
 ) {
-	if !reflect.DeepEqual(plan.GuardConfigurations, state.GuardConfigurations) {
-		var customModel *client.CustomModel
-		customModel, err = r.provider.service.GetCustomModel(ctx, plan.ID.ValueString())
-		if err != nil {
-			return
-		}
-
-		guardsToAdd := make([]GuardConfiguration, 0)
-		for _, guard := range plan.GuardConfigurations {
-			found := false
-			for _, stateGuard := range state.GuardConfigurations {
-				if reflect.DeepEqual(guard, stateGuard) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				guardsToAdd = append(guardsToAdd, guard)
-			}
-		}
-
-		guardsToRemove := make([]GuardConfiguration, 0)
-		for _, stateGuard := range state.GuardConfigurations {
-			found := false
-			for _, guard := range plan.GuardConfigurations {
-				if reflect.DeepEqual(guard, stateGuard) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				guardsToRemove = append(guardsToRemove, stateGuard)
-			}
-		}
-
-		_, errSummary, errDetail := r.createCustomModelVersionFromGuards(
-			ctx,
-			plan,
-			customModel.ID,
-			customModel.LatestVersion.ID,
-			guardsToAdd,
-			guardsToRemove,
-		)
-		if errSummary != "" {
-			err = errors.New(errDetail)
-			return
-		}
-		state.GuardConfigurations = plan.GuardConfigurations
-		state.OverallModerationConfiguration = plan.OverallModerationConfiguration
+	var customModel *client.CustomModel
+	customModel, err = r.provider.service.GetCustomModel(ctx, plan.ID.ValueString())
+	if err != nil {
+		return
 	}
+
+	guardsToAdd := make([]GuardConfiguration, 0)
+	for _, guard := range plan.GuardConfigurations {
+		found := false
+		for _, stateGuard := range state.GuardConfigurations {
+			if reflect.DeepEqual(guard, stateGuard) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			guardsToAdd = append(guardsToAdd, guard)
+		}
+	}
+
+	guardsToRemove := make([]GuardConfiguration, 0)
+	for _, stateGuard := range state.GuardConfigurations {
+		found := false
+		for _, guard := range plan.GuardConfigurations {
+			if reflect.DeepEqual(guard, stateGuard) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			guardsToRemove = append(guardsToRemove, stateGuard)
+		}
+	}
+
+	_, errSummary, errDetail := r.createCustomModelVersionFromGuards(
+		ctx,
+		plan,
+		customModel.ID,
+		customModel.LatestVersion.ID,
+		guardsToAdd,
+		guardsToRemove,
+	)
+	if errSummary != "" {
+		err = errors.New(errDetail)
+		return
+	}
+	state.GuardConfigurations = plan.GuardConfigurations
+	state.OverallModerationConfiguration = plan.OverallModerationConfiguration
 
 	return
 }


### PR DESCRIPTION
This pull request includes updates to the `CHANGELOG.md` file and modifications to the `updateGuardConfigurations` function in `pkg/provider/custom_model_resource.go`. The changes ensure that the `moderation-config.yaml` is preserved during Custom Model updates and simplify the update logic for guard configurations.

### Changes to `CHANGELOG.md`:

* Added version 0.2.4 with a note about preserving `moderation-config.yaml` on Custom Model updates. (`CHANGELOG.md`, [CHANGELOG.mdR1-R4](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4))

### Codebase simplification:

* Removed unnecessary deep equality check for `GuardConfigurations` in the `updateGuardConfigurations` function. (`pkg/provider/custom_model_resource.go`, [pkg/provider/custom_model_resource.goL1666](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL1666))
* Simplified the logic by removing an extra closing brace in the `updateGuardConfigurations` function. (`pkg/provider/custom_model_resource.go`, [pkg/provider/custom_model_resource.goL1715](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL1715))