### PR TITLE
Removed platform specific code for detecting symlink cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## Unreleased
 
+## [0.10.1] - 2025-05-29
 
+### Fixed
 
-## [0.10.0] - 2025-05-29	
+- Windows build does not have inodes, dropped cycle detection for symlinks
+
+## [0.10.0] - 2025-05-29
 
 ### Added
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
+	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -55,7 +56,6 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect


### PR DESCRIPTION
The Windows build began failing due to the INode checks I added for loop detection. Rather than create multiple versions of the module for the different platforms, I've opted to remove the extra functionality of loop detection