### PR TITLE
[-] Attempt fixing resource upload and removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.9.4] - 2025-05-09
+
+### Fixed
+
+- Fixed batch file uploads and deletions to avoid API limits by processing them in groups of 100.
+
 ## [v0.9.3] - 2025-04-23
 
 ### Fixed

--- a/pkg/provider/application_source_from_template_resource.go
+++ b/pkg/provider/application_source_from_template_resource.go
@@ -663,17 +663,27 @@ func (r *ApplicationSourceFromTemplateResource) updateLocalFiles(
 		}
 	}
 
-	if len(filesToDelete) > 0 {
-		traceAPICall("UpdateApplicationSourceFromTemplateVersion")
-		_, err = r.provider.service.UpdateApplicationSourceVersion(
-			ctx,
-			state.ID.ValueString(),
-			applicationSourceFromTemplateVersion.ID,
-			&client.UpdateApplicationSourceVersionRequest{
-				FilesToDelete: filesToDelete,
-			})
-		if err != nil {
-			return
+	// Batch file deletions in groups of 100 to avoid API limits
+	const batchSize = 100
+	for i := 0; i < len(filesToDelete); i += batchSize {
+		end := i + batchSize
+		if end > len(filesToDelete) {
+			end = len(filesToDelete)
+		}
+
+		batchToDelete := filesToDelete[i:end]
+		if len(batchToDelete) > 0 {
+			traceAPICall("UpdateApplicationSourceFromTemplateVersion")
+			_, err = r.provider.service.UpdateApplicationSourceVersion(
+				ctx,
+				state.ID.ValueString(),
+				applicationSourceFromTemplateVersion.ID,
+				&client.UpdateApplicationSourceVersionRequest{
+					FilesToDelete: batchToDelete,
+				})
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1242,15 +1242,26 @@ func (r *CustomModelResource) createCustomModelVersionFromFiles(
 		return
 	}
 
-	traceAPICall("CreateCustomModelVersionFromLocalFiles")
-	_, err = r.provider.service.CreateCustomModelVersionFromFiles(ctx, customModelID, &client.CreateCustomModelVersionFromFilesRequest{
-		BaseEnvironmentID: baseEnvironmentID,
-		Files:             localFiles,
-	})
-	if err != nil {
-		return
-	}
+	// Batch file uploads in groups of 100 to avoid API limits
+	const batchSize = 100
+	for i := 0; i < len(localFiles); i += batchSize {
+		end := i + batchSize
+		if end > len(localFiles) {
+			end = len(localFiles)
+		}
 
+		batchToUpload := localFiles[i:end]
+		if len(batchToUpload) > 0 {
+			traceAPICall("CreateCustomModelVersionFromLocalFiles")
+			_, err = r.provider.service.CreateCustomModelVersionFromFiles(ctx, customModelID, &client.CreateCustomModelVersionFromFilesRequest{
+				BaseEnvironmentID: baseEnvironmentID,
+				Files:             batchToUpload,
+			})
+			if err != nil {
+				return
+			}
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This pull request introduces batching for file uploads and file deletions to avoid hitting API limits. 

Files to be uploaded `localFiles` are divided into batches of 100 files each.
Each batch is processed separately. This ensures that no more than 100 files are uploaded in a single API call.

Similarly, files to be deleted are processed in batches of 100 files.