### PR TITLE
[BUZZOK-27392] Add support for agentic playground type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-
+## [0.10.16] - 2025-08-27
+- Added a new `playground_type` key to `datarobot_playground` resource
 
 ## [0.10.15] - 2025-08-26
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.10.16
+VERSION=0.10.17
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,21 @@ ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
 default: lint install
 
+.PHONY: build
 build:
 	go build -o ${BINARY}
 
+.PHONY: generate
 # Generate Terraform Provider docs.
 generate:
 	go generate
 
+.PHONY: mocks
 # Make mocks for the service
 mocks:
 	mockgen -source=internal/client/service.go -destination=mock/service.go -package=mock_client
 
+.PHONY: release
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
@@ -34,16 +38,20 @@ release:
 	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
+.PHONY: install
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/$(OS)_$(ARCH)
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/$(OS)_$(ARCH)
 
+.PHONY: test
 test:
 	go test ./... -v $(TESTARGS) -timeout 5m
 
+.PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m -paralleldot0
 
+.PHONY: lint
 lint:
 	echo "Running checks for service"
 	golangci-lint run ./...

--- a/docs/resources/playground.md
+++ b/docs/resources/playground.md
@@ -18,9 +18,8 @@ resource "datarobot_use_case" "example" {
 }
 
 resource "datarobot_playground" "example" {
-  name            = "An example playground"
-  use_case_id     = datarobot_use_case.example.id
-  playground_type = "agentic"
+  name        = "An example playground"
+  use_case_id = datarobot_use_case.example.id
 }
 
 output "example_id" {
@@ -40,6 +39,7 @@ output "example_id" {
 ### Optional
 
 - `description` (String) The description of the Playground.
+- `playground_type` (String) The type of the Playground, either 'rag' (default) or 'agentic'.
 
 ### Read-Only
 

--- a/docs/resources/playground.md
+++ b/docs/resources/playground.md
@@ -18,8 +18,9 @@ resource "datarobot_use_case" "example" {
 }
 
 resource "datarobot_playground" "example" {
-  name        = "An example playground"
-  use_case_id = datarobot_use_case.example.id
+  name            = "An example playground"
+  use_case_id     = datarobot_use_case.example.id
+  playground_type = "agentic"
 }
 
 output "example_id" {

--- a/internal/client/playground_service.go
+++ b/internal/client/playground_service.go
@@ -1,9 +1,10 @@
 package client
 
 type CreatePlaygroundRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	UseCaseID   string `json:"useCaseId"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	UseCaseID      string `json:"useCaseId"`
+	PlaygroundType string `json:"playgroundType"`
 }
 
 type UpdatePlaygroundRequest struct {
@@ -16,8 +17,9 @@ type CreatePlaygroundResponse struct {
 }
 
 type PlaygroundResponse struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	UseCaseID   string `json:"useCaseId"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	UseCaseID      string `json:"useCaseId"`
+	PlaygroundType string `json:"playgroundType"`
 }

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -128,10 +128,11 @@ type ChunkingParametersModel struct {
 
 // PlaygroundResourceModel describes the playground associated to a use case.
 type PlaygroundResourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	UseCaseID   types.String `tfsdk:"use_case_id"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	UseCaseID      types.String `tfsdk:"use_case_id"`
+	PlaygroundType types.String `tfsdk:"playground_type"`
 }
 
 // LLMBlueprintResourceModel describes the LLM blueprint resource.

--- a/pkg/provider/playground_resource.go
+++ b/pkg/provider/playground_resource.go
@@ -61,7 +61,7 @@ func (r *PlaygroundResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 			},
 			"playground_type": schema.StringAttribute{
-				MarkdownDescription: "The type of the Playground.",
+				MarkdownDescription: "The type of the Playground, either 'rag' or 'agentic'.",
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString("rag"),

--- a/pkg/provider/playground_resource.go
+++ b/pkg/provider/playground_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -59,6 +60,16 @@ func (r *PlaygroundResource) Schema(ctx context.Context, req resource.SchemaRequ
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"playground_type": schema.StringAttribute{
+				MarkdownDescription: "The type of the Playground.",
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("rag"),
+				Validators:          PlaygroundTypeValidators(),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 	}
 }
@@ -86,11 +97,18 @@ func (r *PlaygroundResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Get the playground type, defaulting to "rag" if not set
+	playgroundType := "rag"
+	if !data.PlaygroundType.IsNull() && !data.PlaygroundType.IsUnknown() {
+		playgroundType = data.PlaygroundType.ValueString()
+	}
+
 	traceAPICall("CreatePlayground")
 	createResp, err := r.provider.service.CreatePlayground(ctx, &client.CreatePlaygroundRequest{
-		Name:        data.Name.ValueString(),
-		Description: data.Description.ValueString(),
-		UseCaseID:   data.UseCaseID.ValueString(),
+		Name:           data.Name.ValueString(),
+		Description:    data.Description.ValueString(),
+		UseCaseID:      data.UseCaseID.ValueString(),
+		PlaygroundType: playgroundType,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Playground", err.Error())
@@ -130,6 +148,11 @@ func (r *PlaygroundResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 	data.Name = types.StringValue(playground.Name)
 	data.UseCaseID = types.StringValue(playground.UseCaseID)
+	// Set playground type, defaulting to "rag" if not returned by API
+	data.PlaygroundType = types.StringValue("rag")
+	if playground.PlaygroundType != "" {
+		data.PlaygroundType = types.StringValue(playground.PlaygroundType)
+	}
 	if playground.Description != "" {
 		data.Description = types.StringValue(playground.Description)
 	}

--- a/pkg/provider/playground_resource_test.go
+++ b/pkg/provider/playground_resource_test.go
@@ -19,45 +19,89 @@ func TestAccPlaygroundResource(t *testing.T) {
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read
+			// Create and Read with default playground_type (should be "rag")
 			{
-				Config: playgroundResourceConfig("example_name", "example_description", "test_use_case"),
+				Config: playgroundResourceConfig("example_name", "example_description", "test_use_case", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkPlaygroundResourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "example_name"),
 					resource.TestCheckResourceAttr(resourceName, "description", "example_description"),
+					resource.TestCheckResourceAttr(resourceName, "playground_type", "rag"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
 			// Update name, description
 			{
-				Config: playgroundResourceConfig("new_example_name", "new_example_description", "test_use_case"),
+				Config: playgroundResourceConfig("new_example_name", "new_example_description", "test_use_case", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkPlaygroundResourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "new_example_name"),
 					resource.TestCheckResourceAttr(resourceName, "description", "new_example_description"),
+					resource.TestCheckResourceAttr(resourceName, "playground_type", "rag"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
 			// Update use case
 			{
-				Config: playgroundResourceConfig("new_example_name", "new_example_description", "new_test_use_case"),
+				Config: playgroundResourceConfig("new_example_name", "new_example_description", "new_test_use_case", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkPlaygroundResourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "new_example_name"),
 					resource.TestCheckResourceAttr(resourceName, "description", "new_example_description"),
+					resource.TestCheckResourceAttr(resourceName, "playground_type", "rag"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
-			// Delete is tested automatically
 		},
 	})
 }
 
-func playgroundResourceConfig(name, description, use_case_resource_name string) string {
+func TestAccPlaygroundResourceWithExplicitType(t *testing.T) {
+	t.Parallel()
+	resourceName := "datarobot_playground.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read with explicit playground_type "agentic"
+			{
+				Config: playgroundResourceConfig("example_name", "example_description", "test_use_case", "agentic"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkPlaygroundResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "example_name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "example_description"),
+					resource.TestCheckResourceAttr(resourceName, "playground_type", "agentic"),
+					resource.TestCheckResourceAttrSet(resourceName, "use_case_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			// Update to explicit playground_type "rag"
+			{
+				Config: playgroundResourceConfig("example_name", "example_description", "test_use_case", "rag"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkPlaygroundResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "example_name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "example_description"),
+					resource.TestCheckResourceAttr(resourceName, "playground_type", "rag"),
+					resource.TestCheckResourceAttrSet(resourceName, "use_case_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func playgroundResourceConfig(name, description, use_case_resource_name, playground_type string) string {
+	playgroundTypeConfig := ""
+	if playground_type != "" {
+		playgroundTypeConfig = fmt.Sprintf(`  playground_type = "%s"`, playground_type)
+	}
+
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "%s" {
 	name = "%s"
@@ -68,8 +112,9 @@ resource "datarobot_playground" "test" {
 	  name = "%s"
 	  description = "%s"
 	  use_case_id = "${datarobot_use_case.%s.id}"
+%s
 }
-`, use_case_resource_name, name, description, name, description, use_case_resource_name)
+`, use_case_resource_name, name, description, name, description, use_case_resource_name, playgroundTypeConfig)
 }
 
 func checkPlaygroundResourceExists(resourceName string) resource.TestCheckFunc {
@@ -95,12 +140,19 @@ func checkPlaygroundResourceExists(resourceName string) resource.TestCheckFunc {
 			return err
 		}
 
+		// Check if playground_type is set in the resource attributes
+		expectedPlaygroundType := "rag" // default value
+		if playgroundType, ok := rs.Primary.Attributes["playground_type"]; ok && playgroundType != "" {
+			expectedPlaygroundType = playgroundType
+		}
+
 		if playground.Name == rs.Primary.Attributes["name"] &&
 			playground.Description == rs.Primary.Attributes["description"] &&
-			playground.UseCaseID == rs.Primary.Attributes["use_case_id"] {
+			playground.UseCaseID == rs.Primary.Attributes["use_case_id"] &&
+			playground.PlaygroundType == expectedPlaygroundType {
 			return nil
 		}
 
-		return fmt.Errorf("Playground not found")
+		return fmt.Errorf("Playground not found or attributes don't match")
 	}
 }

--- a/pkg/provider/validators.go
+++ b/pkg/provider/validators.go
@@ -954,3 +954,12 @@ func BatchPredictionJobExplanationAlgorithmValidators() []validator.String {
 		),
 	}
 }
+
+func PlaygroundTypeValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf(
+			"rag",
+			"agentic",
+		),
+	}
+}

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -840,6 +840,7 @@ func TestPlayground(t *testing.T) {
 		require.NoError(err)
 	}()
 
+	// Test 1: Create playground without specifying playground_type (should default to "rag")
 	name := "Integration Test" + uuid.New().String()
 	description := "This is a test playground."
 	playground, err := s.CreatePlayground(ctx, &client.CreatePlaygroundRequest{
@@ -857,6 +858,7 @@ func TestPlayground(t *testing.T) {
 	require.Equal(playground.ID, getPlayground.ID)
 	require.Equal(name, getPlayground.Name)
 	require.Equal(description, getPlayground.Description)
+	require.Equal("rag", getPlayground.PlaygroundType)
 
 	// Update the playground request
 	updateName := "Updated Integration Test" + uuid.New().String()
@@ -880,6 +882,30 @@ func TestPlayground(t *testing.T) {
 	assert.Equal(updateDescription, updatedPlayground.Description)
 
 	err = s.DeletePlayground(ctx, playground.ID)
+	require.NoError(err)
+
+	// Test 2: Create playground with explicit playground_type "agentic"
+	name2 := "Integration Test Agentic" + uuid.New().String()
+	description2 := "This is a test agentic playground."
+	playground2, err := s.CreatePlayground(ctx, &client.CreatePlaygroundRequest{
+		Name:           name2,
+		Description:    description2,
+		UseCaseID:      useCase.ID,
+		PlaygroundType: "agentic",
+	})
+	require.NoError(err)
+	require.NotNil(playground2)
+	assert.NotEmpty(playground2.ID)
+
+	getPlayground2, err := s.GetPlayground(ctx, playground2.ID)
+	require.NoError(err)
+	require.NotNil(getPlayground2)
+	require.Equal(playground2.ID, getPlayground2.ID)
+	require.Equal(name2, getPlayground2.Name)
+	require.Equal(description2, getPlayground2.Description)
+	require.Equal("agentic", getPlayground2.PlaygroundType)
+
+	err = s.DeletePlayground(ctx, playground2.ID)
 	require.NoError(err)
 }
 


### PR DESCRIPTION
A new key `playground_type` was added to API in 11.1 to support agentic workflows. This PR adds the new key to the TF provider.