### PR TITLE
Drop requirement for model ID validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## Unreleased
+
+
+
+## [0.10.15] - 2025-08-26
+
+### Changed
+- Dropped validators for model names on LLM Blueprints
+
 ## [0.10.14] - 2025-08-13
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.10.12
+VERSION=0.10.16
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))

--- a/pkg/provider/llm_blueprint_resource.go
+++ b/pkg/provider/llm_blueprint_resource.go
@@ -79,7 +79,6 @@ func (r *LLMBlueprintResource) Schema(ctx context.Context, req resource.SchemaRe
 			"llm_id": schema.StringAttribute{
 				MarkdownDescription: "The id of the LLM for the LLM Blueprint. If custom_model_llm_settings is set, this value must be 'custom-model'.",
 				Optional:            true,
-				Validators:          LlmIDValidators(),
 				PlanModifiers: []planmodifier.String{
 					// in order to generate an update to the custom model resource, we need to force a replace
 					stringplanmodifier.RequiresReplace(),

--- a/pkg/provider/validators.go
+++ b/pkg/provider/validators.go
@@ -354,32 +354,6 @@ func LanguageCodeValidators() []validator.String {
 	}
 }
 
-func LlmIDValidators() []validator.String {
-	return []validator.String{
-		stringvalidator.OneOf(
-			"azure-openai-gpt-3.5-turbo-16k",
-			"azure-openai-gpt-4",
-			"azure-openai-gpt-4-32k",
-			"azure-openai-gpt-4-turbo",
-			"azure-openai-gpt-4-o",
-			"azure-openai-gpt-4-o-mini",
-			"amazon-nova-micro",
-			"amazon-nova-lite",
-			"amazon-nova-pro",
-			"anthropic-claude-2",
-			"anthropic-claude-3-haiku",
-			"anthropic-claude-3-sonnet",
-			"anthropic-claude-3-opus",
-			"anthropic-claude-3.5-sonnet-v1",
-			"amazon-anthropic-claude-3.5-sonnet-v2",
-			"google-bison",
-			"google-gemini-1.5-flash",
-			"google-gemini-1.5-pro",
-			"custom-model",
-		),
-	}
-}
-
 func TimeUnitValidators() []validator.String {
 	return []validator.String{
 		stringvalidator.OneOf(


### PR DESCRIPTION
This is out of date, and it is nearly impossible to keep up to date. We should allow the API to validate this on behalf of the provider