### PR TITLE
fix phantom updates on Custom Model description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7
+
+- Make `description` Computed for Custom Model in order to fix phantom updates
+
 ## 0.2.6
 
 - Link entities to Use Cases

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -83,6 +83,10 @@ func (r *CustomModelResource) Schema(ctx context.Context, req resource.SchemaReq
 			"description": schema.StringAttribute{
 				MarkdownDescription: "The description of the Custom Model.",
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"source_llm_blueprint_id": schema.StringAttribute{
 				Optional:            true,
@@ -482,7 +486,6 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 		baseEnvironmentVersionID = customModel.LatestVersion.BaseEnvironmentVersionID
 
 		state.Name = types.StringValue(name)
-		state.Description = plan.Description
 	} else {
 		classLabels, err := getClassLabels(plan)
 		if err != nil {
@@ -514,7 +517,6 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 
 		state.ID = types.StringValue(customModelID)
 		state.Name = types.StringValue(name)
-		state.Description = plan.Description
 		state.TargetType = types.StringValue(plan.TargetType.ValueString())
 		state.ClassLabels = plan.ClassLabels
 		state.ClassLabelsFile = plan.ClassLabelsFile
@@ -577,6 +579,7 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 	state.VersionID = types.StringValue(customModel.LatestVersion.ID)
 	state.BaseEnvironmentID = types.StringValue(customModel.LatestVersion.BaseEnvironmentID)
 	state.BaseEnvironmentVersionID = types.StringValue(customModel.LatestVersion.BaseEnvironmentVersionID)
+	state.Description = types.StringValue(customModel.Description)
 	state.SourceRemoteRepositories = plan.SourceRemoteRepositories
 	state.FolderPath = plan.FolderPath
 	state.FolderPathHash = plan.FolderPathHash

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -968,6 +968,7 @@ resource "datarobot_custom_model" "test_from_llm_blueprint" {
 	name = "%s"
 	description = "%s"
 	source_llm_blueprint_id = "${datarobot_llm_blueprint.test_custom_model.id}"
+	base_environment_id = "65f9b27eab986d30d4c64268"
 	runtime_parameter_values = [
 	  { 
 		  key="OPENAI_API_BASE", 
@@ -1329,8 +1330,13 @@ func checkCustomModelResourceExists(resourceName string) resource.TestCheckFunc 
 
 		if customModel.Name == rs.Primary.Attributes["name"] &&
 			customModel.Description == rs.Primary.Attributes["description"] {
-			if rs.Primary.Attributes["runtime_parameter_values.0.value"] != "" &&
-				(customModel.LatestVersion.RuntimeParameters[0].CurrentValue != rs.Primary.Attributes["runtime_parameter_values.0.value"]) {
+			if rs.Primary.Attributes["runtime_parameter_values.0.value"] != "" {
+				for _, runtimeParam := range customModel.LatestVersion.RuntimeParameters {
+					if runtimeParam.FieldName == rs.Primary.Attributes["runtime_parameter_values.0.key"] &&
+						runtimeParam.CurrentValue == rs.Primary.Attributes["runtime_parameter_values.0.value"] {
+						return nil
+					}
+				}
 				return fmt.Errorf("Runtime parameter value does not match")
 			}
 			return nil


### PR DESCRIPTION
This pull request includes several changes to improve the handling of the `description` attribute for the `CustomModelResource` and to enhance the test coverage. The most important changes involve making the `description` attribute computed, updating the `Create` method to set the `description` state, and refining the test cases to ensure correct functionality.

### Improvements to `description` attribute handling:

* [`pkg/provider/custom_model_resource.go`](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afR86-R89): Made the `description` attribute computed and added a plan modifier to use the state for unknown values.
* [`pkg/provider/custom_model_resource.go`](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afR582): Updated the `Create` method to set the `description` state from the `customModel` object.

### Enhancements to test coverage:

* [`pkg/provider/custom_model_resource_test.go`](diffhunk://#diff-230e859113b75eabd363bb98279014c4885ba12519a2a86b280be39103d78b20R971): Added `base_environment_id` to the test resource configuration to ensure comprehensive testing.
* [`pkg/provider/custom_model_resource_test.go`](diffhunk://#diff-230e859113b75eabd363bb98279014c4885ba12519a2a86b280be39103d78b20L1332-R1339): Refined the `checkCustomModelResourceExists` function to correctly verify runtime parameter values.

### Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added a new entry for version 0.2.7, documenting the change to make the `description` attribute computed.