### PR TITLE
BaseEnvironmentID could change when there is stale state.BaseEnvironmentVersionID.

### DIFF
--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1046,6 +1046,11 @@ func (r CustomModelResource) ModifyPlan(ctx context.Context, req resource.Modify
 		if plan.BaseEnvironmentID == state.BaseEnvironmentID {
 			// use state base environment version id if base environment id is not changed
 			plan.BaseEnvironmentVersionID = state.BaseEnvironmentVersionID
+		} else if IsKnown(plan.BaseEnvironmentID) && IsKnown(state.BaseEnvironmentVersionID) &&
+			plan.BaseEnvironmentID != state.BaseEnvironmentID {
+			// base environment has changed, explicitly reset version id to unknown
+			// so API can resolve the correct version for the new environment
+			plan.BaseEnvironmentVersionID = types.StringUnknown()
 		}
 	}
 


### PR DESCRIPTION
I recently encountered a situation where I would like to assign an execution environment ID for my custom model. However setting `base_environment_id` in CustomModelArgs alone was not sufficient and I kept getting the old obsolete environment version and erro message: `response 422 Unprocessable Entity {"message": "Provided environment version id {old ID} belongs to an environment id {old ID} , and not to the provided environment id {new ID}"` 

It looks like it's due to this line `plan.BaseEnvironmentVersionID = state.BaseEnvironmentVersionID` so I had to specify `base_environment_version_id` explicitly in CustomModelArgs too. The conditional block added in this PR should handle this and allow for setting base environment ``base_environment_id` without specifying its version.

This is my first PR to this repo so please let me know if I am missing anything.

<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
as explained in summary above

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
I am not sure how this change can be tested, would appreciate guidance. 

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.
