### PR TITLE
block updating immutable Custom Model attributes if deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+- Block updating immutable Custom Model attributes if deployed
+
 ## 0.3.1
 
 - Clean up integration tests

--- a/pkg/provider/deployment_resource_test.go
+++ b/pkg/provider/deployment_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/datarobot-community/terraform-provider-datarobot/internal/client"
@@ -55,7 +56,7 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: deploymentResourceConfig("example_label", "MODERATE", &useCaseResourceName, false, false, false, false, false, false, false),
+				Config: deploymentResourceConfig("example_label", "MODERATE", "target", &useCaseResourceName, false, false, false, false, false, false, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
 						resourceName,
@@ -84,7 +85,7 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 			},
 			// Update label, importance, settings, and use case id
 			{
-				Config: deploymentResourceConfig("new_example_label", "LOW", &useCaseResourceName2, true, true, true, true, true, true, true),
+				Config: deploymentResourceConfig("new_example_label", "LOW", "target", &useCaseResourceName2, true, true, true, true, true, true, true),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
 						resourceName,
@@ -109,7 +110,7 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 			},
 			// Remove settings and use case id
 			{
-				Config: deploymentResourceConfig("new_example_label", "LOW", nil, false, false, false, false, false, false, false),
+				Config: deploymentResourceConfig("new_example_label", "LOW", "target", nil, false, false, false, false, false, false, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
 						resourceName,
@@ -135,6 +136,11 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
+			// Try to update target_name of Custom Model (should fail)
+			{
+				Config:      deploymentResourceConfig("new_example_label", "LOW", "new_target", nil, false, false, false, false, false, false, false),
+				ExpectError: regexp.MustCompile(`target_name cannot be changed if the model was deployed.`),
+			},
 			// Update custom model version (by updating the file contents) updates registered model version of deployment
 			// which triggers a model replacement for the Deployment
 			{
@@ -143,7 +149,7 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 						t.Fatal(err)
 					}
 				},
-				Config: deploymentResourceConfig("new_example_label", "LOW", nil, false, false, false, false, false, false, false),
+				Config: deploymentResourceConfig("new_example_label", "LOW", "target", nil, false, false, false, false, false, false, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
 						resourceName,
@@ -185,6 +191,7 @@ func TestDeploymentResourceSchema(t *testing.T) {
 func deploymentResourceConfig(
 	label,
 	importance string,
+	customModelTargetName string,
 	useCaseResourceName *string,
 	isPredictionsByForecastDateEnabled,
 	isSegmentAnalysisEnabled,
@@ -290,7 +297,7 @@ resource "datarobot_custom_model" "test_deployment" {
 	name = "test deployment"
 	description = "test"
 	target_type = "Binary"
-	target_name = "my_label"
+	target_name = "%s"
 	base_environment_id = "65f9b27eab986d30d4c64268"
 	folder_path = "deployment"
 }
@@ -312,7 +319,7 @@ resource "datarobot_deployment" "test" {
 	%s
 	%s
 }
-`, label, importance, useCaseIDsStr, deploymentSettings)
+`, customModelTargetName, label, importance, useCaseIDsStr, deploymentSettings)
 }
 
 func checkDeploymentResourceExists() resource.TestCheckFunc {


### PR DESCRIPTION
This pull request includes changes to enforce immutability of certain Custom Model attributes when the model is deployed, and updates to the corresponding tests. The most important changes include blocking updates to immutable attributes and adding tests to ensure these attributes cannot be changed once the model is deployed.

### Enforcing immutability of Custom Model attributes:
* [`pkg/provider/custom_model_resource.go`](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL143): Added checks in the `ModifyPlan` function to block updates to `target_name`, `positive_class_label`, `negative_class_label`, `class_labels`, and `class_labels_file` if the model has deployments. Removed the `RequiresReplaceIfDeployed` plan modifiers from these attributes. [[1]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL143) [[2]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL152) [[3]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL161) [[4]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL188-L197) [[5]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afR945-R973) [[6]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afR1009-R1017) [[7]](diffhunk://#diff-94743e6a8d375df921a6fb09057662a62693f1a096883ddf1bc4c53cf765b5afL1907-L1958)

### Test updates:
* [`pkg/provider/deployment_resource_test.go`](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dR7): Updated test configurations to include `target_name` and added a test case to ensure updating `target_name` fails when the model is deployed. [[1]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dR7) [[2]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL58-R59) [[3]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL87-R88) [[4]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL112-R113) [[5]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dR139-R143) [[6]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL146-R152) [[7]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dR194) [[8]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL293-R300) [[9]](diffhunk://#diff-96d6df18e132a58d68f8e9146afc7d159aee5551204b9cc4d1413ba04a15d78dL315-R322)

### Documentation:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added an entry for version 0.3.3 to document the change that blocks updates to immutable Custom Model attributes if deployed.