### PR TITLE
[-] Always populate `resources` field when creating Custom Application Sources

### DIFF
--- a/pkg/provider/application_source_resource.go
+++ b/pkg/provider/application_source_resource.go
@@ -90,6 +90,7 @@ func (r *ApplicationSourceResource) Schema(ctx context.Context, req resource.Sch
 			},
 			"resources": schema.SingleNestedAttribute{
 				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: "The resources for the Application Source.",
 				Attributes: map[string]schema.Attribute{
 					"replicas": schema.Int64Attribute{


### PR DESCRIPTION
…n Sources