### PR TITLE
[-] Add Notebook workflow example to TF Provider

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ export DATAROBOT_API_TOKEN=<YOUR_API_KEY>
 
 ## Regenerating Docs
 
-Documentations is generated based on the `Description` and `MarkdownDescription` fields in the schemas.
+Documentation is generated based on the `Description` and `MarkdownDescription` fields in the schemas.
 
 ~~~shell
 make generate

--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ Since the provider has not been published to the Terraform Registry yet, you mus
 
 1. Run `make install` to build the provider locally. 
 
-Now you can continue with the Low Code RAG example:
+Now you can continue with the Low Code RAG example (or the notebooks example):
 
-1. Go to the `examples/workflows/low_code_rag` directory.
+1. Go to either the `examples/workflows/low_code_rag` or `examples/workflows/notebooks` directory.
 
     ~~~ shell
     cd examples/workflows/low_code_rag
+    ~~~
+
+    ~~~ shell
+    cd examples/workflows/notebooks
     ~~~
 
 1. The provider requires an API key set in an environment variable named `DATROBOT_API_TOKEN`. Copy the [API key](https://docs.datarobot.com/en/docs/get-started/acct-mgmt/acct-settings/api-key-mgmt.html#api-key-management) from the DataRobot console and create the `DATAROBOT_API_TOKEN` environment variable.
@@ -45,10 +49,12 @@ Now you can continue with the Low Code RAG example:
     ~~~
 
     Where `<your API key>` is the API key you copied from the DataRobot Console.
- 
- 1. The example requires Google Cloud service account credentials in order to call the Google Vertex AI API. Follow [this guide](https://cloud.google.com/iam/docs/keys-create-delete#creating) to create a service account key for your Google account.
 
- 1. In a text editor create a new file `terraform.tfvars` in `low_code_rag` with the following settings.
+    You can alternately set this API KEY in the `main.tf` file in the example's directory using the `apikey` value set in the `provider`.
+ 
+ 1. The RAG example requires Google Cloud service account credentials in order to call the Google Vertex AI API. Follow [this guide](https://cloud.google.com/iam/docs/keys-create-delete#creating) to create a service account key for your Google account.
+
+ 1. For the RAG example, in a text editor create a new file `terraform.tfvars` in `low_code_rag` with the following settings.
 
      ~~~
     use_case_name = "<use case name>"
@@ -81,7 +87,7 @@ Now you can continue with the Low Code RAG example:
 
     Enter `yes` when prompted to apply the plan and create the resources.
 
-1. Once the creation is complete, navigate to the `datarobot_qa_application_url` to view your Q&A application.
+1. Once the creation is complete, navigate to the `datarobot_qa_application_url` to view your Q&A application. Or if working with notebook example use the `datarobot_notebook_url` provided in the output.
 
     ~~~ shell
     Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

--- a/examples/workflows/low_code_rag/main.tf
+++ b/examples/workflows/low_code_rag/main.tf
@@ -15,7 +15,14 @@ terraform {
 }
 
 provider "datarobot" {
-  # export DATAROBOT_API_TOKEN="the API Key value here"
+  # There are two options to set your API Key using either an environment variable or set in the code here.
+  # Option one is to use this line in your terminal `export DATAROBOT_API_TOKEN="the API Key value here"`
+  # Option two is to uncomment the line below and enter your API Key
+  # apikey = "<REPLACE_WITH_YOUR_API_KEY>"
+
+  # This is the default endpoint but you may find value in altering it.
+  # For example either our EU or JP endpoints like: https://app.eu.datarobot.com/api/v2
+  endpoint = "https://app.datarobot.com/api/v2"
 }
 
 resource "datarobot_use_case" "example" {

--- a/examples/workflows/notebooks/main.tf
+++ b/examples/workflows/notebooks/main.tf
@@ -1,0 +1,36 @@
+variable "use_case_name" {
+  type = string
+}
+
+terraform {
+  required_providers {
+    datarobot = {
+      source = "datarobot-community/datarobot"
+    }
+  }
+}
+
+provider "datarobot" {
+  # There are two options to set your API Key using either an environment variable or set in the code here.
+  # Option one is to use this line in your terminal `export DATAROBOT_API_TOKEN="the API Key value here"`
+  # Option two is to uncomment the line below and enter your API Key
+  # apikey = "<REPLACE_WITH_YOUR_API_KEY>"
+
+  # This is the default endpoint but you may find value in altering it.
+  # For example either our EU or JP endpoints like: https://app.eu.datarobot.com/api/v2
+  endpoint = "https://app.datarobot.com/api/v2"
+}
+
+resource "datarobot_use_case" "example" {
+  name = var.use_case_name
+}
+
+resource "datarobot_notebook" "example" {
+  file_path   = "./test_notebook.ipynb"
+  use_case_id = datarobot_use_case.example.id
+}
+
+output "datarobot_notebook_url" {
+  value       = datarobot_notebook.example.url
+  description = "The URL for the Notebook"
+}

--- a/examples/workflows/notebooks/terraform.tfvars
+++ b/examples/workflows/notebooks/terraform.tfvars
@@ -1,0 +1,1 @@
+use_case_name = "My Test Use Case"

--- a/examples/workflows/notebooks/test_notebook.ipynb
+++ b/examples/workflows/notebooks/test_notebook.ipynb
@@ -1,0 +1,57 @@
+{
+	"cells": [
+		{
+			"id": "67f06651dde320520f20ee51",
+			"cell_type": "markdown",
+			"source": "# DataRobot Terraform Provider Test Notebook\n\nWe're working to make using DataRobot and Terraform together easy, especially with notebooks!\n\nPlease take a look at our [terraform-provider-datarobot](https://github.com/datarobot-community/terraform-provider-datarobot)\n",
+			"metadata": {
+				"collapsed": false,
+				"scrolled": false,
+				"datarobot": {
+					"language": "markdown"
+				},
+				"hide_code": false,
+				"hide_results": false,
+				"disable_run": false,
+				"chart_settings": null,
+				"custom_metric_settings": null,
+				"custom_llm_metric_settings": null,
+				"dataframe_view_options": null
+			}
+		},
+		{
+			"id": "67f0697ddde320520f20ef4f",
+			"cell_type": "code",
+			"source": "print(\"Hello, world.\")",
+			"metadata": {
+				"collapsed": false,
+				"scrolled": false,
+				"datarobot": {
+					"language": "python"
+				},
+				"hide_code": false,
+				"hide_results": false,
+				"disable_run": false,
+				"chart_settings": null,
+				"custom_metric_settings": null,
+				"custom_llm_metric_settings": null,
+				"dataframe_view_options": null
+			},
+			"outputs": [],
+			"execution_count": null
+		}
+	],
+	"metadata": {
+		"kernelspec": {
+			"name": "python",
+			"language": "python",
+			"display_name": "Python 3.11"
+		},
+		"language_info": {
+			"name": "python",
+			"version": "3.11"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 5
+}


### PR DESCRIPTION
# RATIONALE

While starting to see about adding Codespace support I wanted an easy way to confirm non-Codespace Notebook flow was working correctly.

Once we add Codespace support I believe a workflow for that as well may be valuable.

## CHANGES

- Fixed typo I noticed in development markdown file
- Updated README to represent changes I made to add another example workflow
- Updated the example RAG `main.tf` to have notes on how to set values in `provider "datarobot"`
- Added a notebook workflow example and associated sample .ipynb file along with variable file

## SCREENSHOTS

I tested locally using one of our Dev. Envs.

<img width="980" alt="Screenshot 2025-04-04 at 7 52 11 PM" src="https://github.com/user-attachments/assets/b4177289-d3d7-4adc-a8b5-bb1994c4c616" />
