### PR TITLE
[PLT-18887] Switched OAuth to use standard client

### DIFF
--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -248,7 +248,6 @@ type Service interface {
 type ServiceImpl struct {
 	client      *Client
 	apiGWClient *Client
-	baseClient  *Client
 }
 
 // NewService creates a new API service.
@@ -261,14 +260,9 @@ func NewService(c *Client) Service {
 	apiGWConfig.Endpoint = apiGWConfig.BaseURL() + "/api-gw"
 	apiGWClient := NewClient(&apiGWConfig)
 
-	baseClientConfig := *c.cfg
-	baseClientConfig.Endpoint = baseClientConfig.BaseURL()
-	baseClient := NewClient(&baseClientConfig)
-
 	return &ServiceImpl{
 		client:      c,
 		apiGWClient: apiGWClient,
-		baseClient:  baseClient,
 	}
 }
 
@@ -1016,17 +1010,17 @@ func (s *ServiceImpl) DeleteNotebook(ctx context.Context, id string) error {
 
 // OAUTH Provider Service Implementation.
 func (s *ServiceImpl) CreateAppOAuthProvider(ctx context.Context, req *CreateAppOAuthProviderRequest) (*AppOAuthProviderResponse, error) {
-	return Post[AppOAuthProviderResponse](s.baseClient, ctx, "/externalOAuth/providers/", req)
+	return Post[AppOAuthProviderResponse](s.client, ctx, "/externalOAuth/providers/", req)
 }
 
 func (s *ServiceImpl) GetAppOAuthProvider(ctx context.Context, id string) (*AppOAuthProviderResponse, error) {
-	return Get[AppOAuthProviderResponse](s.baseClient, ctx, "/externalOAuth/providers/"+id+"/")
+	return Get[AppOAuthProviderResponse](s.client, ctx, "/externalOAuth/providers/"+id+"/")
 }
 
 func (s *ServiceImpl) UpdateAppOAuthProvider(ctx context.Context, id string, req *UpdateAppOAuthProviderRequest) (*AppOAuthProviderResponse, error) {
-	return Patch[AppOAuthProviderResponse](s.baseClient, ctx, "/externalOAuth/providers/"+id+"/", req)
+	return Patch[AppOAuthProviderResponse](s.client, ctx, "/externalOAuth/providers/"+id+"/", req)
 }
 
 func (s *ServiceImpl) DeleteAppOAuthProvider(ctx context.Context, id string) error {
-	return Delete(s.baseClient, ctx, "/externalOAuth/providers/"+id+"/")
+	return Delete(s.client, ctx, "/externalOAuth/providers/"+id+"/")
 }


### PR DESCRIPTION
The regular client should work now for these endpoints as they've been added the `/api/v2` namespace recently