### PR TITLE
Add Resources to CreateCustomApplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.10.0] - 2025-05-20
+
+### Added
+
+- Added support for resources on applications
+
 ## [v0.9.5] - 2025-05-20
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.22
+VERSION=0.10.0
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))

--- a/docs/resources/custom_application.md
+++ b/docs/resources/custom_application.md
@@ -66,6 +66,7 @@ output "datarobot_custom_application_url" {
 - `external_access_enabled` (Boolean) Whether external access is enabled for the Custom Application.
 - `external_access_recipients` (List of String) The list of external email addresses that have access to the Custom Application.
 - `name` (String) The name of the Custom Application.
+- `resources` (Attributes) The resources for the Custom Application. (see [below for nested schema](#nestedatt--resources))
 - `use_case_ids` (List of String) The list of Use Case IDs to add the Custom Application to.
 
 ### Read-Only
@@ -73,3 +74,12 @@ output "datarobot_custom_application_url" {
 - `application_url` (String) The URL of the Custom Application.
 - `id` (String) The ID of the Custom Application.
 - `source_id` (String) The ID of the Custom Application Source.
+
+<a id="nestedatt--resources"></a>
+### Nested Schema for `resources`
+
+Optional:
+
+- `replicas` (Number) The replicas for the Custom Application.
+- `resource_label` (String) The resource label for the Custom Application.
+- `session_affinity` (Boolean) The session affinity for the Custom Application.

--- a/docs/resources/custom_application_from_environment.md
+++ b/docs/resources/custom_application_from_environment.md
@@ -49,6 +49,7 @@ output "datarobot_custom_application_url" {
 - `allow_auto_stopping` (Boolean) Whether auto stopping is allowed for the Custom Application.
 - `external_access_enabled` (Boolean) Whether external access is enabled for the Custom Application.
 - `external_access_recipients` (List of String) The list of external email addresses that have access to the Custom Application.
+- `resources` (Attributes) The resources for the Custom Application. (see [below for nested schema](#nestedatt--resources))
 - `use_case_ids` (List of String) The list of Use Case IDs to add the Custom Application to.
 
 ### Read-Only
@@ -56,3 +57,12 @@ output "datarobot_custom_application_url" {
 - `application_url` (String) The URL of the Custom Application.
 - `environment_version_id` (String) The version ID of the Execution Environment used to create the Custom Application.
 - `id` (String) The ID of the Custom Application.
+
+<a id="nestedatt--resources"></a>
+### Nested Schema for `resources`
+
+Optional:
+
+- `replicas` (Number) The replicas for the Custom Application.
+- `resource_label` (String) The resource label for the Custom Application.
+- `session_affinity` (Boolean) The session affinity for the Custom Application.

--- a/internal/client/application_service.go
+++ b/internal/client/application_service.go
@@ -4,30 +4,33 @@ type CreateQAApplicationRequest struct {
 	DeploymentID string `json:"deploymentId"`
 }
 
-type CreateCustomApplicationeRequest struct {
-	ApplicationSourceVersionID string `json:"applicationSourceVersionId,omitempty"`
-	EnvironmentID              string `json:"environmentId,omitempty"`
+type CreateCustomApplicationRequest struct {
+	ApplicationSourceVersionID string                `json:"applicationSourceVersionId,omitempty"`
+	EnvironmentID              string                `json:"environmentId,omitempty"`
+	Resources                  *ApplicationResources `json:"resources,omitempty"`
 }
 
 type Application struct {
-	ID                               string   `json:"id"`
-	Name                             string   `json:"name"`
-	Status                           string   `json:"status"`
-	CustomApplicationSourceID        string   `json:"customApplicationSourceId"`
-	CustomApplicationSourceVersionID string   `json:"customApplicationSourceVersionId"`
-	EnvVersionID                     string   `json:"envVersionId"`
-	ApplicationUrl                   string   `json:"applicationUrl"`
-	ExternalAccessEnabled            bool     `json:"externalAccessEnabled"`
-	ExternalAccessRecipients         []string `json:"externalAccessRecipients"`
-	AllowAutoStopping                bool     `json:"allowAutoStopping"`
+	ID                               string                `json:"id"`
+	Name                             string                `json:"name"`
+	Status                           string                `json:"status"`
+	CustomApplicationSourceID        string                `json:"customApplicationSourceId"`
+	CustomApplicationSourceVersionID string                `json:"customApplicationSourceVersionId"`
+	EnvVersionID                     string                `json:"envVersionId"`
+	ApplicationUrl                   string                `json:"applicationUrl"`
+	ExternalAccessEnabled            bool                  `json:"externalAccessEnabled"`
+	ExternalAccessRecipients         []string              `json:"externalAccessRecipients"`
+	AllowAutoStopping                bool                  `json:"allowAutoStopping"`
+	Resources                        *ApplicationResources `json:"resources,omitempty"`
 }
 
 type UpdateApplicationRequest struct {
-	Name                             string   `json:"name,omitempty"`
-	CustomApplicationSourceVersionID string   `json:"customApplicationSourceVersionId,omitempty"`
-	ExternalAccessEnabled            bool     `json:"externalAccessEnabled"`
-	ExternalAccessRecipients         []string `json:"externalAccessRecipients"`
-	AllowAutoStopping                bool     `json:"allowAutoStopping"`
+	Name                             string                `json:"name,omitempty"`
+	CustomApplicationSourceVersionID string                `json:"customApplicationSourceVersionId,omitempty"`
+	ExternalAccessEnabled            bool                  `json:"externalAccessEnabled"`
+	ExternalAccessRecipients         []string              `json:"externalAccessRecipients"`
+	AllowAutoStopping                bool                  `json:"allowAutoStopping"`
+	Resources                        *ApplicationResources `json:"resources,omitempty"`
 }
 
 type CreateApplicationSourceFromTemplateRequest struct {

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -199,7 +199,7 @@ type Service interface {
 	GetCustomTemplateFile(ctx context.Context, customTemplateID, fileID string) (*CustomTemplateFile, error)
 
 	// Application
-	CreateCustomApplication(ctx context.Context, req *CreateCustomApplicationeRequest) (*Application, error)
+	CreateCustomApplication(ctx context.Context, req *CreateCustomApplicationRequest) (*Application, error)
 	CreateQAApplication(ctx context.Context, req *CreateQAApplicationRequest) (*Application, error)
 	GetApplication(ctx context.Context, id string) (*Application, error)
 	UpdateApplication(ctx context.Context, id string, req *UpdateApplicationRequest) (*Application, error)
@@ -882,7 +882,7 @@ func (s *ServiceImpl) GetCustomTemplateFile(ctx context.Context, customTemplateI
 	return Get[CustomTemplateFile](s.client, ctx, "/customTemplates/"+customTemplateID+"/files/"+fileID+"/")
 }
 
-func (s *ServiceImpl) CreateCustomApplication(ctx context.Context, req *CreateCustomApplicationeRequest) (*Application, error) {
+func (s *ServiceImpl) CreateCustomApplication(ctx context.Context, req *CreateCustomApplicationRequest) (*Application, error) {
 	return Post[Application](s.client, ctx, "/customApplications/", req)
 }
 

--- a/mock/service.go
+++ b/mock/service.go
@@ -140,7 +140,7 @@ func (mr *MockServiceMockRecorder) CreateCredential(ctx, req interface{}) *gomoc
 }
 
 // CreateCustomApplication mocks base method.
-func (m *MockService) CreateCustomApplication(ctx context.Context, req *client.CreateCustomApplicationeRequest) (*client.Application, error) {
+func (m *MockService) CreateCustomApplication(ctx context.Context, req *client.CreateCustomApplicationRequest) (*client.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCustomApplication", ctx, req)
 	ret0, _ := ret[0].(*client.Application)
@@ -167,6 +167,21 @@ func (m *MockService) CreateCustomJob(ctx context.Context, req *client.CreateCus
 func (mr *MockServiceMockRecorder) CreateCustomJob(ctx, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomJob", reflect.TypeOf((*MockService)(nil).CreateCustomJob), ctx, req)
+}
+
+// CreateCustomJobSchedule mocks base method.
+func (m *MockService) CreateCustomJobSchedule(ctx context.Context, id string, req client.CreateaCustomJobScheduleRequest) (*client.CustomJobScheduleResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCustomJobSchedule", ctx, id, req)
+	ret0, _ := ret[0].(*client.CustomJobScheduleResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCustomJobSchedule indicates an expected call of CreateCustomJobSchedule.
+func (mr *MockServiceMockRecorder) CreateCustomJobSchedule(ctx, id, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomJobSchedule", reflect.TypeOf((*MockService)(nil).CreateCustomJobSchedule), ctx, id, req)
 }
 
 // CreateCustomMetric mocks base method.
@@ -737,6 +752,20 @@ func (mr *MockServiceMockRecorder) DeleteCustomJob(ctx, id interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomJob", reflect.TypeOf((*MockService)(nil).DeleteCustomJob), ctx, id)
 }
 
+// DeleteCustomJobSchedule mocks base method.
+func (m *MockService) DeleteCustomJobSchedule(ctx context.Context, id, scheduleID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCustomJobSchedule", ctx, id, scheduleID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCustomJobSchedule indicates an expected call of DeleteCustomJobSchedule.
+func (mr *MockServiceMockRecorder) DeleteCustomJobSchedule(ctx, id, scheduleID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomJobSchedule", reflect.TypeOf((*MockService)(nil).DeleteCustomJobSchedule), ctx, id, scheduleID)
+}
+
 // DeleteCustomMetric mocks base method.
 func (m *MockService) DeleteCustomMetric(ctx context.Context, deploymentID, id string) error {
 	m.ctrl.T.Helper()
@@ -1288,6 +1317,21 @@ func (mr *MockServiceMockRecorder) GetDeploymentHealthSettings(ctx, id interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentHealthSettings", reflect.TypeOf((*MockService)(nil).GetDeploymentHealthSettings), ctx, id)
 }
 
+// GetDeploymentRetrainingSettings mocks base method.
+func (m *MockService) GetDeploymentRetrainingSettings(ctx context.Context, deploymentID string) (*client.RetrainingSettingsRetrieve, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeploymentRetrainingSettings", ctx, deploymentID)
+	ret0, _ := ret[0].(*client.RetrainingSettingsRetrieve)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeploymentRetrainingSettings indicates an expected call of GetDeploymentRetrainingSettings.
+func (mr *MockServiceMockRecorder) GetDeploymentRetrainingSettings(ctx, deploymentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentRetrainingSettings", reflect.TypeOf((*MockService)(nil).GetDeploymentRetrainingSettings), ctx, deploymentID)
+}
+
 // GetDeploymentSettings mocks base method.
 func (m *MockService) GetDeploymentSettings(ctx context.Context, id string) (*client.DeploymentSettings, error) {
 	m.ctrl.T.Helper()
@@ -1722,50 +1766,6 @@ func (mr *MockServiceMockRecorder) ListCustomJobSchedules(ctx, id interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCustomJobSchedules", reflect.TypeOf((*MockService)(nil).ListCustomJobSchedules), ctx, id)
 }
-// CreateCustomJobSchedule mocks base method.
-func (m *MockService) CreateCustomJobSchedule(ctx context.Context, id string, req client.CreateaCustomJobScheduleRequest) (*client.CustomJobScheduleResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCustomJobSchedule", ctx, id, req)
-	ret0, _ := ret[0].(*client.CustomJobScheduleResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCustomJobSchedule indicates an expected call of CreateCustomJobSchedule.
-func (mr *MockServiceMockRecorder) CreateCustomJobSchedule(ctx, id, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomJobSchedule", reflect.TypeOf((*MockService)(nil).CreateCustomJobSchedule), ctx, id, req)
-}
-
-// DeleteCustomJobSchedule mocks base method.
-func (m *MockService) DeleteCustomJobSchedule(ctx context.Context, id string, scheduleID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCustomJobSchedule", ctx, id, scheduleID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCustomJobSchedule indicates an expected call of DeleteCustomJobSchedule.
-func (mr *MockServiceMockRecorder) DeleteCustomJobSchedule(ctx, id, scheduleID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomJobSchedule", reflect.TypeOf((*MockService)(nil).DeleteCustomJobSchedule), ctx, id, scheduleID)
-}
-
-// UpdateCustomJobSchedule mocks base method.
-func (m *MockService) UpdateCustomJobSchedule(ctx context.Context, id string, scheduleID string, req client.CreateaCustomJobScheduleRequest) (*client.CustomJobScheduleResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCustomJobSchedule", ctx, id, scheduleID, req)
-	ret0, _ := ret[0].(*client.CustomJobScheduleResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCustomJobSchedule indicates an expected call of UpdateCustomJobSchedule.
-func (mr *MockServiceMockRecorder) UpdateCustomJobSchedule(ctx, id, scheduleID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomJobSchedule", reflect.TypeOf((*MockService)(nil).UpdateCustomJobSchedule), ctx, id, scheduleID, req)
-}
-
 
 // ListCustomModelVersions mocks base method.
 func (m *MockService) ListCustomModelVersions(ctx context.Context, id string) ([]client.CustomModelVersion, error) {
@@ -2081,6 +2081,21 @@ func (mr *MockServiceMockRecorder) UpdateCustomJobFiles(ctx, id, files interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomJobFiles", reflect.TypeOf((*MockService)(nil).UpdateCustomJobFiles), ctx, id, files)
 }
 
+// UpdateCustomJobSchedule mocks base method.
+func (m *MockService) UpdateCustomJobSchedule(ctx context.Context, id, scheduleID string, req client.CreateaCustomJobScheduleRequest) (*client.CustomJobScheduleResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCustomJobSchedule", ctx, id, scheduleID, req)
+	ret0, _ := ret[0].(*client.CustomJobScheduleResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCustomJobSchedule indicates an expected call of UpdateCustomJobSchedule.
+func (mr *MockServiceMockRecorder) UpdateCustomJobSchedule(ctx, id, scheduleID, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomJobSchedule", reflect.TypeOf((*MockService)(nil).UpdateCustomJobSchedule), ctx, id, scheduleID, req)
+}
+
 // UpdateCustomMetric mocks base method.
 func (m *MockService) UpdateCustomMetric(ctx context.Context, deploymentID, id string, req *client.UpdateCustomMetricRequest) (*client.CustomMetric, error) {
 	m.ctrl.T.Helper()
@@ -2255,16 +2270,6 @@ func (m *MockService) UpdateDeploymentRetrainingSettings(ctx context.Context, de
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
-
-// GetDeploymentRetrainingSettings mocks base method.
-func (m *MockService) GetDeploymentRetrainingSettings(ctx context.Context, deploymentID string) (*client.RetrainingSettingsRetrieve, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentRetrainingSettings", ctx, deploymentID)
-	ret0, _ := ret[0].(*client.RetrainingSettingsRetrieve)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
 
 // UpdateDeploymentRetrainingSettings indicates an expected call of UpdateDeploymentRetrainingSettings.
 func (mr *MockServiceMockRecorder) UpdateDeploymentRetrainingSettings(ctx, deploymentID, req interface{}) *gomock.Call {

--- a/pkg/provider/custom_application_from_environment_resource_test.go
+++ b/pkg/provider/custom_application_from_environment_resource_test.go
@@ -160,18 +160,23 @@ func customApplicationFromEnvironmentResourceConfig(
 
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "test_custom_application_from_environment" {
-	name = "test custom application from env"
+	   name = "test custom application from env"
 }
 resource "datarobot_use_case" "test_new_custom_application_from_environment" {
-	name = "test new custom application from env"
+	   name = "test new custom application from env"
 }
 
 resource "datarobot_custom_application_from_environment" "test" {
-	environment_id = "%s"
-	external_access_enabled = %t
-	%s
-	%s
-	%s
+	   environment_id = "%s"
+	   external_access_enabled = %t
+	   resources = {
+		   replicas = 2
+		   resource_label = "test-label-env"
+		   session_affinity = true
+	   }
+	   %s
+	   %s
+	   %s
 }
 `, environmentID, externalAccess, recipients, nameStr, useCaseIDsStr)
 }
@@ -208,12 +213,27 @@ func checkCustomApplicationFromEnvironmentResourceExists() resource.TestCheckFun
 					if len(application.ExternalAccessRecipients) > 0 {
 						if application.ExternalAccessRecipients[0] == rs.Primary.Attributes["external_access_recipients.0"] {
 							return nil
+							// pass
+						} else {
+							return fmt.Errorf("ExternalAccessRecipient is %s but should be %s", application.ExternalAccessRecipients[0], rs.Primary.Attributes["external_access_recipients.0"])
 						}
 					} else if rs.Primary.Attributes["external_access_recipients.0"] == "" {
 						return nil
 					}
 				}
 			}
+
+			// Check resources block
+			if rs.Primary.Attributes["resources.replicas"] != "2" {
+				return fmt.Errorf("resources.replicas is %s but should be 2", rs.Primary.Attributes["resources.replicas"])
+			}
+			if rs.Primary.Attributes["resources.resource_label"] != "test-label-env" {
+				return fmt.Errorf("resources.resource_label is %s but should be test-label-env", rs.Primary.Attributes["resources.resource_label"])
+			}
+			if rs.Primary.Attributes["resources.session_affinity"] != "true" {
+				return fmt.Errorf("resources.session_affinity is %s but should be true", rs.Primary.Attributes["resources.session_affinity"])
+			}
+
 			return nil
 		}
 

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1,3 +1,4 @@
+// Used for the resources block in custom_application and custom_application_from_environment
 package provider
 
 import (
@@ -711,27 +712,29 @@ type ApplicationSourceResources struct {
 }
 
 type CustomApplicationResourceModel struct {
-	ID                       types.String   `tfsdk:"id"`
-	SourceID                 types.String   `tfsdk:"source_id"`
-	SourceVersionID          types.String   `tfsdk:"source_version_id"`
-	Name                     types.String   `tfsdk:"name"`
-	ApplicationUrl           types.String   `tfsdk:"application_url"`
-	ExternalAccessEnabled    types.Bool     `tfsdk:"external_access_enabled"`
-	ExternalAccessRecipients []types.String `tfsdk:"external_access_recipients"`
-	AllowAutoStopping        types.Bool     `tfsdk:"allow_auto_stopping"`
-	UseCaseIDs               []types.String `tfsdk:"use_case_ids"`
+	ID                       types.String                `tfsdk:"id"`
+	SourceID                 types.String                `tfsdk:"source_id"`
+	SourceVersionID          types.String                `tfsdk:"source_version_id"`
+	Name                     types.String                `tfsdk:"name"`
+	ApplicationUrl           types.String                `tfsdk:"application_url"`
+	ExternalAccessEnabled    types.Bool                  `tfsdk:"external_access_enabled"`
+	ExternalAccessRecipients []types.String              `tfsdk:"external_access_recipients"`
+	AllowAutoStopping        types.Bool                  `tfsdk:"allow_auto_stopping"`
+	UseCaseIDs               []types.String              `tfsdk:"use_case_ids"`
+	Resources                *ApplicationSourceResources `tfsdk:"resources"`
 }
 
 type CustomApplicationFromEnvironmentResourceModel struct {
-	ID                       types.String   `tfsdk:"id"`
-	EnvironmentID            types.String   `tfsdk:"environment_id"`
-	EnvironmentVersionID     types.String   `tfsdk:"environment_version_id"`
-	Name                     types.String   `tfsdk:"name"`
-	ApplicationUrl           types.String   `tfsdk:"application_url"`
-	ExternalAccessEnabled    types.Bool     `tfsdk:"external_access_enabled"`
-	ExternalAccessRecipients []types.String `tfsdk:"external_access_recipients"`
-	AllowAutoStopping        types.Bool     `tfsdk:"allow_auto_stopping"`
-	UseCaseIDs               []types.String `tfsdk:"use_case_ids"`
+	ID                       types.String                `tfsdk:"id"`
+	EnvironmentID            types.String                `tfsdk:"environment_id"`
+	EnvironmentVersionID     types.String                `tfsdk:"environment_version_id"`
+	Name                     types.String                `tfsdk:"name"`
+	ApplicationUrl           types.String                `tfsdk:"application_url"`
+	ExternalAccessEnabled    types.Bool                  `tfsdk:"external_access_enabled"`
+	ExternalAccessRecipients []types.String              `tfsdk:"external_access_recipients"`
+	AllowAutoStopping        types.Bool                  `tfsdk:"allow_auto_stopping"`
+	UseCaseIDs               []types.String              `tfsdk:"use_case_ids"`
+	Resources                *ApplicationSourceResources `tfsdk:"resources"`
 }
 
 // CredentialResourceModel describes the credential resource.


### PR DESCRIPTION
The CustomApplication API itself supports creating applications with resources, but it does not support updates. As a result, this use case for the declaritive API isn't particularly useful, as it really only works properly from an attachment to an Application Source. As we mature the Custom Application API to handle direct environment deployments better, we'll want this eventually.