### PR TITLE
Paginate List APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Paginate List API calls
+
 ## 0.3.3
 
 - Block updating immutable Custom Model attributes if deployed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/golang/mock v1.6.0
+	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-docs v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -61,9 +61,12 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/client/application_service.go
+++ b/internal/client/application_service.go
@@ -45,10 +45,6 @@ type CreateApplicationSourceVersionRequest struct {
 	RuntimeParameterValues   string               `json:"runtimeParameterValues,omitempty"`
 }
 
-type ListApplicationSourceVersionsResponse struct {
-	Data []ApplicationSourceVersion `json:"data"`
-}
-
 type ApplicationSourceVersion struct {
 	ID                       string               `json:"id"`
 	Label                    string               `json:"label"`

--- a/internal/client/custom_model_service.go
+++ b/internal/client/custom_model_service.go
@@ -156,10 +156,6 @@ type RuntimeParameterValueRequest struct {
 	Value     *any   `json:"value"`
 }
 
-type ListExecutionEnvironmentsResponse struct {
-	Data []ExecutionEnvironment `json:"data"`
-}
-
 type ExecutionEnvironment struct {
 	ID            string                      `json:"id"`
 	Name          string                      `json:"name"`
@@ -170,10 +166,6 @@ type ExecutionEnvironment struct {
 type ExecutionEnvironmentVersion struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
-}
-
-type ListGuardTemplatesResponse struct {
-	Data []GuardTemplate `json:"data"`
 }
 
 type GuardTemplate struct {

--- a/internal/client/llm_blueprint_service.go
+++ b/internal/client/llm_blueprint_service.go
@@ -41,10 +41,6 @@ type LLMBlueprint struct {
 	PromptType       string      `json:"promptType"`
 }
 
-type ListLLMsResponse struct {
-	Data []LanguageModelDefinitionAPIFormatted `json:"data"`
-}
-
 type LanguageModelDefinitionAPIFormatted struct {
 	ID string `json:"id"`
 }

--- a/internal/client/registered_model_service.go
+++ b/internal/client/registered_model_service.go
@@ -37,8 +37,14 @@ type UpdateRegisteredModelVersionRequest struct {
 	PredictionThreshold *float64 `json:"predictionThreshold,omitempty"`
 }
 
+type ListRegisteredModelsRequest struct {
+	IsGlobal bool   `url:"isGlobal,omitempty"`
+	Search   string `url:"search,omitempty"`
+}
+
 type ListRegisteredModelsResponse struct {
 	Data []RegisteredModel
+	Next string
 }
 
 type UpdateRegisteredModelRequest struct {
@@ -66,4 +72,5 @@ type RegisteredModelVersionTarget struct {
 
 type ListRegisteredModelVersionsResponse struct {
 	Data []RegisteredModelVersion
+	Next string
 }

--- a/mock/service.go
+++ b/mock/service.go
@@ -1042,41 +1042,11 @@ func (mr *MockServiceMockRecorder) IsVectorDatabaseReady(ctx, id interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVectorDatabaseReady", reflect.TypeOf((*MockService)(nil).IsVectorDatabaseReady), ctx, id)
 }
 
-// ListApplicationSourceVersions mocks base method.
-func (m *MockService) ListApplicationSourceVersions(ctx context.Context, id string) (*client.ListApplicationSourceVersionsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListApplicationSourceVersions", ctx, id)
-	ret0, _ := ret[0].(*client.ListApplicationSourceVersionsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListApplicationSourceVersions indicates an expected call of ListApplicationSourceVersions.
-func (mr *MockServiceMockRecorder) ListApplicationSourceVersions(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplicationSourceVersions", reflect.TypeOf((*MockService)(nil).ListApplicationSourceVersions), ctx, id)
-}
-
-// ListExecutionEnvironments mocks base method.
-func (m *MockService) ListExecutionEnvironments(ctx context.Context) (*client.ListExecutionEnvironmentsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExecutionEnvironments", ctx)
-	ret0, _ := ret[0].(*client.ListExecutionEnvironmentsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListExecutionEnvironments indicates an expected call of ListExecutionEnvironments.
-func (mr *MockServiceMockRecorder) ListExecutionEnvironments(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExecutionEnvironments", reflect.TypeOf((*MockService)(nil).ListExecutionEnvironments), ctx)
-}
-
 // ListGuardTemplates mocks base method.
-func (m *MockService) ListGuardTemplates(ctx context.Context) (*client.ListGuardTemplatesResponse, error) {
+func (m *MockService) ListGuardTemplates(ctx context.Context) ([]client.GuardTemplate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGuardTemplates", ctx)
-	ret0, _ := ret[0].(*client.ListGuardTemplatesResponse)
+	ret0, _ := ret[0].([]client.GuardTemplate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1087,26 +1057,11 @@ func (mr *MockServiceMockRecorder) ListGuardTemplates(ctx interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGuardTemplates", reflect.TypeOf((*MockService)(nil).ListGuardTemplates), ctx)
 }
 
-// ListLLMs mocks base method.
-func (m *MockService) ListLLMs(ctx context.Context) (*client.ListLLMsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLLMs", ctx)
-	ret0, _ := ret[0].(*client.ListLLMsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListLLMs indicates an expected call of ListLLMs.
-func (mr *MockServiceMockRecorder) ListLLMs(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLLMs", reflect.TypeOf((*MockService)(nil).ListLLMs), ctx)
-}
-
 // ListRegisteredModelVersions mocks base method.
-func (m *MockService) ListRegisteredModelVersions(ctx context.Context, id string) (*client.ListRegisteredModelVersionsResponse, error) {
+func (m *MockService) ListRegisteredModelVersions(ctx context.Context, id string) ([]client.RegisteredModelVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRegisteredModelVersions", ctx, id)
-	ret0, _ := ret[0].(*client.ListRegisteredModelVersionsResponse)
+	ret0, _ := ret[0].([]client.RegisteredModelVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1118,18 +1073,18 @@ func (mr *MockServiceMockRecorder) ListRegisteredModelVersions(ctx, id interface
 }
 
 // ListRegisteredModels mocks base method.
-func (m *MockService) ListRegisteredModels(ctx context.Context) (*client.ListRegisteredModelsResponse, error) {
+func (m *MockService) ListRegisteredModels(ctx context.Context, req *client.ListRegisteredModelsRequest) ([]client.RegisteredModel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegisteredModels", ctx)
-	ret0, _ := ret[0].(*client.ListRegisteredModelsResponse)
+	ret := m.ctrl.Call(m, "ListRegisteredModels", ctx, req)
+	ret0, _ := ret[0].([]client.RegisteredModel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListRegisteredModels indicates an expected call of ListRegisteredModels.
-func (mr *MockServiceMockRecorder) ListRegisteredModels(ctx interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) ListRegisteredModels(ctx, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegisteredModels", reflect.TypeOf((*MockService)(nil).ListRegisteredModels), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegisteredModels", reflect.TypeOf((*MockService)(nil).ListRegisteredModels), ctx, req)
 }
 
 // RemoveEntityFromUseCase mocks base method.

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1305,8 +1305,8 @@ func (r *CustomModelResource) createCustomModelVersionFromGuards(
 
 	for _, guardConfigToAdd := range guardConfigsToAdd {
 		var guardTemplate *client.GuardTemplate
-		for index := range guardTemplates.Data {
-			template := guardTemplates.Data[index]
+		for index := range guardTemplates {
+			template := guardTemplates[index]
 			if template.Name == guardConfigToAdd.TemplateName.ValueString() {
 				guardTemplate = &template
 				break

--- a/pkg/provider/llm_blueprint_resource.go
+++ b/pkg/provider/llm_blueprint_resource.go
@@ -170,33 +170,6 @@ func (r *LLMBlueprintResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	var llmID string
-	if IsKnown(data.LLMID) {
-		llmID = data.LLMID.ValueString()
-		listResp, err := r.provider.service.ListLLMs(ctx)
-		if err != nil {
-			resp.Diagnostics.AddError("Error getting LLM Blueprint", err.Error())
-			return
-		}
-
-		// loop through resp.data and ensure llmID exists in the list
-		llmExists := false
-		for _, llm := range listResp.Data {
-			if llm.ID == llmID {
-				llmExists = true
-				break
-			}
-		}
-
-		if !llmExists {
-			resp.Diagnostics.AddError(
-				"Error getting LLM Blueprint",
-				fmt.Sprintf("Unable to get LLM Blueprint, LLM ID does not exist: %s", llmID),
-			)
-			return
-		}
-	}
-
 	createLLMBlueprintRequest := &client.CreateLLMBlueprintRequest{
 		Name:             data.Name.ValueString(),
 		Description:      data.Description.ValueString(),

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -273,21 +273,6 @@ func TestCustomModelFromGitHub(t *testing.T) {
 	require.Equal(newName, remoteRepository.Name)
 	require.Equal(newDescription, remoteRepository.Description)
 
-	listResp, err := s.ListExecutionEnvironments(ctx)
-	require.NoError(err)
-
-	var environmentID string
-	var environmentVersionID string
-	for _, executionEnvironment := range listResp.Data {
-		if executionEnvironment.Name == "[GenAI] Python 3.11 with Moderations" {
-			environmentID = executionEnvironment.ID
-			environmentVersionID = executionEnvironment.LatestVersion.ID
-			break
-		}
-	}
-	require.NotEmpty(environmentID)
-	require.NotEmpty(environmentVersionID)
-
 	name = "Integration Test" + uuid.New().String()
 	description = "This is a test custom model."
 	customModel, err := s.CreateCustomModel(ctx, &client.CreateCustomModelRequest{
@@ -301,7 +286,7 @@ func TestCustomModelFromGitHub(t *testing.T) {
 	require.NotEmpty(customModel.ID)
 
 	_, _, err = s.CreateCustomModelVersionFromRemoteRepository(ctx, customModel.ID, &client.CreateCustomModelVersionFromRemoteRepositoryRequest{
-		BaseEnvironmentID: environmentID,
+		BaseEnvironmentID: "65f9b27eab986d30d4c64268",
 		IsMajorUpdate:     true,
 		RepositoryID:      remoteRepository.ID,
 		Ref:               "master",
@@ -448,9 +433,9 @@ func TestApplicationFromCustomModel(t *testing.T) {
 
 	overallModerationConfiguration.TimeoutSec = 120
 
-	listGuardTemplatesResp, err := s.ListGuardTemplates(ctx)
+	guardTemplates, err := s.ListGuardTemplates(ctx)
 	require.NoError(err)
-	require.NotEmpty(listGuardTemplatesResp.Data)
+	require.NotEmpty(guardTemplates)
 
 	var newGuardData client.GuardConfiguration
 


### PR DESCRIPTION
This pull request introduces pagination support for List API calls, removes unused response types, and updates the service interface to use the new pagination functionality. Additionally, it updates the mock service to reflect these changes.

### Pagination and API Enhancements:

* Added a `PaginatedResponse` type and a `GetAllPages` function to handle paginated API responses in `internal/client/client.go`. [[1]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514R12-R24) [[2]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514R131-R154)

### Removal of Unused Types:

* Removed unused response types such as `ListApplicationSourceVersionsResponse`, `ListExecutionEnvironmentsResponse`, and `ListGuardTemplatesResponse` from various files. [[1]](diffhunk://#diff-9cfb1e553d35e26e8fce058097152e6919f357ecedb6364ed9eec765ae264a6fL48-L51) [[2]](diffhunk://#diff-285417b43ec40b5f9feb83c75ed265c924547e7968031d9dd458e92d153e69b2L159-L162) [[3]](diffhunk://#diff-285417b43ec40b5f9feb83c75ed265c924547e7968031d9dd458e92d153e69b2L175-L178) [[4]](diffhunk://#diff-cfd2d215239e493186e70bd289a2cd6a735ba32d5338a422a3f526c7784760eaL44-L47)

### Service Interface Updates:

* Updated the `Service` interface to remove methods that return the unused response types and replaced them with methods that leverage the new pagination functionality. [[1]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL57) [[2]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL69-R68) [[3]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL81-R83) [[4]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL114) [[5]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL304-L307) [[6]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL348-R342) [[7]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL393-R383) [[8]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL408-R398) [[9]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL427-R417) [[10]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccL522-L525)

### Mock Service Updates:

* Updated the mock service to align with the new service interface changes, removing methods that return the unused response types and updating existing methods to use the new pagination functionality. [[1]](diffhunk://#diff-abc7a0658f54544ee7e7926dff547cf1685ebdeae9bbd8a903abda28536579b5L1045-R1049) [[2]](diffhunk://#diff-abc7a0658f54544ee7e7926dff547cf1685ebdeae9bbd8a903abda28536579b5L1090-R1064) [[3]](diffhunk://#diff-abc7a0658f54544ee7e7926dff547cf1685ebdeae9bbd8a903abda28536579b5L1121-R1087)

### Dependency Updates:

* Added `github.com/google/go-querystring` to `go.mod` for handling query string encoding.