### PR TITLE
[YOLO] a quick fix to prevent flaky tests

### DIFF
--- a/pkg/provider/application_source_resource_test.go
+++ b/pkg/provider/application_source_resource_test.go
@@ -43,7 +43,7 @@ func TestApplicationSourceResourceSchema(t *testing.T) {
 func testApplicationSourceResource(t *testing.T, isMock bool) {
 	resourceName := "datarobot_application_source.test"
 
-	newName := "new_example_name " + nameSalt
+	newName := "application_source " + nameSalt
 
 	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
 	baseEnvironmentVersionID := "668548c1b8e086572a96fbf5"
@@ -421,9 +421,9 @@ func applicationSourceResourceConfig(
 	if len(files) > 0 {
 		runtimeParamValueStr = `
 		runtime_parameter_values = [
-			{ 
-				key="STRING_PARAMETER", 
-				type="string", 
+			{
+				key="STRING_PARAMETER",
+				type="string",
 				value="val",
 			},
 		  ]`

--- a/pkg/provider/custom_application_from_environment_resource_test.go
+++ b/pkg/provider/custom_application_from_environment_resource_test.go
@@ -28,8 +28,8 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	name := "example_name_from_env" + nameSalt
-	newName := "new_example_name_from_env " + nameSalt
+	name := "custom_app_from_env" + nameSalt
+	newName := "new_custom_app_from_env " + nameSalt
 
 	environmentID := "67987589391fe8fa0a2275b8"
 	environmentID2 := "67987b1a90dbd55389b699c2"

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -24,7 +24,7 @@ func TestAccCustomApplicationResource(t *testing.T) {
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 
-	newName := "new_example_name " + nameSalt
+	newName := "new_custom_application " + nameSalt
 
 	useCaseResourceName := "test_custom_application"
 	useCaseResourceName2 := "test_new_custom_application"

--- a/pkg/provider/custom_job_resource_test.go
+++ b/pkg/provider/custom_job_resource_test.go
@@ -21,8 +21,8 @@ func TestAccCustomJobResource(t *testing.T) {
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "custom_job " + nameSalt
+	newName := "new_custom_job " + nameSalt
 
 	description := "example_description"
 	newDescription := "new_example_description"
@@ -37,7 +37,7 @@ func TestAccCustomJobResource(t *testing.T) {
 	runScript := `#!/bin/bash
 
 	echo "Job Starting: ($0)"
-	
+
 	echo "===== Runtime Parameters ======"
 	echo "Model Package:     $MODEL_PACKAGE"
 	echo "Deployment:        $DEPLOYMENT"
@@ -50,14 +50,14 @@ func TestAccCustomJobResource(t *testing.T) {
 	echo "DATAROBOT_ENDPOINT:        $DATAROBOT_ENDPOINT"
 	echo "DATAROBOT_API_TOKEN:       Use the environment variable $DATAROBOT_API_TOKEN"
 	echo "==================================================="
-	
+
 	echo
 	echo "How to check how much memory your job has"
 	  memory_limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 	  memory_limit_megabytes=$((memory_limit_bytes / 1024 / 1024))
 	echo "Memory Limit (in Megabytes): $memory_limit_megabytes"
 	echo
-	
+
 	# Uncomment the following if you want to check if the job has network access
 	## Define the IP address of an external server to ping (e.g., Google's DNS)
 	#external_server="8.8.8.8"
@@ -73,19 +73,19 @@ func TestAccCustomJobResource(t *testing.T) {
 	#fi
 	#echo
 	#echo
-	
+
 	# Run the code in job.py
 	dir_path=$(dirname $0)
 	echo "Entrypoint is at $dir_path - cd into it"
 	cd $dir_path
-	
+
 	if command -v python3 &>/dev/null; then
 		echo "python3 is installed and available."
 	else
 		echo "Error: python3 is not installed or not available."
 		exit 1
 	fi
-	
+
 	python_file="job.py"
 	if [ -f "$python_file" ]; then
 		echo "Found $python_file .. running it"
@@ -155,9 +155,9 @@ runtimeParameterDefinitions:
     defaultValue: null`
 
 	runtimeParameters := `[
-		{ 
-			key="OPENAI_API_BASE", 
-			type="string", 
+		{
+			key="OPENAI_API_BASE",
+			type="string",
 			value="https://datarobot-genai-enablement.openai.azure.com/"
 		},
 	  ]`

--- a/pkg/provider/custom_metric_from_job_resource_test.go
+++ b/pkg/provider/custom_metric_from_job_resource_test.go
@@ -22,8 +22,8 @@ func TestAccCustomMetricFromJobResource(t *testing.T) {
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "custom_metric_from_job " + nameSalt
+	newName := "new_custom_metric_from_job " + nameSalt
 
 	timeStampColumn := "timestamp"
 	newTimeStampColumn := "new_timestamp"
@@ -42,16 +42,16 @@ func TestAccCustomMetricFromJobResource(t *testing.T) {
 
 	parameterOverrides := `[
 		{
-			key="OPENAI_API_BASE", 
-			type="string", 
+			key="OPENAI_API_BASE",
+			type="string",
 			value="val"
 		}
 	]
 	`
 	newParameterOverrides := `[
 		{
-			key="OPENAI_API_BASE", 
-			type="string", 
+			key="OPENAI_API_BASE",
+			type="string",
 			value="newVal"
 		}
 	]

--- a/pkg/provider/custom_metric_job_resource_test.go
+++ b/pkg/provider/custom_metric_job_resource_test.go
@@ -20,8 +20,8 @@ func TestAccCustomMetricJobResource(t *testing.T) {
 
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "custom_metric_job " + nameSalt
+	newName := "new_custom_metric_job " + nameSalt
 
 	description := "example_description"
 	newDescription := "new_example_description"
@@ -36,7 +36,7 @@ func TestAccCustomMetricJobResource(t *testing.T) {
 	runScript := `#!/bin/bash
 
 	echo "Job Starting: ($0)"
-	
+
 	echo "===== Runtime Parameters ======"
 	echo "Model Package:     $MODEL_PACKAGE"
 	echo "Deployment:        $DEPLOYMENT"
@@ -49,14 +49,14 @@ func TestAccCustomMetricJobResource(t *testing.T) {
 	echo "DATAROBOT_ENDPOINT:        $DATAROBOT_ENDPOINT"
 	echo "DATAROBOT_API_TOKEN:       Use the environment variable $DATAROBOT_API_TOKEN"
 	echo "==================================================="
-	
+
 	echo
 	echo "How to check how much memory your job has"
 	  memory_limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 	  memory_limit_megabytes=$((memory_limit_bytes / 1024 / 1024))
 	echo "Memory Limit (in Megabytes): $memory_limit_megabytes"
 	echo
-	
+
 	# Uncomment the following if you want to check if the job has network access
 	## Define the IP address of an external server to ping (e.g., Google's DNS)
 	#external_server="8.8.8.8"
@@ -72,19 +72,19 @@ func TestAccCustomMetricJobResource(t *testing.T) {
 	#fi
 	#echo
 	#echo
-	
+
 	# Run the code in job.py
 	dir_path=$(dirname $0)
 	echo "Entrypoint is at $dir_path - cd into it"
 	cd $dir_path
-	
+
 	if command -v python3 &>/dev/null; then
 		echo "python3 is installed and available."
 	else
 		echo "Error: python3 is not installed or not available."
 		exit 1
 	fi
-	
+
 	python_file="job.py"
 	if [ -f "$python_file" ]; then
 		echo "Found $python_file .. running it"
@@ -148,9 +148,9 @@ runtimeParameterDefinitions:
     defaultValue: null`
 
 	runtimeParameters := `[
-		{ 
-			key="OPENAI_API_BASE", 
-			type="string", 
+		{
+			key="OPENAI_API_BASE",
+			type="string",
 			value="https://datarobot-genai-enablement.openai.azure.com/"
 		},
 	  ]`

--- a/pkg/provider/custom_metric_resource_test.go
+++ b/pkg/provider/custom_metric_resource_test.go
@@ -45,8 +45,8 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 		t.Fatal(err)
 	}
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "custom_metric " + nameSalt
+	newName := "new_custom_metric " + nameSalt
 
 	description := "example_description"
 	newDescription := "new_example_description"

--- a/pkg/provider/custom_model_llm_validation_resource_test.go
+++ b/pkg/provider/custom_model_llm_validation_resource_test.go
@@ -39,8 +39,8 @@ def score(data, model, **kwargs):
 		t.Fatal(err)
 	}
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "custom_model_llm_validation " + nameSalt
+	newName := "new_custom_model_llm_validation " + nameSalt
 
 	promptColumnName := "promptText"
 	newPromptColumnName := "newPromptText"

--- a/pkg/provider/deployment_retraining_policy_resource_test.go
+++ b/pkg/provider/deployment_retraining_policy_resource_test.go
@@ -22,8 +22,8 @@ func TestAccDeploymentRetrainingPolicyResource(t *testing.T) {
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "deployment_retraining_policy " + nameSalt
+	newName := "new_deployment_retraining_policy " + nameSalt
 
 	description := "test description"
 	newDescription := "new test description"

--- a/pkg/provider/notification_channel_resource_test.go
+++ b/pkg/provider/notification_channel_resource_test.go
@@ -46,8 +46,8 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 		t.Fatal(err)
 	}
 
-	name := "example_name"
-	newName := "new_example_name"
+	name := "notification_channel " + nameSalt
+	newName := "new_notification_channel " + nameSalt
 
 	channelType := "DataRobotUser"
 	newChannelType := "DataRobotGroup"

--- a/pkg/provider/notification_policy_resource_test.go
+++ b/pkg/provider/notification_policy_resource_test.go
@@ -45,8 +45,8 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 		t.Fatal(err)
 	}
 
-	name := "example_name"
-	newName := "new_example_name"
+	name := "notification_policy " + nameSalt
+	newName := "new_notification_policy " + nameSalt
 
 	eventGroup := "inference_endpoints.health"
 	newEventGroup := "batch_predictions.all"

--- a/pkg/provider/qa_application_resource_test.go
+++ b/pkg/provider/qa_application_resource_test.go
@@ -16,8 +16,8 @@ func TestAccQAApplicationResource(t *testing.T) {
 
 	resourceName := "datarobot_qa_application.test"
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "qa_application " + nameSalt
+	newName := "new_qa_application " + nameSalt
 
 	folderPath := "qa_application"
 	if err := os.Mkdir(folderPath, 0755); err != nil {

--- a/pkg/provider/registered_model_from_leaderboard_resource_test.go
+++ b/pkg/provider/registered_model_from_leaderboard_resource_test.go
@@ -32,8 +32,8 @@ func TestAccRegisteredModelFromLeaderboardResource(t *testing.T) {
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	name := "example_name " + nameSalt
-	newName := "new_example_name " + nameSalt
+	name := "registered_model_from_leaderboard " + nameSalt
+	newName := "new_registered_model_from_leaderboard " + nameSalt
 
 	versionName := "version_name"
 	newVersionName := "new_version_name"

--- a/pkg/provider/vector_database_resource_test.go
+++ b/pkg/provider/vector_database_resource_test.go
@@ -14,8 +14,8 @@ func TestAccVectorDatabaseResource(t *testing.T) {
 	t.Parallel()
 	resourceName := "datarobot_vector_database.test"
 
-	name := "example_name"
-	newName := "new_example_name"
+	name := "vector_database " + nameSalt
+	newName := "new_vector_database " + nameSalt
 
 	chunkSize := 500
 	newChunkSize := 510
@@ -76,7 +76,7 @@ resource "datarobot_use_case" "test_vector_database" {
 	name = "test"
 	description = "test"
 }
-  
+
 resource "datarobot_dataset_from_file" "test_vector_database" {
 	file_path = "../../test/datarobot_english_documentation_docsassist.zip"
 	use_case_ids = ["${datarobot_use_case.test_vector_database.id}"]


### PR DESCRIPTION
We discovered that certain acceptance tests were failing due to naming conflicts, even though we implemented a salt generation mechanism during test initialization. This PR improves naming consistency throughout the test suite to address these issues. While we haven't yet covered all edge cases, these changes resolve the most frequent and reproducible naming conflicts that were causing test failures.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/c9e51b05-5985-4da7-acc2-b3d6e71b6c1c" />
