### PR TITLE
[-]Fix the deployment update

### DIFF
--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -814,7 +814,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		}
 	}
 
-		err = r.updateDeploymentSettings(ctx, id, plan)
+	err = r.updateDeploymentSettings(ctx, id, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating Deployment settings", err.Error())
 		return


### PR DESCRIPTION
Few days ago there was some changes related to the settings updates for deployments. 
looks like now they should be set only on the active deployment. Here a fixes to make pipeline green again...