### PR TITLE
[-] Skip Registered model test - from LEaderboard

### DIFF
--- a/pkg/provider/registered_model_from_leaderboard_resource_test.go
+++ b/pkg/provider/registered_model_from_leaderboard_resource_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccRegisteredModelFromLeaderboardResource(t *testing.T) {
 	t.Parallel()
-
+	t.Skip("Skipping TestAccRegisteredModelFromLeaderboardResource until we can get a model id that works in all environments")
 	modelID := "673b722dfd279fd86944d088"
 	modelID2 := "673b6fd8e060b90658aebe66"
 	if strings.Contains(globalTestCfg.Endpoint, "staging") {


### PR DESCRIPTION
AS models in this test not created and hardcoded that's may fail on other environments,
add skip line to skip it until it will be refactored