### PR TITLE
[CFX-1998] Fix the memory_mb overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed memory size overwrite issue in the Custom Model resource. Added a check to ensure that the memory size attribute is not when the `resource_bundle_id` is set to a non-empty value. This prevents the memory size from being unintentionally overwritten when using resource bundles.
+- Fixed memory size overwrite issue in the Custom Model resource. Added a check to ensure that the memory size attribute is not set when the `resource_bundle_id` is set to a non-empty value. This prevents the memory size from being unintentionally overwritten when using resource bundles.
 
 ## v0.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.9.3] - 2025-04-23
+
+### Fixed
+
+- Fixed memory size overwrite issue in the Custom Model resource. Added a check to ensure that the memory size attribute is not when the `resource_bundle_id` is set to a non-empty value. This prevents the memory size from being unintentionally overwritten when using resource bundles.
+
 ## v0.9.2
 
 - Trigger new Execution Environment version on Docker Image changes

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -738,7 +738,7 @@ func TestAccBinaryCustomModelResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "negative_class_label", "no"),
 					resource.TestCheckResourceAttr(resourceName, "language", "r"),
 					resource.TestCheckResourceAttr(resourceName, "prediction_threshold", "0.8"),
-					resource.TestCheckResourceAttr(resourceName, "memory_mb", "2048"),
+					resource.TestCheckNoResourceAttr(resourceName, "memory_mb"),
 					resource.TestCheckResourceAttr(resourceName, "replicas", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access", "PUBLIC"),
 					resource.TestCheckResourceAttr(resourceName, "resource_bundle_id", resourceBundle),
@@ -757,7 +757,7 @@ func TestAccBinaryCustomModelResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "negative_class_label", "no"),
 					resource.TestCheckResourceAttr(resourceName, "language", "r"),
 					resource.TestCheckResourceAttr(resourceName, "prediction_threshold", "0.8"),
-					resource.TestCheckResourceAttr(resourceName, "memory_mb", "2048"),
+					resource.TestCheckNoResourceAttr(resourceName, "memory_mb"),
 					resource.TestCheckResourceAttr(resourceName, "replicas", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access", "PUBLIC"),
 					resource.TestCheckResourceAttr(resourceName, "resource_bundle_id", resourceBundle2),
@@ -1106,14 +1106,14 @@ resource "datarobot_custom_model" "test_from_llm_blueprint" {
 	source_llm_blueprint_id = "${datarobot_llm_blueprint.test_custom_model.id}"
 	base_environment_id = "67ab469cecdca772287de644"
 	runtime_parameter_values = [
-	  { 
-		  key="OPENAI_API_BASE", 
-		  type="string", 
+	  {
+		  key="OPENAI_API_BASE",
+		  type="string",
 		  value="https://datarobot-genai-enablement.openai.azure.com/"
 	  },
-	  { 
-		  key="OPENAI_API_KEY", 
-		  type="credential", 
+	  {
+		  key="OPENAI_API_KEY",
+		  type="credential",
 		  value=datarobot_api_token_credential.test_custom_model.id
 	  }
 	]
@@ -1258,7 +1258,7 @@ resource "datarobot_api_token_credential" "%s" {
 	name = "open ai %s %s"
 	api_token = "test"
 }
-	
+
 resource "datarobot_custom_model" "%s" {
 	name        		  = "%s"
 	description 		  = "%s"


### PR DESCRIPTION
### Fixed
 **_maximumMemory_**  - This setting is incompatible with setting the resourceBundleId.
so there also shouldn't be any default values for that, even for update or create, as it might be restricted to change the size of memory by organization 

### Added
test check that **_memory_mb_** not exist in resource when it's updating/adding _**resource_bundle_id**_