### PR TITLE
[BUZZOK-27392] Add support for `llm_settings.custom_model_id` to `datarobot_llm_blueprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## [0.10.17] - 2025-09-01
+- Added a new key `llm_settings.custom_model_id` to `datarobot_llm_blueprint` resource
+
+
 ## [0.10.16] - 2025-08-27
 - Added a new `playground_type` key to `datarobot_playground` resource
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.10.17
+VERSION=0.10.18
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))

--- a/docs/resources/llm_blueprint.md
+++ b/docs/resources/llm_blueprint.md
@@ -91,6 +91,7 @@ Optional:
 
 Optional:
 
+- `custom_model_id` (String) The ID of the custom model to use via chat completion interface.
 - `max_completion_length` (Number) The maximum number of tokens allowed in the completion. The combined count of this value and prompt tokens must be below the model's maximum context size, where prompt token count is comprised of system prompt, user prompt, recent chat history, and vector database citations.
 - `system_prompt` (String) Guides the style of the LLM response. It is a 'universal' prompt, prepended to all individual prompts.
 - `temperature` (Number) Controls the randomness of model output, where higher values return more diverse output and lower values return more deterministic results.

--- a/internal/client/llm_blueprint_service.go
+++ b/internal/client/llm_blueprint_service.go
@@ -21,6 +21,7 @@ type LLMSettings struct {
 	Temperature         *float64 `json:"temperature,omitempty"`
 	TopP                *float64 `json:"topP,omitempty"`
 	SystemPrompt        *string  `json:"systemPrompt,omitempty"`
+	CustomModelID       *string  `json:"customModelId,omitempty"`
 }
 
 type CustomModelLLMSettings struct {

--- a/pkg/provider/llm_blueprint_resource.go
+++ b/pkg/provider/llm_blueprint_resource.go
@@ -107,6 +107,10 @@ func (r *LLMBlueprintResource) Schema(ctx context.Context, req resource.SchemaRe
 						MarkdownDescription: "Guides the style of the LLM response. It is a 'universal' prompt, prepended to all individual prompts.",
 						Optional:            true,
 					},
+					"custom_model_id": schema.StringAttribute{
+						MarkdownDescription: "The ID of the custom model to use via chat completion interface.",
+						Optional:            true,
+					},
 				},
 			},
 			"prompt_type": schema.StringAttribute{
@@ -207,6 +211,7 @@ func (r *LLMBlueprintResource) Create(ctx context.Context, req resource.CreateRe
 			Temperature:         Float64ValuePointerOptional(data.LLMSettings.Temperature),
 			TopP:                Float64ValuePointerOptional(data.LLMSettings.TopP),
 			SystemPrompt:        StringValuePointerOptional(data.LLMSettings.SystemPrompt),
+			CustomModelID:       StringValuePointerOptional(data.LLMSettings.CustomModelID),
 		}
 	}
 

--- a/pkg/provider/llm_blueprint_resource_test.go
+++ b/pkg/provider/llm_blueprint_resource_test.go
@@ -254,3 +254,40 @@ func checkLlmBlueprintResourceExists(resourceName string) resource.TestCheckFunc
 		return fmt.Errorf("LLM Blueprint not found")
 	}
 }
+
+func TestAccLLMBlueprintResource_ChatInterfaceCustomModel(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "datarobot_llm_blueprint.test"
+	llmID := "chat-interface-custom-model"
+	customModelID := "test-custom-model-123"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "datarobot_use_case" "test" {
+	name = "test use case"
+}
+resource "datarobot_playground" "test" {
+	name = "test playground"
+	use_case_id = datarobot_use_case.test.id
+}
+resource "datarobot_llm_blueprint" "test" {
+	name = "test blueprint"
+	playground_id = datarobot_playground.test.id
+	llm_id = "%s"
+	llm_settings = {
+		custom_model_id = "%s"
+	}
+}`, llmID, customModelID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "llm_id", llmID),
+					resource.TestCheckResourceAttr(resourceName, "llm_settings.custom_model_id", customModelID),
+				),
+			},
+		},
+	})
+}

--- a/pkg/provider/llm_blueprint_resource_test.go
+++ b/pkg/provider/llm_blueprint_resource_test.go
@@ -298,6 +298,7 @@ resource "datarobot_llm_blueprint" "test" {
 	llm_settings = {
 		custom_model_id = datarobot_custom_model.test.id
 	}
+	prompt_type = "ONE_TIME_PROMPT"
 }`, llmID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "llm_id", llmID),

--- a/pkg/provider/llm_blueprint_resource_test.go
+++ b/pkg/provider/llm_blueprint_resource_test.go
@@ -287,9 +287,6 @@ resource "datarobot_custom_model" "test" {
   files = []
 }
 
-resource "datarobot_use_case" "test" {
-	name = "test use case"
-}
 resource "datarobot_playground" "test" {
 	name = "test playground"
 	use_case_id = datarobot_use_case.test.id

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -159,6 +159,7 @@ type LLMSettings struct {
 	Temperature         types.Float64 `tfsdk:"temperature"`
 	TopP                types.Float64 `tfsdk:"top_p"`
 	SystemPrompt        types.String  `tfsdk:"system_prompt"`
+	CustomModelID       types.String  `tfsdk:"custom_model_id"`
 }
 
 type CustomModelLLMSettings struct {


### PR DESCRIPTION
Agentic playgrounds are introduced in DataRobot 11.1. When creating agentic playgrounds, the payload to `/llmBlueprints/` looks like this:

```
{
        "llmId": "chat-interface-custom-model",
        "llmSettings": {
            "customModelId": <ObjectId>,
        },
        "promptType": "ONE_TIME_PROMPT",
        "playgroundId": <ObjectId>,
        "name": "Custom model LLM blueprint",
    }
```

This PR extends LLMSettings to support passing custom model id, the other fields seem to already be passed as expected.