### PR TITLE
Force Replacement if Client ID changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.10.10] - 2025-07-01
+
+### Fixed
+
+- Fixed OAuth resource such that if a Client ID changes, the resource should be replaced
+
 ## [0.10.9] - 2025-06-23
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.22
+VERSION=0.10.11
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))

--- a/pkg/provider/app_oauth_resource.go
+++ b/pkg/provider/app_oauth_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -53,6 +55,9 @@ func (r *AppOAuthResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:    true,
 				Sensitive:   true,
 				Description: "OAuth client ID.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"client_secret": schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
Right now, the provider doesn't replace the resource, it just silently "updates" even though that update never applies as the API doesn't support changing the Client ID