### PR TITLE
[CFX-5318] Refactor environment ID usage and improve test configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed deployment runtime parameter updates failing with 500 after model replacement by reordering Update operations to apply runtime parameters before triggering model replacement
 - Fixed deployment updates hanging indefinitely when the deployment is inactive. The provider now detects inactive deployments and automatically activates them before proceeding with updates or model replacements
 - Fixed `waitForDeploymentStatus` to fail fast when a deployment is stable in inactive state instead of retrying for up to 30 minutes
+- Fixed custom metric job runtime parameter values not being cleared when removed from configuration. The Update path was skipping empty lists instead of sending `"[]"` to the API
 
 ## [0.10.30] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased] 
+
+### Fixed
+
+- Fixed deployment runtime parameter updates failing with 500 after model replacement by reordering Update operations to apply runtime parameters before triggering model replacement
+- Fixed deployment updates hanging indefinitely when the deployment is inactive. The provider now detects inactive deployments and automatically activates them before proceeding with updates or model replacements
+- Fixed `waitForDeploymentStatus` to fail fast when a deployment is stable in inactive state instead of retrying for up to 30 minutes
+
 ## [0.10.30] - 2026-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ### Fixed
 
+- Fixed deployment creation task status polling getting stuck when the status API returns `INITIALIZED` indefinitely. After 2 minutes of `INITIALIZED` with no progress, the provider now skips the status check and verifies the deployment readiness directly
+- Added detailed logging to task status polling — each poll now logs the task ID, current status, and elapsed time via `tflog.Info` for easier debugging
+- Fixed `waitForDeploymentStatus` race condition where the fail-fast check on `inactive` status could race with `activateDeployment`, causing spurious permanent errors. Removed the fail-fast and added status/elapsed info to timeout errors instead
+- Fixed deployment creation/model replacement to proceed to deployment readiness check even if task status polling fails, preventing unnecessary resource deletion on transient status API issues
+- Deduplicated registered model version creation logic in Update — extracted `createNewRegisteredModelVersion` helper to eliminate near-identical code blocks for custom model version changes and tag-only changes
+- Fixed QA Application acceptance test to set `GUARD_CONFIG_PLACEHOLDER` runtime parameter on the deployment, required by the updated `POST /customApplications/qanda/` API
 - Fixed deployment runtime parameter updates failing with 500 after model replacement by reordering Update operations to apply runtime parameters before triggering model replacement
 - Fixed deployment updates hanging indefinitely when the deployment is inactive. The provider now detects inactive deployments and automatically activates them before proceeding with updates or model replacements
-- Fixed `waitForDeploymentStatus` to fail fast when a deployment is stable in inactive state instead of retrying for up to 30 minutes
 - Fixed custom metric job runtime parameter values not being cleared when removed from configuration. The Update path was skipping empty lists instead of sending `"[]"` to the API
 
 ## [0.10.30] - 2026-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased] 
+## [Unreleased]
 
 ### Fixed
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -188,6 +189,9 @@ func Put[T any](c *Client, ctx context.Context, path string, body any) (*T, erro
 }
 
 func Delete(c *Client, ctx context.Context, path string) (err error) {
+	if os.Getenv("SKIP_RESOURCE_DESTROY") == "1" {
+		return nil
+	}
 	_, err = doRequest[CreateVoidResponse](c, ctx, http.MethodDelete, path, nil)
 	return
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -189,9 +188,6 @@ func Put[T any](c *Client, ctx context.Context, path string, body any) (*T, erro
 }
 
 func Delete(c *Client, ctx context.Context, path string) (err error) {
-	if os.Getenv("SKIP_RESOURCE_DESTROY") == "1" {
-		return nil
-	}
 	_, err = doRequest[CreateVoidResponse](c, ctx, http.MethodDelete, path, nil)
 	return
 }

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -228,6 +228,9 @@ type Service interface {
 	// User Info
 	GetUserInfo(ctx context.Context) (*UserInfo, error)
 
+	// Feature Flags
+	IsFeatureFlagEnabled(ctx context.Context, flagName string) (bool, error)
+
 	// User MCP Tool Metadata
 	CreateUserMCPToolMetadata(ctx context.Context, mcpServerVersionID string, req *UserMCPToolMetadataRequest) (*UserMCPToolMetadataResponse, error)
 
@@ -255,8 +258,9 @@ type Service interface {
 
 // Service for the DataRobot API.
 type ServiceImpl struct {
-	client      *Client
-	apiGWClient *Client
+	client        *Client
+	apiGWClient   *Client
+	profileClient *Client
 }
 
 // NewService creates a new API service.
@@ -269,9 +273,15 @@ func NewService(c *Client) Service {
 	apiGWConfig.Endpoint = apiGWConfig.BaseURL() + "/api-gw"
 	apiGWClient := NewClient(&apiGWConfig)
 
+	// Construct the profile client for non-API-v2 endpoints
+	profileConfig := *c.cfg
+	profileConfig.Endpoint = profileConfig.BaseURL()
+	profileClient := NewClient(&profileConfig)
+
 	return &ServiceImpl{
-		client:      c,
-		apiGWClient: apiGWClient,
+		client:        c,
+		apiGWClient:   apiGWClient,
+		profileClient: profileClient,
 	}
 }
 
@@ -997,11 +1007,19 @@ func (s *ServiceImpl) GetUserInfo(ctx context.Context) (*UserInfo, error) {
 	return Get[UserInfo](s.client, ctx, "/account/info/")
 }
 
+func (s *ServiceImpl) IsFeatureFlagEnabled(ctx context.Context, flagName string) (bool, error) {
+	userInfo, err := s.GetUserInfo(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch user info for feature flag %q: %w", flagName, err)
+	}
+	return userInfo.Permissions[flagName], nil
+}
+
 // User MCP Tool Metadata Service Implementation.
 func (s *ServiceImpl) CreateUserMCPToolMetadata(ctx context.Context, mcpServerVersionID string, req *UserMCPToolMetadataRequest) (*UserMCPToolMetadataResponse, error) {
 	return Post[UserMCPToolMetadataResponse](s.client, ctx, fmt.Sprintf("/userMCPServerVersions/%s/tools/", mcpServerVersionID), req)
-}
 
+}
 // User MCP Prompt Metadata Service Implementation.
 func (s *ServiceImpl) CreateUserMCPPromptMetadata(ctx context.Context, mcpServerVersionID string, req *UserMCPPromptMetadataRequest) (*UserMCPPromptMetadataResponse, error) {
 	return Post[UserMCPPromptMetadataResponse](s.client, ctx, fmt.Sprintf("/userMCPServerVersions/%s/prompts/", mcpServerVersionID), req)

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -258,9 +258,8 @@ type Service interface {
 
 // Service for the DataRobot API.
 type ServiceImpl struct {
-	client        *Client
-	apiGWClient   *Client
-	profileClient *Client
+	client      *Client
+	apiGWClient *Client
 }
 
 // NewService creates a new API service.
@@ -273,15 +272,9 @@ func NewService(c *Client) Service {
 	apiGWConfig.Endpoint = apiGWConfig.BaseURL() + "/api-gw"
 	apiGWClient := NewClient(&apiGWConfig)
 
-	// Construct the profile client for non-API-v2 endpoints
-	profileConfig := *c.cfg
-	profileConfig.Endpoint = profileConfig.BaseURL()
-	profileClient := NewClient(&profileConfig)
-
 	return &ServiceImpl{
-		client:        c,
-		apiGWClient:   apiGWClient,
-		profileClient: profileClient,
+		client:      c,
+		apiGWClient: apiGWClient,
 	}
 }
 

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -1018,8 +1018,8 @@ func (s *ServiceImpl) IsFeatureFlagEnabled(ctx context.Context, flagName string)
 // User MCP Tool Metadata Service Implementation.
 func (s *ServiceImpl) CreateUserMCPToolMetadata(ctx context.Context, mcpServerVersionID string, req *UserMCPToolMetadataRequest) (*UserMCPToolMetadataResponse, error) {
 	return Post[UserMCPToolMetadataResponse](s.client, ctx, fmt.Sprintf("/userMCPServerVersions/%s/tools/", mcpServerVersionID), req)
-
 }
+
 // User MCP Prompt Metadata Service Implementation.
 func (s *ServiceImpl) CreateUserMCPPromptMetadata(ctx context.Context, mcpServerVersionID string, req *UserMCPPromptMetadataRequest) (*UserMCPPromptMetadataResponse, error) {
 	return Post[UserMCPPromptMetadataResponse](s.client, ctx, fmt.Sprintf("/userMCPServerVersions/%s/prompts/", mcpServerVersionID), req)

--- a/internal/client/user_service.go
+++ b/internal/client/user_service.go
@@ -1,10 +1,11 @@
 package client
 
 type UserInfo struct {
-	UID       string `json:"uid"`
-	Email     string `json:"email"`
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	OrgID     string `json:"orgId"`
-	TenantID  string `json:"tenantId"`
+	UID         string          `json:"uid"`
+	Email       string          `json:"email"`
+	FirstName   string          `json:"firstName"`
+	LastName    string          `json:"lastName"`
+	OrgID       string          `json:"orgId"`
+	TenantID    string          `json:"tenantId"`
+	Permissions map[string]bool `json:"permissions"`
 }

--- a/mock/service.go
+++ b/mock/service.go
@@ -667,21 +667,6 @@ func (mr *MockServiceMockRecorder) CreateUseCase(ctx, req interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUseCase", reflect.TypeOf((*MockService)(nil).CreateUseCase), ctx, req)
 }
 
-// CreateUserMCPToolMetadata mocks base method.
-func (m *MockService) CreateUserMCPToolMetadata(ctx context.Context, mcpServerVersionID string, req *client.UserMCPToolMetadataRequest) (*client.UserMCPToolMetadataResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUserMCPToolMetadata", ctx, mcpServerVersionID, req)
-	ret0, _ := ret[0].(*client.UserMCPToolMetadataResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateUserMCPToolMetadata indicates an expected call of CreateUserMCPToolMetadata.
-func (mr *MockServiceMockRecorder) CreateUserMCPToolMetadata(ctx, mcpServerVersionID, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserMCPToolMetadata", reflect.TypeOf((*MockService)(nil).CreateUserMCPToolMetadata), ctx, mcpServerVersionID, req)
-}
-
 // CreateUserMCPPromptMetadata mocks base method.
 func (m *MockService) CreateUserMCPPromptMetadata(ctx context.Context, mcpServerVersionID string, req *client.UserMCPPromptMetadataRequest) (*client.UserMCPPromptMetadataResponse, error) {
 	m.ctrl.T.Helper()
@@ -710,6 +695,21 @@ func (m *MockService) CreateUserMCPResourceMetadata(ctx context.Context, mcpServ
 func (mr *MockServiceMockRecorder) CreateUserMCPResourceMetadata(ctx, mcpServerVersionID, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserMCPResourceMetadata", reflect.TypeOf((*MockService)(nil).CreateUserMCPResourceMetadata), ctx, mcpServerVersionID, req)
+}
+
+// CreateUserMCPToolMetadata mocks base method.
+func (m *MockService) CreateUserMCPToolMetadata(ctx context.Context, mcpServerVersionID string, req *client.UserMCPToolMetadataRequest) (*client.UserMCPToolMetadataResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserMCPToolMetadata", ctx, mcpServerVersionID, req)
+	ret0, _ := ret[0].(*client.UserMCPToolMetadataResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserMCPToolMetadata indicates an expected call of CreateUserMCPToolMetadata.
+func (mr *MockServiceMockRecorder) CreateUserMCPToolMetadata(ctx, mcpServerVersionID, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserMCPToolMetadata", reflect.TypeOf((*MockService)(nil).CreateUserMCPToolMetadata), ctx, mcpServerVersionID, req)
 }
 
 // CreateVectorDatabase mocks base method.
@@ -1779,6 +1779,21 @@ func (m *MockService) IsCustomModelReady(ctx context.Context, id string) (bool, 
 func (mr *MockServiceMockRecorder) IsCustomModelReady(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCustomModelReady", reflect.TypeOf((*MockService)(nil).IsCustomModelReady), ctx, id)
+}
+
+// IsFeatureFlagEnabled mocks base method.
+func (m *MockService) IsFeatureFlagEnabled(ctx context.Context, flagName string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsFeatureFlagEnabled", ctx, flagName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsFeatureFlagEnabled indicates an expected call of IsFeatureFlagEnabled.
+func (mr *MockServiceMockRecorder) IsFeatureFlagEnabled(ctx, flagName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureFlagEnabled", reflect.TypeOf((*MockService)(nil).IsFeatureFlagEnabled), ctx, flagName)
 }
 
 // IsRegisteredModelVersionReady mocks base method.

--- a/pkg/provider/application_source_from_template_resource_test.go
+++ b/pkg/provider/application_source_from_template_resource_test.go
@@ -45,8 +45,8 @@ func testApplicationSourceFromTemplateResource(t *testing.T, isMock bool) {
 
 	newName := "new_from_template " + nameSalt
 
-	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
-	baseEnvironmentVersionID := "668548c1b8e086572a96fbf5"
+	baseEnvironmentID := testStreamlitBaseEnvID
+	baseEnvironmentVersionID := testAppSourceBaseEnvVersionID
 
 	appCodeFileName := "flask_app.py"
 	appCode := `import streamlit as st
@@ -81,10 +81,10 @@ if __name__ == "__main__":
 	resourceLabel := "cpu.medium"
 	resourceLabel2 := "cpu.small"
 
-	slackbotTemplateID := "67126757e7819551baceb22b"
-	qaTemplateID := "670fb324bf9bbb1081114333"
-	streamlitTemplateID := "671267597665e0b33f7acdb7"
-	flaskTemplateID := "67126750e8342440587acd74"
+	slackbotTemplateID := testSlackbotTemplateID
+	qaTemplateID := testQATemplateID
+	streamlitTemplateID := testStreamlitTemplateID
+	flaskTemplateID := testFlaskTemplateID
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: isMock,

--- a/pkg/provider/application_source_resource_test.go
+++ b/pkg/provider/application_source_resource_test.go
@@ -52,8 +52,8 @@ func testApplicationSourceResource(t *testing.T, isMock bool) {
 	name := "application_source " + testUniqueID
 	newName := "new_application_source " + testUniqueID
 
-	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
-	baseEnvironmentVersionID := "668548c1b8e086572a96fbf5"
+	baseEnvironmentID := testStreamlitBaseEnvID
+	baseEnvironmentVersionID := testAppSourceBaseEnvVersionID
 
 	// Create a unique directory for this test to avoid parallel test interference
 	testDir := fmt.Sprintf("test_app_source_%s", testUniqueID)
@@ -398,7 +398,7 @@ func TestAccApplicationSourceResourceBatchFiles(t *testing.T) {
 func testApplicationSourceResourceBatchFiles(t *testing.T, isMock bool) {
 	resourceName := "datarobot_application_source.test"
 
-	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
+	baseEnvironmentID := testStreamlitBaseEnvID
 
 	testUniqueID := nameSalt + "-" + t.Name()
 	testDir := fmt.Sprintf("test_batch_files_%s", testUniqueID)
@@ -720,7 +720,7 @@ func applicationSourceWithScopeLevelConfig(scopeLevel string) string {
 
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test_scope" {
-	base_environment_id = "6542cd582a9d3d51bf4ac71e"
+	base_environment_id = "` + testStreamlitBaseEnvID + `"
 	files = [
 		["start-app.sh"],
 		["streamlit-app.py"]

--- a/pkg/provider/application_source_resource_test.go
+++ b/pkg/provider/application_source_resource_test.go
@@ -720,7 +720,7 @@ func applicationSourceWithScopeLevelConfig(scopeLevel string) string {
 
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test_scope" {
-	base_environment_id = "` + testStreamlitBaseEnvID + `"
+	base_environment_id = "`+testStreamlitBaseEnvID+`"
 	files = [
 		["start-app.sh"],
 		["streamlit-app.py"]

--- a/pkg/provider/batch_prediction_job_definition_resource_test.go
+++ b/pkg/provider/batch_prediction_job_definition_resource_test.go
@@ -194,7 +194,7 @@ resource "datarobot_custom_model" "batch_prediction_job_definition" {
 	name = "test batch prediction job %s"
 	target_type = "Binary"
 	target_name = "t"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "batch_prediction_job_definition"
 }
 resource "datarobot_registered_model" "batch_prediction_job_definition" {

--- a/pkg/provider/batch_prediction_job_definition_resource_test.go
+++ b/pkg/provider/batch_prediction_job_definition_resource_test.go
@@ -191,10 +191,10 @@ resource "datarobot_basic_credential" "batch_prediction_job_definition" {
 	password = "b@tch_prediction_Job"
 }
 resource "datarobot_custom_model" "batch_prediction_job_definition" {
-	name = "test batch prediction job"
+	name = "test batch prediction job %s"
 	target_type = "Binary"
 	target_name = "t"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "batch_prediction_job_definition"
 }
 resource "datarobot_registered_model" "batch_prediction_job_definition" {
@@ -203,7 +203,7 @@ resource "datarobot_registered_model" "batch_prediction_job_definition" {
 	custom_model_version_id = "${datarobot_custom_model.batch_prediction_job_definition.version_id}"
 }
 resource "datarobot_prediction_environment" "batch_prediction_job_definition" {
-	name = "test batch prediction job"
+	name = "test batch prediction job %s"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "batch_prediction_job_definition" {
@@ -247,7 +247,9 @@ resource "datarobot_batch_prediction_job_definition" "test" {
 		day_of_week 	= ["*"]
 	}
 }`, name,
+		nameSalt,
 		name,
+		nameSalt,
 		name,
 		name,
 		numConcurrent,

--- a/pkg/provider/custom_application_from_environment_resource_test.go
+++ b/pkg/provider/custom_application_from_environment_resource_test.go
@@ -31,8 +31,8 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 	name := "custom_app_from_env" + nameSalt
 	newName := "new_custom_app_from_env " + nameSalt
 
-	environmentID := "67987589391fe8fa0a2275b8"
-	environmentID2 := "67987b1a90dbd55389b699c2"
+	environmentID := testCustomAppEnvID
+	environmentID2 := testCustomAppEnvID2
 
 	useCaseResourceName := "test_custom_application"
 	useCaseResourceName2 := "test_new_custom_application"

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -212,7 +212,7 @@ resource "datarobot_use_case" "test_new_custom_application" {
 }
 
 resource "datarobot_application_source" "test" {
-	base_environment_id = "` + testStreamlitBaseEnvID + `"
+	base_environment_id = "`+testStreamlitBaseEnvID+`"
 	folder_path = "custom_application"
 	resources = {
 		replicas = %d
@@ -768,7 +768,7 @@ func customApplicationWithResourcesFromSourceConfig(folderPath string) string {
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test" {
 	name = "Resources Test Source %s"
-	base_environment_id = "` + testStreamlitBaseEnvID + `"
+	base_environment_id = "`+testStreamlitBaseEnvID+`"
 	folder_path = "%s"
 	resources = {
 		replicas = 2
@@ -882,7 +882,7 @@ func customApplicationWithScopeLevelConfig(folderPath, scopeLevel, nameSalt stri
 
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test_scope" {
-	base_environment_id = "` + testStreamlitBaseEnvID + `"
+	base_environment_id = "`+testStreamlitBaseEnvID+`"
 	folder_path = "%s"
 }
 

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -205,14 +205,14 @@ func customApplicationResourceConfig(
 
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "test_custom_application" {
-	name = "test custom application"
+	name = "test custom application %s"
 }
 resource "datarobot_use_case" "test_new_custom_application" {
-	name = "test new custom application"
+	name = "test new custom application %s"
 }
 
 resource "datarobot_application_source" "test" {
-	base_environment_id = "6542cd582a9d3d51bf4ac71e"
+	base_environment_id = "` + testStreamlitBaseEnvID + `"
 	folder_path = "custom_application"
 	resources = {
 		replicas = %d
@@ -227,7 +227,7 @@ resource "datarobot_custom_application" "test" {
 	%s
 	%s
 }
-`, applicationSourceReplicas, externalAccess, allowAutoStopping, recipients, nameStr, useCaseIDsStr)
+`, nameSalt, nameSalt, applicationSourceReplicas, externalAccess, allowAutoStopping, recipients, nameStr, useCaseIDsStr)
 }
 
 func checkCustomApplicationResourceExists() resource.TestCheckFunc {
@@ -356,7 +356,7 @@ numpy
 		}
 	}
 
-	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
+	baseEnvironmentID := testStreamlitBaseEnvID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -567,7 +567,7 @@ numpy
 		}
 	}
 
-	baseEnvironmentID := "6542cd582a9d3d51bf4ac71e"
+	baseEnvironmentID := testStreamlitBaseEnvID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -768,7 +768,7 @@ func customApplicationWithResourcesFromSourceConfig(folderPath string) string {
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test" {
 	name = "Resources Test Source %s"
-	base_environment_id = "6542cd582a9d3d51bf4ac71e"
+	base_environment_id = "` + testStreamlitBaseEnvID + `"
 	folder_path = "%s"
 	resources = {
 		replicas = 2
@@ -882,7 +882,7 @@ func customApplicationWithScopeLevelConfig(folderPath, scopeLevel, nameSalt stri
 
 	return fmt.Sprintf(`
 resource "datarobot_application_source" "test_scope" {
-	base_environment_id = "6542cd582a9d3d51bf4ac71e"
+	base_environment_id = "` + testStreamlitBaseEnvID + `"
 	folder_path = "%s"
 }
 

--- a/pkg/provider/custom_job_resource_test.go
+++ b/pkg/provider/custom_job_resource_test.go
@@ -478,7 +478,7 @@ resource "datarobot_custom_job" "test" {
 	name = "%s"
 	description = "%s"
 	job_type = "%s"
-	environment_id = "66d07fae0513a1edf18595bb"
+	environment_id = "` + testCustomJobEnvID + `"
 	egress_network_policy = "%s"
 	%s
 	%s

--- a/pkg/provider/custom_job_resource_test.go
+++ b/pkg/provider/custom_job_resource_test.go
@@ -478,7 +478,7 @@ resource "datarobot_custom_job" "test" {
 	name = "%s"
 	description = "%s"
 	job_type = "%s"
-	environment_id = "` + testCustomJobEnvID + `"
+	environment_id = "`+testCustomJobEnvID+`"
 	egress_network_policy = "%s"
 	%s
 	%s

--- a/pkg/provider/custom_metric_from_job_resource_test.go
+++ b/pkg/provider/custom_metric_from_job_resource_test.go
@@ -62,6 +62,21 @@ func TestAccCustomMetricFromJobResource(t *testing.T) {
 	if err := os.Mkdir(folderPath, 0755); err != nil {
 		t.Fatal(err)
 	}
+
+	metadataFileName := "metadata.yaml"
+	metadataFilePath := folderPath + "/" + metadataFileName
+	metadataFileContents := `name: runtime-params
+
+runtimeParameterDefinitions:
+  - fieldName: OPENAI_API_BASE
+    type: string
+    description: OpenAI API Base URL
+    defaultValue: null`
+
+	err := os.WriteFile(metadataFilePath, []byte(metadataFileContents), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(folderPath)
 
 	modelContents := `from typing import Any, Dict
@@ -252,13 +267,14 @@ func customMetricFromJobResourceConfig(
 	return fmt.Sprintf(`
 resource "datarobot_custom_metric_job" "datarobot_custom_metric_from_job" {
 	name = "%s"
-	environment_id = "66d07fae0513a1edf18595bb"
+	environment_id = "` + testCustomJobEnvID + `"
+	folder_path = "custom_metric_from_job"
 }
 resource "datarobot_custom_model" "datarobot_custom_metric_from_job" {
-	name = "test custom metric from job"
+	name = "test custom metric from job %s"
 	target_type = "Binary"
 	target_name = "t"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "custom_metric_from_job"
 }
 resource "datarobot_registered_model" "datarobot_custom_metric_from_job" {
@@ -266,7 +282,7 @@ resource "datarobot_registered_model" "datarobot_custom_metric_from_job" {
 	custom_model_version_id = "${datarobot_custom_model.datarobot_custom_metric_from_job.version_id}"
 }
 resource "datarobot_prediction_environment" "datarobot_custom_metric_from_job" {
-	name = "test custom metric from job"
+	name = "test custom metric from job %s"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "datarobot_custom_metric_from_job" {
@@ -303,7 +319,9 @@ resource "datarobot_custom_metric_from_job" "test" {
 	parameter_overrides = %s
 }
 `, name,
+		nameSalt,
 		name,
+		nameSalt,
 		name,
 		name,
 		baselineValue,

--- a/pkg/provider/custom_metric_from_job_resource_test.go
+++ b/pkg/provider/custom_metric_from_job_resource_test.go
@@ -267,14 +267,14 @@ func customMetricFromJobResourceConfig(
 	return fmt.Sprintf(`
 resource "datarobot_custom_metric_job" "datarobot_custom_metric_from_job" {
 	name = "%s"
-	environment_id = "` + testCustomJobEnvID + `"
+	environment_id = "`+testCustomJobEnvID+`"
 	folder_path = "custom_metric_from_job"
 }
 resource "datarobot_custom_model" "datarobot_custom_metric_from_job" {
 	name = "test custom metric from job %s"
 	target_type = "Binary"
 	target_name = "t"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "custom_metric_from_job"
 }
 resource "datarobot_registered_model" "datarobot_custom_metric_from_job" {

--- a/pkg/provider/custom_metric_job_resource.go
+++ b/pkg/provider/custom_metric_job_resource.go
@@ -342,7 +342,7 @@ func (r *CustomMetricJobResource) Update(ctx context.Context, req resource.Updat
 
 	var runtimeParameterValues string
 	var err error
-	if len(plan.RuntimeParameterValues.Elements()) > 0 {
+	if IsKnown(plan.RuntimeParameterValues) {
 		runtimeParameterValues, err = convertRuntimeParameterValues(ctx, plan.RuntimeParameterValues)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading runtime parameter values", err.Error())

--- a/pkg/provider/custom_metric_job_resource.go
+++ b/pkg/provider/custom_metric_job_resource.go
@@ -340,10 +340,14 @@ func (r *CustomMetricJobResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
-	runtimeParameterValues, err := convertRuntimeParameterValues(ctx, plan.RuntimeParameterValues)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading runtime parameter values", err.Error())
-		return
+	var runtimeParameterValues string
+	var err error
+	if len(plan.RuntimeParameterValues.Elements()) > 0 {
+		runtimeParameterValues, err = convertRuntimeParameterValues(ctx, plan.RuntimeParameterValues)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading runtime parameter values", err.Error())
+			return
+		}
 	}
 
 	// then update the rest of the Custom Job fields

--- a/pkg/provider/custom_metric_job_resource_test.go
+++ b/pkg/provider/custom_metric_job_resource_test.go
@@ -362,7 +362,7 @@ func customMetricJobResourceConfig(
 resource "datarobot_custom_metric_job" "test" {
 	name = "%s"
 	description = "%s"
-	environment_id = "66d07fae0513a1edf18595bb"
+	environment_id = "` + testCustomJobEnvID + `"
 	egress_network_policy = "%s"
 	type = "%s"
 	directionality = "%s"

--- a/pkg/provider/custom_metric_job_resource_test.go
+++ b/pkg/provider/custom_metric_job_resource_test.go
@@ -362,7 +362,7 @@ func customMetricJobResourceConfig(
 resource "datarobot_custom_metric_job" "test" {
 	name = "%s"
 	description = "%s"
-	environment_id = "` + testCustomJobEnvID + `"
+	environment_id = "`+testCustomJobEnvID+`"
 	egress_network_policy = "%s"
 	type = "%s"
 	directionality = "%s"

--- a/pkg/provider/custom_metric_resource_test.go
+++ b/pkg/provider/custom_metric_resource_test.go
@@ -197,11 +197,11 @@ func customMetricResourceConfig(
 	timeFormat := "%Y-%m-%dT%H:%M:%SZ"
 	return fmt.Sprintf(`
 resource "datarobot_custom_model" "test_custom_metric" {
-	name = "test custom metric"
+	name = "test custom metric %s"
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "custom_metric"
 }
 resource "datarobot_registered_model" "test_custom_metric" {
@@ -210,12 +210,12 @@ resource "datarobot_registered_model" "test_custom_metric" {
 	custom_model_version_id = "${datarobot_custom_model.test_custom_metric.version_id}"
 }
 resource "datarobot_prediction_environment" "test_custom_metric" {
-	name = "test deployment"
+	name = "test custom metric %s"
 	description = "test"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "test_custom_metric" {
-	label = "test custom metric"
+	label = "test custom metric %s"
 	importance = "LOW"
 	prediction_environment_id = datarobot_prediction_environment.test_custom_metric.id
 	registered_model_version_id = datarobot_registered_model.test_custom_metric.version_id
@@ -245,6 +245,9 @@ resource "datarobot_custom_metric" "test" {
 	}
 }
 `, nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
 		name,
 		description,
 		untis,

--- a/pkg/provider/custom_metric_resource_test.go
+++ b/pkg/provider/custom_metric_resource_test.go
@@ -201,7 +201,7 @@ resource "datarobot_custom_model" "test_custom_metric" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "custom_metric"
 }
 resource "datarobot_registered_model" "test_custom_metric" {

--- a/pkg/provider/custom_model_llm_validation_resource_test.go
+++ b/pkg/provider/custom_model_llm_validation_resource_test.go
@@ -165,19 +165,19 @@ func customModelLLMValidationResourceConfig(
 
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "test_custom_model_llm_validation" {
-	name = "test custom model llm validation"
+	name = "test custom model llm validation %s"
 }
 resource "datarobot_playground" "test_custom_model_llm_validation" {
-	name = "llm validation test"
+	name = "llm validation test %s"
 	description = "test"
 	use_case_id = "${datarobot_use_case.test_custom_model_llm_validation.id}"
 }
 resource "datarobot_custom_model" "test_custom_model_llm_validation" {
-	name = "test custom model llm validation"
+	name = "test custom model llm validation %s"
 	description = "test"
 	target_type = "TextGeneration"
 	target_name = "resultText"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "custom_model_llm_validation"
 }
 resource "datarobot_registered_model" "test_custom_model_llm_validation" {
@@ -185,12 +185,12 @@ resource "datarobot_registered_model" "test_custom_model_llm_validation" {
 	custom_model_version_id = "${datarobot_custom_model.test_custom_model_llm_validation.version_id}"
 }
 resource "datarobot_prediction_environment" "test_custom_model_llm_validation" {
-	name = "test custom model llm validation"
+	name = "test custom model llm validation %s"
 	description = "test"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "test_custom_model_llm_validation" {
-	label = "test custom model llm validation"
+	label = "test custom model llm validation %s"
 	importance = "LOW"
 	prediction_environment_id = datarobot_prediction_environment.test_custom_model_llm_validation.id
 	registered_model_version_id = datarobot_registered_model.test_custom_model_llm_validation.version_id
@@ -205,16 +205,22 @@ resource "datarobot_custom_model_llm_validation" "test" {
 	use_case_id = datarobot_use_case.test_custom_model_llm_validation.id
 }
 resource "datarobot_llm_blueprint" "test_custom_model_llm_validation" {
-	name = "test custom model llm validation"
+	name = "test custom model llm validation %s"
 	playground_id = "${datarobot_playground.test_custom_model_llm_validation.id}"
 	llm_id = "custom-model"
 }
 `, nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
 		name,
 		chatModelIDStr,
 		promptColumnNameStr,
 		targetColumnNameStr,
-		predictionTimeout)
+		predictionTimeout,
+		nameSalt)
 }
 
 func checkCustomModelLLMValidationResourceExists() resource.TestCheckFunc {

--- a/pkg/provider/custom_model_llm_validation_resource_test.go
+++ b/pkg/provider/custom_model_llm_validation_resource_test.go
@@ -177,7 +177,7 @@ resource "datarobot_custom_model" "test_custom_model_llm_validation" {
 	description = "test"
 	target_type = "TextGeneration"
 	target_name = "resultText"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "custom_model_llm_validation"
 }
 resource "datarobot_registered_model" "test_custom_model_llm_validation" {

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1887,6 +1887,11 @@ func (r *CustomModelResource) updateGuardConfigurations(
 ) (
 	err error,
 ) {
+	if reflect.DeepEqual(plan.GuardConfigurations, state.GuardConfigurations) &&
+		reflect.DeepEqual(plan.OverallModerationConfiguration, state.OverallModerationConfiguration) {
+		return
+	}
+
 	var customModel *client.CustomModel
 	customModel, err = r.provider.service.GetCustomModel(ctx, plan.ID.ValueString())
 	if err != nil {

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -75,8 +75,8 @@ func TestAccCustomModelWithoutLlmBlueprintResource(t *testing.T) {
 
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	baseEnvironmentID := "65f9b27eab986d30d4c64268"  // [GenAI] Python 3.11 with Moderations
-	baseEnvironmentID2 := "6542cd582a9d3d51bf4ac71e" // [Experimental] Python 3.9 Streamlit
+	baseEnvironmentID := testGenAIBaseEnvID
+	baseEnvironmentID2 := testStreamlitBaseEnvID
 
 	fileName := "requirements.txt"
 	folderPath := "custom_model_without_llm_blueprint"
@@ -86,6 +86,32 @@ func TestAccCustomModelWithoutLlmBlueprintResource(t *testing.T) {
 	}
 	defer os.Remove(fileName)
 
+	metadataFileName := "model-metadata.yaml"
+	metadataContents := `name: test-model
+runtimeParameterDefinitions:
+  - fieldName: GUARD_CONFIG_PLACEHOLDER
+    type: string
+    description: Placeholder for guard configuration schema
+    defaultValue: null
+  - fieldName: MODERATION_OOTB_RESPONSE_FAITHFULNESS_AZURE_OPENAI_API_KEY
+    type: credential
+    description: Azure OpenAI API key for Faithfulness guard
+    defaultValue: null
+  - fieldName: MODERATION_NEMO_GUARDRAILS_PROMPT_AZURE_OPENAI_API_KEY
+    type: credential
+    description: Azure OpenAI API key for NeMo guard
+    defaultValue: null
+  - fieldName: MODERATION_OOTB_RESPONSE_FAITHFULNESS_OPENAI_API_KEY
+    type: credential
+    description: OpenAI API key for Faithfulness guard
+    defaultValue: null
+`
+	err = os.WriteFile(metadataFileName, []byte(metadataContents), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(metadataFileName)
+
 	os.RemoveAll(folderPath)
 	err = os.Mkdir(folderPath, 0755)
 	if err != nil {
@@ -94,6 +120,11 @@ func TestAccCustomModelWithoutLlmBlueprintResource(t *testing.T) {
 	defer os.RemoveAll(folderPath)
 
 	err = os.WriteFile(folderPath+"/"+fileName, []byte(`langchain == 0.2.9`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(folderPath+"/"+metadataFileName, []byte(metadataContents), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +150,7 @@ func TestAccCustomModelWithoutLlmBlueprintResource(t *testing.T) {
 					baseEnvironmentID,
 					sourceRemoteRepositories,
 					nil,
-					[]FileTuple{{LocalPath: fileName}},
+					[]FileTuple{{LocalPath: fileName}, {LocalPath: metadataFileName}},
 					[]GuardConfiguration{
 						{
 							TemplateName: basetypes.NewStringValue("Rouge 1"),
@@ -225,7 +256,7 @@ func TestAccCustomModelWithoutLlmBlueprintResource(t *testing.T) {
 					baseEnvironmentID2,
 					sourceRemoteRepositories,
 					nil,
-					[]FileTuple{{LocalPath: fileName, PathInModel: "new_dir/" + fileName}},
+					[]FileTuple{{LocalPath: fileName, PathInModel: "new_dir/" + fileName}, {LocalPath: metadataFileName}},
 					[]GuardConfiguration{
 						{
 							TemplateName: basetypes.NewStringValue("Faithfulness"),
@@ -567,7 +598,7 @@ func TestAccCustomModelWithTrainingDatasetResource(t *testing.T) {
 	resourceTestName := "test_with_training_dataset"
 	resourceName := resourceType + "." + resourceTestName
 
-	baseEnvironmentID := "65f9b27eab986d30d4c64268" // [GenAI] Python 3.11 with Moderations
+	baseEnvironmentID := testGenAIBaseEnvID
 
 	sourceRemoteRepositories := []SourceRemoteRepository{
 		{
@@ -612,7 +643,7 @@ func TestAccCustomModelWithRuntimeParamsResource(t *testing.T) {
 
 	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
 
-	baseEnvironmentID := "65f9b27eab986d30d4c64268" // [GenAI] Python 3.11 with Moderations
+	baseEnvironmentID := testGenAIBaseEnvID
 
 	folderPath := "custom_model_with_runtime_params"
 	fileName := "model-metadata.yaml"
@@ -1315,7 +1346,7 @@ func TestCustomModelResourceConflictingRuntimeFields(t *testing.T) {
 func customModelFromLlmBlueprintResourceConfig(name, description, nameSalt string) string {
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "test_custom_model" {
-	name = "test custom model"
+	name = "test custom model %s"
 	description = "test"
 }
 resource "datarobot_dataset_from_file" "test_custom_model" {
@@ -1323,17 +1354,17 @@ resource "datarobot_dataset_from_file" "test_custom_model" {
 	use_case_ids = ["${datarobot_use_case.test_custom_model.id}"]
 }
 resource "datarobot_vector_database" "test_custom_model" {
-	  name = "test custom model"
+	  name = "test custom model %s"
 	  dataset_id = "${datarobot_dataset_from_file.test_custom_model.id}"
 	  use_case_id = "${datarobot_use_case.test_custom_model.id}"
 }
 resource "datarobot_playground" "test_custom_model" {
-	name = "test custom model"
+	name = "test custom model %s"
 	description = "test"
 	use_case_id = "${datarobot_use_case.test_custom_model.id}"
 }
 resource "datarobot_llm_blueprint" "test_custom_model" {
-	name = "test custom model"
+	name = "test custom model %s"
 	description = "test"
 	vector_database_id = "${datarobot_vector_database.test_custom_model.id}"
 	playground_id = "${datarobot_playground.test_custom_model.id}"
@@ -1348,7 +1379,7 @@ resource "datarobot_custom_model" "test_from_llm_blueprint" {
 	name = "%s"
 	description = "%s"
 	source_llm_blueprint_id = "${datarobot_llm_blueprint.test_custom_model.id}"
-	base_environment_id = "67ab469cecdca772287de644"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	runtime_parameter_values = [
 	  {
 		  key="OPENAI_API_BASE",
@@ -1362,7 +1393,7 @@ resource "datarobot_custom_model" "test_from_llm_blueprint" {
 	  }
 	]
 }
-`, nameSalt, name, description)
+`, nameSalt, nameSalt, nameSalt, nameSalt, nameSalt, name, description)
 }
 
 func customModelWithoutLlmBlueprintResourceConfig(
@@ -1504,7 +1535,7 @@ func customModelWithoutLlmBlueprintResourceConfig(
 
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "%s" {
-	name = "test custom model without llm blueprint"
+	name = "test custom model without llm blueprint %s"
 }
 
 resource "datarobot_dataset_from_file" "%s" {
@@ -1513,7 +1544,7 @@ resource "datarobot_dataset_from_file" "%s" {
 }
 
 resource "datarobot_remote_repository" "%s" {
-	name        = "Test Custom Model from Remote Repository"
+	name        = "Test Custom Model from Remote Repository %s"
 	description = "test"
 	location    = "https://github.com/datarobot-community/custom-models"
 	source_type = "github"
@@ -1539,9 +1570,11 @@ resource "datarobot_custom_model" "%s" {
 	%s
 }
 `, resourceName,
+		nameSalt,
 		resourceName,
 		resourceName,
 		resourceName,
+		nameSalt,
 		resourceName,
 		resourceName,
 		nameSalt,
@@ -1563,7 +1596,7 @@ func customModelWithRuntimeParamsConfig(value string) string {
 		name        		     = "with runtime params"
 		target_type              = "TextGeneration"
 		target_name              = "target"
-		base_environment_id      = "65f9b27eab986d30d4c64268"
+		base_environment_id      = "` + testGenAIBaseEnvID + `"
 		folder_path 			 = "custom_model_with_runtime_params"
 		runtime_parameter_values = [
 			{
@@ -1582,7 +1615,7 @@ func customModelWithoutRuntimeParamsConfig() string {
 		name        		     = "with runtime params"
 		target_type              = "TextGeneration"
 		target_name              = "target"
-		base_environment_id      = "65f9b27eab986d30d4c64268"
+		base_environment_id      = "` + testGenAIBaseEnvID + `"
 		folder_path 			 = "custom_model_with_runtime_params"
 	}
 	`
@@ -1626,7 +1659,7 @@ resource "datarobot_custom_model" "test_binary" {
 	positive_class_label  = "%s"
 	negative_class_label  = "%s"
 	prediction_threshold  = %f
-	base_environment_id   = "65f9b27eab986d30d4c64268"
+	base_environment_id   = "` + testGenAIBaseEnvID + `"
 	%s
 	%s
 	%s
@@ -1660,7 +1693,7 @@ resource "datarobot_custom_model" "test_multiclass" {
 	target_name           							  = "%s"
 	language 			  							  = "%s"
 	class_labels  		  							  = [%s]
-	base_environment_id 							  = "65f9b27eab986d30d4c64268"
+	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
 	is_proxy 										  = true
 	%s
 	%s
@@ -1683,7 +1716,7 @@ func regressionCustomModelResourceConfig(
 	return fmt.Sprintf(`
 %s
 resource "datarobot_use_case" "test_regression" {
-	name = "test custom model regression"
+	name = "test custom model regression %s"
 }
 
 resource "datarobot_custom_model" "test_regression" {
@@ -1691,11 +1724,11 @@ resource "datarobot_custom_model" "test_regression" {
 	target_type           							  = "Regression"
 	target_name           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 					  		  = "65f9b27eab986d30d4c64268"
+	base_environment_id 					  		  = "` + testGenAIBaseEnvID + `"
 	%s
 	%s
 }
-`, resourceBlock, name, targetName, language, useCaseIDsStr, customModelBlock)
+`, resourceBlock, nameSalt, name, targetName, language, useCaseIDsStr, customModelBlock)
 }
 
 func textGenerationCustomModelResourceConfig(
@@ -1713,10 +1746,10 @@ func textGenerationCustomModelResourceConfig(
 	return fmt.Sprintf(`
 %s
 resource "datarobot_use_case" "test_text_generation" {
-	name = "test custom model text generation"
+	name = "test custom model text generation %s"
 }
 resource "datarobot_use_case" "test_new_text_generation" {
-	name = "test new custom model text generation"
+	name = "test new custom model text generation %s"
 }
 
 resource "datarobot_custom_model" "test_text_generation" {
@@ -1724,12 +1757,12 @@ resource "datarobot_custom_model" "test_text_generation" {
 	target_type         = "TextGeneration"
 	target_name         = "%s"
 	language 			= "%s"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	is_proxy 			= true
 	%s
 	%s
 }
-`, resourceBlock, name, targetName, language, useCaseIDsStr, customModelBlock)
+`, resourceBlock, nameSalt, nameSalt, name, targetName, language, useCaseIDsStr, customModelBlock)
 }
 
 func mcpServerCustomModelResourceConfig(
@@ -1747,10 +1780,10 @@ func mcpServerCustomModelResourceConfig(
 	return fmt.Sprintf(`
 %s
 resource "datarobot_use_case" "test_mcp_server" {
-	name = "test custom model mcp server"
+	name = "test custom model mcp server %s"
 }
 resource "datarobot_use_case" "test_new_mcp_server" {
-	name = "test new custom model mcp server"
+	name = "test new custom model mcp server %s"
 }
 
 resource "datarobot_custom_model" "test_mcp_server" {
@@ -1758,12 +1791,12 @@ resource "datarobot_custom_model" "test_mcp_server" {
 	target_type         = "MCP"
 	target_name         = "%s"
 	language 			= "%s"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	is_proxy 			= true
 	%s
 	%s
 }
-`, resourceBlock, name, targetName, language, useCaseIDsStr, customModelBlock)
+`, resourceBlock, nameSalt, nameSalt, name, targetName, language, useCaseIDsStr, customModelBlock)
 }
 
 func basicCustomModelResourceConfig(
@@ -1779,7 +1812,7 @@ resource "datarobot_custom_model" "test_%s" {
 	name        		  							  = "%s"
 	target_type           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 							  = "65f9b27eab986d30d4c64268"
+	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
 	%s
 }
 `, resourceBlock, strings.ToLower(targetType), name, targetType, language, customModelBlock)
@@ -1788,12 +1821,12 @@ resource "datarobot_custom_model" "test_%s" {
 func remoteRepositoryResource(resourceName string) (string, string) {
 	resourceBlock := fmt.Sprintf(`
 resource "datarobot_remote_repository" "%s" {
-	name        = "Test Custom Model from Remote Repository"
+	name        = "Test Custom Model from Remote Repository %s"
 	description = "test"
 	location    = "https://github.com/datarobot-community/custom-models"
 	source_type = "github"
 }
-		`, resourceName)
+		`, resourceName, nameSalt)
 
 	customModelBlock := fmt.Sprintf(`
 	source_remote_repositories = [
@@ -1893,7 +1926,7 @@ resource "datarobot_custom_model" "test_with_tags" {
 	name        		  							  = "%s"
 	target_type           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 							  = "65f9b27eab986d30d4c64268"
+	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
 	%s
 
 	tags = [

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -1379,7 +1379,7 @@ resource "datarobot_custom_model" "test_from_llm_blueprint" {
 	name = "%s"
 	description = "%s"
 	source_llm_blueprint_id = "${datarobot_llm_blueprint.test_custom_model.id}"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	runtime_parameter_values = [
 	  {
 		  key="OPENAI_API_BASE",
@@ -1596,7 +1596,7 @@ func customModelWithRuntimeParamsConfig(value string) string {
 		name        		     = "with runtime params"
 		target_type              = "TextGeneration"
 		target_name              = "target"
-		base_environment_id      = "` + testGenAIBaseEnvID + `"
+		base_environment_id      = "`+testGenAIBaseEnvID+`"
 		folder_path 			 = "custom_model_with_runtime_params"
 		runtime_parameter_values = [
 			{
@@ -1659,7 +1659,7 @@ resource "datarobot_custom_model" "test_binary" {
 	positive_class_label  = "%s"
 	negative_class_label  = "%s"
 	prediction_threshold  = %f
-	base_environment_id   = "` + testGenAIBaseEnvID + `"
+	base_environment_id   = "`+testGenAIBaseEnvID+`"
 	%s
 	%s
 	%s
@@ -1693,7 +1693,7 @@ resource "datarobot_custom_model" "test_multiclass" {
 	target_name           							  = "%s"
 	language 			  							  = "%s"
 	class_labels  		  							  = [%s]
-	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
+	base_environment_id 							  = "`+testGenAIBaseEnvID+`"
 	is_proxy 										  = true
 	%s
 	%s
@@ -1724,7 +1724,7 @@ resource "datarobot_custom_model" "test_regression" {
 	target_type           							  = "Regression"
 	target_name           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 					  		  = "` + testGenAIBaseEnvID + `"
+	base_environment_id 					  		  = "`+testGenAIBaseEnvID+`"
 	%s
 	%s
 }
@@ -1757,7 +1757,7 @@ resource "datarobot_custom_model" "test_text_generation" {
 	target_type         = "TextGeneration"
 	target_name         = "%s"
 	language 			= "%s"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	is_proxy 			= true
 	%s
 	%s
@@ -1791,7 +1791,7 @@ resource "datarobot_custom_model" "test_mcp_server" {
 	target_type         = "MCP"
 	target_name         = "%s"
 	language 			= "%s"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	is_proxy 			= true
 	%s
 	%s
@@ -1812,7 +1812,7 @@ resource "datarobot_custom_model" "test_%s" {
 	name        		  							  = "%s"
 	target_type           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
+	base_environment_id 							  = "`+testGenAIBaseEnvID+`"
 	%s
 }
 `, resourceBlock, strings.ToLower(targetType), name, targetType, language, customModelBlock)
@@ -1926,7 +1926,7 @@ resource "datarobot_custom_model" "test_with_tags" {
 	name        		  							  = "%s"
 	target_type           							  = "%s"
 	language 			  							  = "%s"
-	base_environment_id 							  = "` + testGenAIBaseEnvID + `"
+	base_environment_id 							  = "`+testGenAIBaseEnvID+`"
 	%s
 
 	tags = [

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/datarobot-community/terraform-provider-datarobot/internal/client"
@@ -610,10 +611,10 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 
 	err = waitForTaskStatusToComplete(ctx, r.provider.service, statusID)
 	if err != nil {
-		traceAPICall("DeleteDeployment")
-		_ = r.provider.service.DeleteDeployment(ctx, createResp.ID)
-		resp.Diagnostics.AddError("Deployment creation failed", err.Error())
-		return
+		tflog.Warn(ctx, "Task status polling failed, checking if deployment is ready anyway", map[string]interface{}{
+			"status_id": statusID,
+			"error":     err.Error(),
+		})
 	}
 
 	deployment, err := r.waitForDeploymentToBeReady(ctx, createResp.ID)
@@ -787,8 +788,10 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		// model replacement is an async operation, separate from waiting for the deployment to be ready
 		err = waitForTaskStatusToComplete(ctx, r.provider.service, statusId)
 		if err != nil {
-			resp.Diagnostics.AddError("Deployment model replacement task not completed", err.Error())
-			return
+			tflog.Warn(ctx, "Model replacement task status polling failed, checking if deployment is ready anyway", map[string]interface{}{
+				"status_id": statusId,
+				"error":     err.Error(),
+			})
 		}
 
 		_, err = r.waitForDeploymentToBeReady(ctx, id)
@@ -971,6 +974,9 @@ func (r *DeploymentResource) waitForDeploymentToBeReady(ctx context.Context, id 
 func (r *DeploymentResource) waitForDeploymentStatus(ctx context.Context, id string, status string) (*client.Deployment, error) {
 	expBackoff := getExponentialBackoff()
 
+	startTime := time.Now()
+	lastStatus := ""
+
 	operation := func() error {
 		deployment, err := r.provider.service.GetDeployment(ctx, id)
 		if err != nil {
@@ -981,11 +987,9 @@ func (r *DeploymentResource) waitForDeploymentStatus(ctx context.Context, id str
 			return nil
 		} else if strings.Contains(deployment.Status, "error") {
 			return backoff.Permanent(errors.New("deployment has errored"))
-		} else if deployment.Status == "inactive" && status == "active" {
-			// Don't keep retrying if the deployment is stable in inactive state;
-			// it won't become active on its own.
-			return backoff.Permanent(fmt.Errorf("deployment is inactive but expected active"))
 		}
+
+		lastStatus = deployment.Status
 
 		return errors.New("deployment is not ready")
 	}
@@ -993,7 +997,7 @@ func (r *DeploymentResource) waitForDeploymentStatus(ctx context.Context, id str
 	// Retry the operation using the backoff strategy
 	err := backoff.Retry(operation, expBackoff)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w (last status: %s, elapsed: %s)", err, lastStatus, time.Since(startTime).Round(time.Second))
 	}
 
 	traceAPICall("GetDeployment")

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -734,9 +734,10 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	_, err = r.waitForDeploymentToBeReady(ctx, id)
-	if err != nil {
-		resp.Diagnostics.AddError("Deployment not ready", err.Error())
+	// Ensure the deployment is active before any updates.
+	// If the deployment was deactivated externally, activate it instead of hanging.
+	if err = r.ensureDeploymentActive(ctx, id); err != nil {
+		resp.Diagnostics.AddError("Error ensuring Deployment is active", err.Error())
 		return
 	}
 
@@ -749,6 +750,13 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	if plan.RegisteredModelVersionID != state.RegisteredModelVersionID {
+		// Ensure the deployment is active before model replacement,
+		// otherwise the replacement may hang or fail.
+		if err = r.ensureDeploymentActive(ctx, id); err != nil {
+			resp.Diagnostics.AddError("Error activating Deployment for model replacement", err.Error())
+			return
+		}
+
 		traceAPICall("ValidateDeploymentModelReplacement")
 		validateModelReplacementResp, err := r.provider.service.ValidateDeploymentModelReplacement(ctx, id, &client.ValidateDeployemntModelReplacementRequest{
 			ModelPackageID: plan.RegisteredModelVersionID.ValueString(),
@@ -973,6 +981,10 @@ func (r *DeploymentResource) waitForDeploymentStatus(ctx context.Context, id str
 			return nil
 		} else if strings.Contains(deployment.Status, "error") {
 			return backoff.Permanent(errors.New("deployment has errored"))
+		} else if deployment.Status == "inactive" && status == "active" {
+			// Don't keep retrying if the deployment is stable in inactive state;
+			// it won't become active on its own.
+			return backoff.Permanent(fmt.Errorf("deployment is inactive but expected active"))
 		}
 
 		return errors.New("deployment is not ready")
@@ -1369,4 +1381,23 @@ func (r *DeploymentResource) activateDeployment(ctx context.Context, id string) 
 	}
 
 	return
+}
+
+// ensureDeploymentActive checks if the deployment is active and activates it if not.
+func (r *DeploymentResource) ensureDeploymentActive(ctx context.Context, id string) error {
+	traceAPICall("GetDeployment")
+	deployment, err := r.provider.service.GetDeployment(ctx, id)
+	if err != nil {
+		return fmt.Errorf("Error getting deployment status: %w", err)
+	}
+
+	if deployment.Status == "active" {
+		return nil
+	}
+
+	if strings.Contains(deployment.Status, "error") {
+		return fmt.Errorf("deployment is in error state: %s", deployment.Status)
+	}
+
+	return r.activateDeployment(ctx, id)
 }

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -740,6 +740,14 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Update runtime parameters before model replacement because
+	// PUT /runtimeParameters/ returns 500 immediately after model replacement.
+	err = r.updateDeploymentRuntimeParameters(ctx, id, plan, state)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating Deployment runtime parameters", err.Error())
+		return
+	}
+
 	if plan.RegisteredModelVersionID != state.RegisteredModelVersionID {
 		traceAPICall("ValidateDeploymentModelReplacement")
 		validateModelReplacementResp, err := r.provider.service.ValidateDeploymentModelReplacement(ctx, id, &client.ValidateDeployemntModelReplacementRequest{
@@ -818,12 +826,6 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	err = r.updateDeploymentSettings(ctx, id, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating Deployment settings", err.Error())
-		return
-	}
-
-	err = r.updateDeploymentRuntimeParameters(ctx, id, plan, state)
-	if err != nil {
-		resp.Diagnostics.AddError("Error updating Deployment runtime parameters", err.Error())
 		return
 	}
 

--- a/pkg/provider/deployment_resource_test.go
+++ b/pkg/provider/deployment_resource_test.go
@@ -449,7 +449,7 @@ resource "datarobot_custom_model" "test_deployment" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "%s"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "deployment"
 }
 resource "datarobot_registered_model" "test_deployment" {

--- a/pkg/provider/deployment_resource_test.go
+++ b/pkg/provider/deployment_resource_test.go
@@ -439,17 +439,17 @@ func deploymentResourceConfig(
 
 	return fmt.Sprintf(`
 resource "datarobot_use_case" "test_deployment" {
-	name = "test deployment"
+	name = "test deployment %s"
 }
 resource "datarobot_use_case" "test_new_deployment" {
-	name = "test new deployment"
+	name = "test new deployment %s"
 }
 resource "datarobot_custom_model" "test_deployment" {
-	name = "test deployment"
+	name = "test deployment %s"
 	description = "test"
 	target_type = "Binary"
 	target_name = "%s"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "deployment"
 }
 resource "datarobot_registered_model" "test_deployment" {
@@ -458,7 +458,7 @@ resource "datarobot_registered_model" "test_deployment" {
 	custom_model_version_id = "${datarobot_custom_model.test_deployment.version_id}"
 }
 resource "datarobot_prediction_environment" "test_deployment" {
-	name = "test deployment"
+	name = "test deployment %s"
 	description = "test"
 	platform = "datarobotServerless"
 }
@@ -471,7 +471,7 @@ resource "datarobot_deployment" "test" {
 	%s
 	%s
 }
-`, customModelTargetName, nameSalt, label, importance, useCaseIDsStr, deploymentSettings, runtimeParameterValuesStr)
+`, nameSalt, nameSalt, nameSalt, customModelTargetName, nameSalt, nameSalt, label, importance, useCaseIDsStr, deploymentSettings, runtimeParameterValuesStr)
 }
 
 func checkDeploymentResourceExists() resource.TestCheckFunc {

--- a/pkg/provider/deployment_retraining_policy_resource_test.go
+++ b/pkg/provider/deployment_retraining_policy_resource_test.go
@@ -172,14 +172,14 @@ func deploymentRetrainingPolicyResourceConfig(
 resource "datarobot_custom_job" "deployment_retraining_policy" {
 	name = "%s"
 	job_type = "retraining"
-	environment_id = "` + testCustomJobEnvID + `"
+	environment_id = "`+testCustomJobEnvID+`"
 	folder_path = "retraining_policy_custom_job"
 }
 resource "datarobot_custom_model" "deployment_retraining_policy" {
     name = "test deployment retraining policy %s"
     target_type = "Binary"
     target_name = "t"
-    base_environment_id = "` + testGenAIBaseEnvID + `"
+    base_environment_id = "`+testGenAIBaseEnvID+`"
     folder_path = "retraining_policy"
 }
 resource "datarobot_registered_model" "deployment_retraining_policy" {

--- a/pkg/provider/deployment_retraining_policy_resource_test.go
+++ b/pkg/provider/deployment_retraining_policy_resource_test.go
@@ -172,14 +172,14 @@ func deploymentRetrainingPolicyResourceConfig(
 resource "datarobot_custom_job" "deployment_retraining_policy" {
 	name = "%s"
 	job_type = "retraining"
-	environment_id = "66d07fae0513a1edf18595bb"
+	environment_id = "` + testCustomJobEnvID + `"
 	folder_path = "retraining_policy_custom_job"
 }
 resource "datarobot_custom_model" "deployment_retraining_policy" {
-    name = "test deployment retraining policy"
+    name = "test deployment retraining policy %s"
     target_type = "Binary"
     target_name = "t"
-    base_environment_id = "65f9b27eab986d30d4c64268"
+    base_environment_id = "` + testGenAIBaseEnvID + `"
     folder_path = "retraining_policy"
 }
 resource "datarobot_registered_model" "deployment_retraining_policy" {
@@ -187,7 +187,7 @@ resource "datarobot_registered_model" "deployment_retraining_policy" {
     custom_model_version_id = "${datarobot_custom_model.deployment_retraining_policy.version_id}"
 }
 resource "datarobot_prediction_environment" "deployment_retraining_policy" {
-    name = "test deployment retraining policy"
+    name = "test deployment retraining policy %s"
     platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "deployment_retraining_policy" {
@@ -197,7 +197,7 @@ resource "datarobot_deployment" "deployment_retraining_policy" {
     registered_model_version_id = datarobot_registered_model.deployment_retraining_policy.version_id
 }
 resource "datarobot_use_case" "deployment_retraining_policy" {
-	name = "sample salt use case"
+	name = "sample retraining policy use case %s"
 	description = "sample retraining policy use case"
 }
 resource "datarobot_deployment_retraining_policy" "test" {
@@ -220,7 +220,7 @@ resource "datarobot_deployment_retraining_policy" "test" {
 	}
 	use_case_id = datarobot_use_case.deployment_retraining_policy.id
 }
-`, name, name, name, name, description, action, modelSelectionStrategy)
+`, name, nameSalt, name, nameSalt, name, nameSalt, name, description, action, modelSelectionStrategy)
 }
 
 func checkDeploymentRetrainingPolicyResourceExists() resource.TestCheckFunc {

--- a/pkg/provider/llm_blueprint_deployment_test.go
+++ b/pkg/provider/llm_blueprint_deployment_test.go
@@ -84,7 +84,7 @@ resource "datarobot_custom_model" "llm_test" {
 	target_type = "TextGeneration"
 	target_name = "resultText"
 	source_llm_blueprint_id = datarobot_llm_blueprint.llm_test.id
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 }
 
 resource "datarobot_registered_model" "llm_test" {

--- a/pkg/provider/llm_blueprint_deployment_test.go
+++ b/pkg/provider/llm_blueprint_deployment_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/compare"
@@ -59,46 +60,46 @@ func TestAccLLMBlueprintDeployment(t *testing.T) {
 }
 
 func llmBlueprintDeploymentConfig(llmID string, systemPrompt string) string {
-	return `
+	return fmt.Sprintf(`
 resource "datarobot_use_case" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 }
 
 resource "datarobot_playground" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 	use_case_id = datarobot_use_case.llm_test.id
 }
 
 resource "datarobot_llm_blueprint" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 	playground_id = datarobot_playground.llm_test.id
-	llm_id = "` + llmID + `"
+	llm_id = "%s"
 	llm_settings = {
-		system_prompt = "` + systemPrompt + `"
+		system_prompt = "%s"
 	}
 }
 
 resource "datarobot_custom_model" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 	target_type = "TextGeneration"
 	target_name = "resultText"
 	source_llm_blueprint_id = datarobot_llm_blueprint.llm_test.id
-	base_environment_id = "67ab469cecdca772287de644"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 }
 
 resource "datarobot_registered_model" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 	custom_model_version_id = datarobot_custom_model.llm_test.version_id
 	use_case_ids = [datarobot_use_case.llm_test.id]
 }
 
 resource "datarobot_prediction_environment" "llm_test" {
-	name = "llm blueprint deployment test"
+	name = "llm blueprint deployment test %s"
 	platform = "datarobotServerless"
 }
 
 resource "datarobot_deployment" "llm_test" {
-	label = "llm blueprint deployment test"
+	label = "llm blueprint deployment test %s"
 	registered_model_version_id = datarobot_registered_model.llm_test.version_id
 	prediction_environment_id = datarobot_prediction_environment.llm_test.id
 	predictions_settings = {
@@ -106,5 +107,5 @@ resource "datarobot_deployment" "llm_test" {
 		max_computes = 2
 	}
 }
-`
+`, nameSalt, nameSalt, nameSalt, llmID, systemPrompt, nameSalt, nameSalt, nameSalt, nameSalt)
 }

--- a/pkg/provider/notification_channel_resource_test.go
+++ b/pkg/provider/notification_channel_resource_test.go
@@ -53,7 +53,7 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 	newChannelType := "DataRobotGroup"
 
 	drEntityID := globalTestCfg.UserID
-	newDrEntityID := "6036d237608973bf082aba1e"
+	newDrEntityID := testDRGroupEntityID
 
 	drEntityName := globalTestCfg.UserName
 	newDrEntityName := "test_group"
@@ -135,11 +135,11 @@ func notificationChannelResourceConfig(
 ) string {
 	return fmt.Sprintf(`
 resource "datarobot_custom_model" "test_notification_channel" {
-	name = "test deployment"
+	name = "test notification channel %s"
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "notification_channel"
 }
 resource "datarobot_registered_model" "test_notification_channel" {
@@ -147,12 +147,12 @@ resource "datarobot_registered_model" "test_notification_channel" {
 	custom_model_version_id = "${datarobot_custom_model.test_notification_channel.version_id}"
 }
 resource "datarobot_prediction_environment" "test_notification_channel" {
-	name = "test notification channel"
+	name = "test notification channel %s"
 	description = "test"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "test_notification_channel" {
-	label = "test notification channel"
+	label = "test notification channel %s"
 	importance = "LOW"
 	prediction_environment_id = datarobot_prediction_environment.test_notification_channel.id
 	registered_model_version_id = datarobot_registered_model.test_notification_channel.version_id
@@ -171,6 +171,9 @@ resource "datarobot_notification_channel" "test" {
 	}]
 }
 `, nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
 		name,
 		channelType,
 		drEntityID,

--- a/pkg/provider/notification_channel_resource_test.go
+++ b/pkg/provider/notification_channel_resource_test.go
@@ -139,7 +139,7 @@ resource "datarobot_custom_model" "test_notification_channel" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "notification_channel"
 }
 resource "datarobot_registered_model" "test_notification_channel" {

--- a/pkg/provider/notification_policy_resource_test.go
+++ b/pkg/provider/notification_policy_resource_test.go
@@ -126,7 +126,7 @@ resource "datarobot_custom_model" "test_notification_policy" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "notification_policy"
 }
 resource "datarobot_registered_model" "test_notification_policy" {

--- a/pkg/provider/notification_policy_resource_test.go
+++ b/pkg/provider/notification_policy_resource_test.go
@@ -122,11 +122,11 @@ func notificationPolicyResourceConfig(
 ) string {
 	return fmt.Sprintf(`
 resource "datarobot_custom_model" "test_notification_policy" {
-	name = "test deployment"
+	name = "test notification policy %s"
 	description = "test"
 	target_type = "Binary"
 	target_name = "target"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "notification_policy"
 }
 resource "datarobot_registered_model" "test_notification_policy" {
@@ -134,18 +134,18 @@ resource "datarobot_registered_model" "test_notification_policy" {
 	custom_model_version_id = "${datarobot_custom_model.test_notification_policy.version_id}"
 }
 resource "datarobot_prediction_environment" "test_notification_policy" {
-	name = "test notification policy"
+	name = "test notification policy %s"
 	description = "test"
 	platform = "datarobotServerless"
 }
 resource "datarobot_deployment" "test_notification_policy" {
-	label = "test notification policy"
+	label = "test notification policy %s"
 	importance = "LOW"
 	prediction_environment_id = datarobot_prediction_environment.test_notification_policy.id
 	registered_model_version_id = datarobot_registered_model.test_notification_policy.version_id
 }
 resource "datarobot_notification_channel" "test_notification_policy" {
-	name = "test notification policy"
+	name = "test notification policy %s"
 	channel_type = "DataRobotUser"
 	related_entity_id = datarobot_deployment.test_notification_policy.id
 	related_entity_type = "deployment"
@@ -163,6 +163,10 @@ resource "datarobot_notification_policy" "test" {
 	event_group         = "%s"
 }
 `, nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
+		nameSalt,
 		globalTestCfg.UserID,
 		globalTestCfg.UserName,
 		name,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
@@ -79,5 +80,28 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 func testAccPreCheck(t *testing.T) {
 	if globalTestCfg.ApiKey == "" {
 		t.Fatalf("%s must be set for acceptance testing", DataRobotApiKeyEnvVar)
+	}
+}
+
+func testAccFeatureFlagPreCheck(t *testing.T, flagName string) {
+	t.Helper()
+	testAccPreCheck(t)
+	svc := client.NewService(cl)
+
+	userInfo, infoErr := svc.GetUserInfo(context.Background())
+	if infoErr != nil {
+		t.Logf("GetUserInfo error: %v", infoErr)
+	} else {
+		t.Logf("permissions: %v", userInfo.Permissions)
+	}
+
+	enabled, err := svc.IsFeatureFlagEnabled(context.Background(), flagName)
+	if err != nil {
+		t.Logf("Feature flag check error for %q: %v", flagName, err)
+		t.Skipf("Skipping test: unable to check feature flag %q: %v", flagName, err)
+	}
+	t.Logf("Feature flag %q = %v", flagName, enabled)
+	if !enabled {
+		t.Skipf("Skipping test: feature flag %q is not enabled on this server", flagName)
 	}
 }

--- a/pkg/provider/qa_application_resource_test.go
+++ b/pkg/provider/qa_application_resource_test.go
@@ -110,6 +110,13 @@ resource "datarobot_deployment" "test_qa_application" {
 	label = "test Q&A application %s"
 	prediction_environment_id = datarobot_prediction_environment.test_qa_application.id
 	registered_model_version_id = datarobot_registered_model.test_qa_application.version_id
+	runtime_parameter_values = [
+		{
+			key = "GUARD_CONFIG_PLACEHOLDER"
+			type = "string"
+			value = "{\"max_tokens\": 100, \"temperature\": 0.7}"
+		},
+	]
 }
 resource "datarobot_qa_application" "test" {
 	name = "%s"

--- a/pkg/provider/qa_application_resource_test.go
+++ b/pkg/provider/qa_application_resource_test.go
@@ -93,7 +93,7 @@ resource "datarobot_custom_model" "test_qa_application" {
 	name = "test qa application %s"
 	target_type = "TextGeneration"
 	target_name = "target"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "qa_application"
 }
 resource "datarobot_registered_model" "test_qa_application" {

--- a/pkg/provider/qa_application_resource_test.go
+++ b/pkg/provider/qa_application_resource_test.go
@@ -43,6 +43,13 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 		t.Fatal(err)
 	}
 
+	metadataContents := `name: test-model
+runtimeParameterDefinitions: []
+`
+	if err := os.WriteFile(folderPath+"/model-metadata.yaml", []byte(metadataContents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -79,10 +86,10 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 func qaApplicationResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "datarobot_custom_model" "test_qa_application" {
-	name = "test qa application"
+	name = "test qa application %s"
 	target_type = "TextGeneration"
 	target_name = "target"
-	base_environment_id = "65f9b27eab986d30d4c64268"
+	base_environment_id = "` + testGenAIBaseEnvID + `"
 	folder_path = "qa_application"
 }
 resource "datarobot_registered_model" "test_qa_application" {
@@ -91,12 +98,12 @@ resource "datarobot_registered_model" "test_qa_application" {
 	custom_model_version_id = "${datarobot_custom_model.test_qa_application.version_id}"
 }
 resource "datarobot_prediction_environment" "test_qa_application" {
-	name = "test Q&A application"
+	name = "test Q&A application %s"
 	description = "test"
 	platform = "aws"
 }
 resource "datarobot_deployment" "test_qa_application" {
-	label = "test Q&A application"
+	label = "test Q&A application %s"
 	prediction_environment_id = datarobot_prediction_environment.test_qa_application.id
 	registered_model_version_id = datarobot_registered_model.test_qa_application.version_id
 }
@@ -104,7 +111,7 @@ resource "datarobot_qa_application" "test" {
 	name = "%s"
 	deployment_id = datarobot_deployment.test_qa_application.id
   }
-`, nameSalt, name)
+`, nameSalt, nameSalt, nameSalt, nameSalt, name)
 }
 
 func checkQAApplicationResourceExists(resourceName string) resource.TestCheckFunc {

--- a/pkg/provider/qa_application_resource_test.go
+++ b/pkg/provider/qa_application_resource_test.go
@@ -44,7 +44,11 @@ def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFr
 	}
 
 	metadataContents := `name: test-model
-runtimeParameterDefinitions: []
+runtimeParameterDefinitions:
+  - fieldName: GUARD_CONFIG_PLACEHOLDER
+    type: string
+    description: Placeholder for guard configuration schema
+    defaultValue: null
 `
 	if err := os.WriteFile(folderPath+"/model-metadata.yaml", []byte(metadataContents), 0644); err != nil {
 		t.Fatal(err)

--- a/pkg/provider/registered_model_from_leaderboard_resource_test.go
+++ b/pkg/provider/registered_model_from_leaderboard_resource_test.go
@@ -19,11 +19,11 @@ import (
 func TestAccRegisteredModelFromLeaderboardResource(t *testing.T) {
 	t.Parallel()
 	t.Skip("Skipping TestAccRegisteredModelFromLeaderboardResource until we can get a model id that works in all environments")
-	modelID := "673b722dfd279fd86944d088"
-	modelID2 := "673b6fd8e060b90658aebe66"
+	modelID := testLeaderboardModelID
+	modelID2 := testLeaderboardModelID2
 	if strings.Contains(globalTestCfg.Endpoint, "staging") {
-		modelID = "673b75ec97f1021bbfb61d3b"
-		modelID2 = "673b75ec97f1021bbfb61d34"
+		modelID = testLeaderboardStagingModelID
+		modelID2 = testLeaderboardStagingModelID2
 	} else if strings.Contains(globalTestCfg.Endpoint, "dr-app-charts") {
 		t.Skip("Skipping registered model from leaderboard test for environment")
 	}

--- a/pkg/provider/registered_model_resource.go
+++ b/pkg/provider/registered_model_resource.go
@@ -374,6 +374,42 @@ func (r *RegisteredModelResource) Update(ctx context.Context, req resource.Updat
 		}
 		plan.VersionID = types.StringValue(registeredModelVersion.ID)
 		plan.VersionName = types.StringValue(registeredModelVersion.Name)
+	} else if !plan.Tags.Equal(state.Tags) {
+		// Tags changed but custom model version didn't change - must create a new registered model
+		// version (same custom model version) because the PATCH endpoint does not support tags.
+		traceAPICall("GetRegisteredModel")
+		registeredModel, err := r.provider.service.GetRegisteredModel(ctx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error getting Registered Model info", err.Error())
+			return
+		}
+
+		createRegisteredModelRequest := &client.CreateRegisteredModelFromCustomModelRequest{
+			RegisteredModelID:    registeredModel.ID,
+			CustomModelVersionID: plan.CustomModelVersionId.ValueString(),
+			Name:                 versionName,
+			Tags:                 convertSetTagsToClientTags(plan.Tags),
+		}
+
+		if err := r.populatePromptFromCustomModel(ctx, createRegisteredModelRequest, plan.CustomModelVersionId.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Error populating prompt from Custom Model", err.Error())
+			return
+		}
+
+		traceAPICall("CreateRegisteredModelVersion")
+		registeredModelVersion, err := r.provider.service.CreateRegisteredModelFromCustomModelVersion(ctx, createRegisteredModelRequest)
+		if err != nil {
+			resp.Diagnostics.AddError("Error creating Registered Model Version", err.Error())
+			return
+		}
+
+		err = waitForRegisteredModelVersionToBeReady(ctx, r.provider.service, registeredModelVersion.RegisteredModelID, registeredModelVersion.ID)
+		if err != nil {
+			resp.Diagnostics.AddError("Registered model version not ready", err.Error())
+			return
+		}
+		plan.VersionID = types.StringValue(registeredModelVersion.ID)
+		plan.VersionName = types.StringValue(registeredModelVersion.Name)
 	}
 
 	// check if we created a new version

--- a/pkg/provider/registered_model_resource.go
+++ b/pkg/provider/registered_model_resource.go
@@ -340,72 +340,11 @@ func (r *RegisteredModelResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
-	if state.CustomModelVersionId.ValueString() != plan.CustomModelVersionId.ValueString() {
-		traceAPICall("GetRegisteredModel")
-		registeredModel, err := r.provider.service.GetRegisteredModel(ctx, plan.ID.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("Error getting Registered Model info", err.Error())
-			return
-		}
-
-		createRegisteredModelRequest := &client.CreateRegisteredModelFromCustomModelRequest{
-			RegisteredModelID:    registeredModel.ID,
-			CustomModelVersionID: plan.CustomModelVersionId.ValueString(),
-			Name:                 versionName,
-			Tags:                 convertSetTagsToClientTags(plan.Tags),
-		}
-
-		if err := r.populatePromptFromCustomModel(ctx, createRegisteredModelRequest, plan.CustomModelVersionId.ValueString()); err != nil {
-			resp.Diagnostics.AddError("Error populating prompt from Custom Model", err.Error())
-			return
-		}
-
-		traceAPICall("CreateRegisteredModelVersion")
-		registeredModelVersion, err := r.provider.service.CreateRegisteredModelFromCustomModelVersion(ctx, createRegisteredModelRequest)
+	if state.CustomModelVersionId.ValueString() != plan.CustomModelVersionId.ValueString() ||
+		!plan.Tags.Equal(state.Tags) {
+		registeredModelVersion, err := r.createNewRegisteredModelVersion(ctx, plan.ID.ValueString(), plan.CustomModelVersionId.ValueString(), versionName, plan.Tags)
 		if err != nil {
 			resp.Diagnostics.AddError("Error creating Registered Model Version", err.Error())
-			return
-		}
-
-		err = waitForRegisteredModelVersionToBeReady(ctx, r.provider.service, registeredModelVersion.RegisteredModelID, registeredModelVersion.ID)
-		if err != nil {
-			resp.Diagnostics.AddError("Registered model version not ready", err.Error())
-			return
-		}
-		plan.VersionID = types.StringValue(registeredModelVersion.ID)
-		plan.VersionName = types.StringValue(registeredModelVersion.Name)
-	} else if !plan.Tags.Equal(state.Tags) {
-		// Tags changed but custom model version didn't change - must create a new registered model
-		// version (same custom model version) because the PATCH endpoint does not support tags.
-		traceAPICall("GetRegisteredModel")
-		registeredModel, err := r.provider.service.GetRegisteredModel(ctx, plan.ID.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("Error getting Registered Model info", err.Error())
-			return
-		}
-
-		createRegisteredModelRequest := &client.CreateRegisteredModelFromCustomModelRequest{
-			RegisteredModelID:    registeredModel.ID,
-			CustomModelVersionID: plan.CustomModelVersionId.ValueString(),
-			Name:                 versionName,
-			Tags:                 convertSetTagsToClientTags(plan.Tags),
-		}
-
-		if err := r.populatePromptFromCustomModel(ctx, createRegisteredModelRequest, plan.CustomModelVersionId.ValueString()); err != nil {
-			resp.Diagnostics.AddError("Error populating prompt from Custom Model", err.Error())
-			return
-		}
-
-		traceAPICall("CreateRegisteredModelVersion")
-		registeredModelVersion, err := r.provider.service.CreateRegisteredModelFromCustomModelVersion(ctx, createRegisteredModelRequest)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating Registered Model Version", err.Error())
-			return
-		}
-
-		err = waitForRegisteredModelVersionToBeReady(ctx, r.provider.service, registeredModelVersion.RegisteredModelID, registeredModelVersion.ID)
-		if err != nil {
-			resp.Diagnostics.AddError("Registered model version not ready", err.Error())
 			return
 		}
 		plan.VersionID = types.StringValue(registeredModelVersion.ID)
@@ -494,6 +433,38 @@ func (r *RegisteredModelResource) findCustomModel(ctx context.Context, customMod
 	}
 
 	return client.CustomModel{}, fmt.Errorf("custom model with version ID %s not found", customModelVersionID)
+}
+
+func (r *RegisteredModelResource) createNewRegisteredModelVersion(ctx context.Context, registeredModelID, customModelVersionID, versionName string, tags types.Set) (*client.RegisteredModelVersion, error) {
+	traceAPICall("GetRegisteredModel")
+	registeredModel, err := r.provider.service.GetRegisteredModel(ctx, registeredModelID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting Registered Model info: %w", err)
+	}
+
+	createRegisteredModelRequest := &client.CreateRegisteredModelFromCustomModelRequest{
+		RegisteredModelID:    registeredModel.ID,
+		CustomModelVersionID: customModelVersionID,
+		Name:                 versionName,
+		Tags:                 convertSetTagsToClientTags(tags),
+	}
+
+	if err := r.populatePromptFromCustomModel(ctx, createRegisteredModelRequest, customModelVersionID); err != nil {
+		return nil, fmt.Errorf("error populating prompt from Custom Model: %w", err)
+	}
+
+	traceAPICall("CreateRegisteredModelVersion")
+	registeredModelVersion, err := r.provider.service.CreateRegisteredModelFromCustomModelVersion(ctx, createRegisteredModelRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Registered Model Version: %w", err)
+	}
+
+	err = waitForRegisteredModelVersionToBeReady(ctx, r.provider.service, registeredModelVersion.RegisteredModelID, registeredModelVersion.ID)
+	if err != nil {
+		return nil, fmt.Errorf("registered model version not ready: %w", err)
+	}
+
+	return registeredModelVersion, nil
 }
 
 func (r *RegisteredModelResource) populatePromptFromCustomModel(ctx context.Context, request *client.CreateRegisteredModelFromCustomModelRequest, customModelVersionID string) error {

--- a/pkg/provider/registered_model_resource_test.go
+++ b/pkg/provider/registered_model_resource_test.go
@@ -619,7 +619,7 @@ resource "datarobot_custom_model" "test_registered_model" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "my_label"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "registered_model_test"
 	guard_configurations = [
 		{
@@ -654,7 +654,7 @@ resource "datarobot_custom_model" "test_registered_model" {
 	description = "test"
 	target_type = "Binary"
 	target_name = "my_label"
-	base_environment_id = "` + testGenAIBaseEnvID + `"
+	base_environment_id = "`+testGenAIBaseEnvID+`"
 	folder_path = "registered_model_test"
 	guard_configurations = [
 		{
@@ -722,7 +722,7 @@ func textGenerationRegisteredModelResourceConfig(
 		target_type         	 = "TextGeneration"
 		target_name         	 = "target"
 		language 				 = "python"
-		base_environment_id 	 = "` + testGenAIBaseEnvID + `"
+		base_environment_id 	 = "`+testGenAIBaseEnvID+`"
 		is_proxy 				 = true
 		folder_path 			 = "registered_model_text_generation"
 		%s
@@ -758,7 +758,7 @@ func textGenerationRegisteredModelUpdateResourceConfig(
 		target_type         	 = "TextGeneration"
 		target_name         	 = "target"
 		language 				 = "python"
-		base_environment_id 	 = "` + testGenAIBaseEnvID + `"
+		base_environment_id 	 = "`+testGenAIBaseEnvID+`"
 		is_proxy 				 = true
 		folder_path 			 = "registered_model_text_generation_update"
 		%s

--- a/pkg/provider/registered_model_resource_test.go
+++ b/pkg/provider/registered_model_resource_test.go
@@ -34,6 +34,41 @@ func TestAccRegisteredModelResource(t *testing.T) {
 	useCaseResourceName := "test_registered_model"
 	useCaseResourceName2 := "test_new_registered_model"
 
+	metadataFileName := "model-metadata.yaml"
+	metadataContents := `name: runtime-params
+
+runtimeParameterDefinitions:
+  - fieldName: GUARD_CONFIG_PLACEHOLDER
+    type: string
+    description: Placeholder for guard configuration schema
+    defaultValue: null`
+
+	folderPath := "registered_model_test"
+	os.RemoveAll(folderPath)
+	if err := os.Mkdir(folderPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folderPath)
+
+	modelContents := `from typing import Any, Dict
+import pandas as pd
+
+def load_model(code_dir: str) -> Any:
+	return "dummy"
+
+def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
+	positive_label = kwargs["positive_class_label"]
+	negative_label = kwargs["negative_class_label"]
+	preds = pd.DataFrame([[0.75, 0.25]] * data.shape[0], columns=[positive_label, negative_label])
+	return preds
+`
+	if err := os.WriteFile(folderPath+"/custom.py", []byte(modelContents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(folderPath+"/"+metadataFileName, []byte(metadataContents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -579,27 +614,13 @@ resource "datarobot_use_case" "test_registered_model" {
 resource "datarobot_use_case" "test_new_registered_model" {
 	name = "test new registered model"
 }
-resource "datarobot_remote_repository" "test_registered_model" {
-	name        = "Test Registered Model"
-	description = "test"
-	location    = "https://github.com/datarobot-community/custom-models"
-	source_type = "github"
-	}
 resource "datarobot_custom_model" "test_registered_model" {
 	name = "test registered model"
 	description = "test"
 	target_type = "Binary"
 	target_name = "my_label"
-	base_environment_id = "65f9b27eab986d30d4c64268"
-	source_remote_repositories = [
-		{
-			id = datarobot_remote_repository.test_registered_model.id
-			ref = "master"
-			source_paths = [
-				"custom_inference/python/gan_mnist/custom.py",
-			]
-		},
-	]
+	base_environment_id = "` + testGenAIBaseEnvID + `"
+	folder_path = "registered_model_test"
 	guard_configurations = [
 		{
 			template_name = "Rouge 1"
@@ -628,29 +649,13 @@ func registeredModelResourceConfigWithTags(name, description string, guardName s
 resource "datarobot_use_case" "test_registered_model" {
 	name = "test registered model"
 }
-resource "datarobot_remote_repository" "test_registered_model" {
-	name        = "Test Registered Model"
-	description = "test"
-	location    = "https://github.com/datarobot-community/custom-models"
-	source_type = "github"
-	}
 resource "datarobot_custom_model" "test_registered_model" {
 	name = "test registered model"
 	description = "test"
 	target_type = "Binary"
 	target_name = "my_label"
-	base_environment_id = "65f9b27eab986d30d4c64268"
-	source_remote_repositories = [
-		{
-			id = datarobot_remote_repository.test_registered_model.id
-			ref = "master"
-			source_paths = [
-				"custom_inference/python/gan_mnist/custom.py",
-				"custom_inference/python/gan_mnist/gan_weights.h5",
-			]
-		}
-	]
-
+	base_environment_id = "` + testGenAIBaseEnvID + `"
+	folder_path = "registered_model_test"
 	guard_configurations = [
 		{
 			template_name = "Rouge 1"
@@ -717,7 +722,7 @@ func textGenerationRegisteredModelResourceConfig(
 		target_type         	 = "TextGeneration"
 		target_name         	 = "target"
 		language 				 = "python"
-		base_environment_id 	 = "65f9b27eab986d30d4c64268"
+		base_environment_id 	 = "` + testGenAIBaseEnvID + `"
 		is_proxy 				 = true
 		folder_path 			 = "registered_model_text_generation"
 		%s
@@ -753,7 +758,7 @@ func textGenerationRegisteredModelUpdateResourceConfig(
 		target_type         	 = "TextGeneration"
 		target_name         	 = "target"
 		language 				 = "python"
-		base_environment_id 	 = "65f9b27eab986d30d4c64268"
+		base_environment_id 	 = "` + testGenAIBaseEnvID + `"
 		is_proxy 				 = true
 		folder_path 			 = "registered_model_text_generation_update"
 		%s

--- a/pkg/provider/test_env_config_test.go
+++ b/pkg/provider/test_env_config_test.go
@@ -1,0 +1,124 @@
+package provider
+
+import "os"
+
+// Centralized test environment configuration.
+//
+// All test environment IDs are loaded from environment variables with fallback defaults.
+// The .env file (loaded in provider_test.go init()) is the recommended way to override
+// these values for local development. CI/CD systems can set the env vars directly.
+//
+// To override a value, add it to the .env file at the project root:
+//
+//	DR_TEST_GENAI_BASE_ENV_ID=67ab469cecdca772287de644
+//	DR_TEST_STREAMLIT_BASE_ENV_ID=6542cd582a9d3d51bf4ac71e
+//	DR_TEST_CUSTOM_JOB_ENV_ID=66d07fae0513a1edf18595bb
+//	DR_TEST_APP_SOURCE_BASE_ENV_VERSION_ID=668548c1b8e086572a96fbf5
+//	DR_TEST_CUSTOM_APP_ENV_ID=67987589391fe8fa0a2275b8
+//	DR_TEST_CUSTOM_APP_ENV_ID_2=67987b1a90dbd55389b699c2
+//	DR_TEST_SLACKBOT_TEMPLATE_ID=67126757e7819551baceb22b
+//	DR_TEST_QA_TEMPLATE_ID=670fb324bf9bbb1081114333
+//	DR_TEST_STREAMLIT_TEMPLATE_ID=671267597665e0b33f7acdb7
+//	DR_TEST_FLASK_TEMPLATE_ID=67126750e8342440587acd74
+//	DR_TEST_LEADERBOARD_MODEL_ID=673b722dfd279fd86944d088
+//	DR_TEST_LEADERBOARD_MODEL_ID_2=673b6fd8e060b90658aebe66
+//	DR_TEST_LEADERBOARD_STAGING_MODEL_ID=673b75ec97f1021bbfb61d3b
+//	DR_TEST_LEADERBOARD_STAGING_MODEL_ID_2=673b75ec97f1021bbfb61d34
+//	DR_TEST_DR_GROUP_ENTITY_ID=6036d237608973bf082aba1e
+var (
+	// Base environment IDs
+
+	// testGenAIBaseEnvID is the [GenAI] Python 3.11 base environment.
+	// Used for custom models (Binary, Regression, TextGeneration, MCP, etc.).
+	testGenAIBaseEnvID string
+
+	// testStreamlitBaseEnvID is the [Experimental] Python 3.9 Streamlit base environment.
+	// Used for application sources and custom applications.
+	testStreamlitBaseEnvID string
+
+	// testCustomJobEnvID is the base environment for custom jobs and metric jobs.
+	testCustomJobEnvID string
+
+	// Base environment version IDs
+
+	// testAppSourceBaseEnvVersionID is a specific version of the Streamlit base environment.
+	// Used in application source and application source from template tests.
+	testAppSourceBaseEnvVersionID string
+
+	// Custom application execution environment IDs
+
+	// testCustomAppEnvID is an execution environment for custom applications from environment.
+	testCustomAppEnvID string
+
+	// testCustomAppEnvID2 is a second execution environment for custom applications from environment.
+	testCustomAppEnvID2 string
+
+	// Template IDs
+
+	// testSlackbotTemplateID is the Slackbot application template.
+	testSlackbotTemplateID string
+
+	// testQATemplateID is the Q&A application template.
+	testQATemplateID string
+
+	// testStreamlitTemplateID is the Streamlit application template.
+	testStreamlitTemplateID string
+
+	// testFlaskTemplateID is the Flask application template.
+	testFlaskTemplateID string
+
+	// Leaderboard / registered model IDs
+
+	// testLeaderboardModelID is a model from a project leaderboard (production).
+	testLeaderboardModelID string
+
+	// testLeaderboardModelID2 is a second model from a project leaderboard (production).
+	testLeaderboardModelID2 string
+
+	// testLeaderboardStagingModelID is a model from a project leaderboard (staging).
+	testLeaderboardStagingModelID string
+
+	// testLeaderboardStagingModelID2 is a second model from a project leaderboard (staging).
+	testLeaderboardStagingModelID2 string
+
+	// Other entity IDs
+
+	// testDRGroupEntityID is a DataRobot group entity ID for notification channel tests.
+	testDRGroupEntityID string
+)
+
+func init() {
+	// Base environments
+	testGenAIBaseEnvID = getTestEnvOrDefault("DR_TEST_GENAI_BASE_ENV_ID", "67ab469cecdca772287de644")
+	testStreamlitBaseEnvID = getTestEnvOrDefault("DR_TEST_STREAMLIT_BASE_ENV_ID", "6542cd582a9d3d51bf4ac71e")
+	testCustomJobEnvID = getTestEnvOrDefault("DR_TEST_CUSTOM_JOB_ENV_ID", "66d07fae0513a1edf18595bb")
+
+	// Base environment versions
+	testAppSourceBaseEnvVersionID = getTestEnvOrDefault("DR_TEST_APP_SOURCE_BASE_ENV_VERSION_ID", "668548c1b8e086572a96fbf5")
+
+	// Custom application execution environments
+	testCustomAppEnvID = getTestEnvOrDefault("DR_TEST_CUSTOM_APP_ENV_ID", "67987589391fe8fa0a2275b8")
+	testCustomAppEnvID2 = getTestEnvOrDefault("DR_TEST_CUSTOM_APP_ENV_ID_2", "67987b1a90dbd55389b699c2")
+
+	// Templates
+	testSlackbotTemplateID = getTestEnvOrDefault("DR_TEST_SLACKBOT_TEMPLATE_ID", "67126757e7819551baceb22b")
+	testQATemplateID = getTestEnvOrDefault("DR_TEST_QA_TEMPLATE_ID", "670fb324bf9bbb1081114333")
+	testStreamlitTemplateID = getTestEnvOrDefault("DR_TEST_STREAMLIT_TEMPLATE_ID", "671267597665e0b33f7acdb7")
+	testFlaskTemplateID = getTestEnvOrDefault("DR_TEST_FLASK_TEMPLATE_ID", "67126750e8342440587acd74")
+
+	// Leaderboard models
+	testLeaderboardModelID = getTestEnvOrDefault("DR_TEST_LEADERBOARD_MODEL_ID", "673b722dfd279fd86944d088")
+	testLeaderboardModelID2 = getTestEnvOrDefault("DR_TEST_LEADERBOARD_MODEL_ID_2", "673b6fd8e060b90658aebe66")
+	testLeaderboardStagingModelID = getTestEnvOrDefault("DR_TEST_LEADERBOARD_STAGING_MODEL_ID", "673b75ec97f1021bbfb61d3b")
+	testLeaderboardStagingModelID2 = getTestEnvOrDefault("DR_TEST_LEADERBOARD_STAGING_MODEL_ID_2", "673b75ec97f1021bbfb61d34")
+
+	// Other entities
+	testDRGroupEntityID = getTestEnvOrDefault("DR_TEST_DR_GROUP_ENTITY_ID", "6036d237608973bf082aba1e")
+}
+
+func getTestEnvOrDefault(envVar, defaultValue string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return defaultValue
+}

--- a/pkg/provider/test_env_config_test.go
+++ b/pkg/provider/test_env_config_test.go
@@ -26,7 +26,7 @@ import "os"
 //	DR_TEST_LEADERBOARD_STAGING_MODEL_ID_2=673b75ec97f1021bbfb61d34
 //	DR_TEST_DR_GROUP_ENTITY_ID=6036d237608973bf082aba1e
 var (
-	// Base environment IDs
+	// Base environment IDs.
 
 	// testGenAIBaseEnvID is the [GenAI] Python 3.11 base environment.
 	// Used for custom models (Binary, Regression, TextGeneration, MCP, etc.).
@@ -39,13 +39,13 @@ var (
 	// testCustomJobEnvID is the base environment for custom jobs and metric jobs.
 	testCustomJobEnvID string
 
-	// Base environment version IDs
+	// Base environment version IDs.
 
 	// testAppSourceBaseEnvVersionID is a specific version of the Streamlit base environment.
 	// Used in application source and application source from template tests.
 	testAppSourceBaseEnvVersionID string
 
-	// Custom application execution environment IDs
+	// Custom application execution environment IDs.
 
 	// testCustomAppEnvID is an execution environment for custom applications from environment.
 	testCustomAppEnvID string
@@ -53,7 +53,7 @@ var (
 	// testCustomAppEnvID2 is a second execution environment for custom applications from environment.
 	testCustomAppEnvID2 string
 
-	// Template IDs
+	// Template IDs.
 
 	// testSlackbotTemplateID is the Slackbot application template.
 	testSlackbotTemplateID string
@@ -67,7 +67,7 @@ var (
 	// testFlaskTemplateID is the Flask application template.
 	testFlaskTemplateID string
 
-	// Leaderboard / registered model IDs
+	// Leaderboard / registered model IDs.
 
 	// testLeaderboardModelID is a model from a project leaderboard (production).
 	testLeaderboardModelID string
@@ -81,7 +81,7 @@ var (
 	// testLeaderboardStagingModelID2 is a second model from a project leaderboard (staging).
 	testLeaderboardStagingModelID2 string
 
-	// Other entity IDs
+	// Other entity IDs.
 
 	// testDRGroupEntityID is a DataRobot group entity ID for notification channel tests.
 	testDRGroupEntityID string

--- a/pkg/provider/user_mcp_prompt_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_prompt_metadata_resource_test.go
@@ -20,7 +20,7 @@ func TestAccUserMcpPromptMetadataResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccFeatureFlagPreCheck(t, "ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/pkg/provider/user_mcp_prompt_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_prompt_metadata_resource_test.go
@@ -16,7 +16,7 @@ func TestAccUserMcpPromptMetadataResource(t *testing.T) {
 	resourceName := "datarobot_user_mcp_prompt_metadata." + promptResourceId
 	promptName := "test-prompt-" + uuid.NewString()[:8]
 	promptType := "userPromptTemplate"
-	baseEnvironmentID := "65f9b27eab986d30d4c64268" // [GenAI] Python 3.11 with Moderations
+	baseEnvironmentID := testGenAIBaseEnvID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/pkg/provider/user_mcp_resource_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_resource_metadata_resource_test.go
@@ -21,7 +21,7 @@ func TestAccUserMcpResourceMetadataResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccFeatureFlagPreCheck(t, "ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/pkg/provider/user_mcp_resource_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_resource_metadata_resource_test.go
@@ -17,7 +17,7 @@ func TestAccUserMcpResourceMetadataResource(t *testing.T) {
 	mcpResourceName := "test-resource-" + uuid.NewString()[:8]
 	mcpResourceType := "userResource"
 	mcpResourceUri := "uri://sasada"
-	baseEnvironmentID := "65f9b27eab986d30d4c64268" // [GenAI] Python 3.11 with Moderations
+	baseEnvironmentID := testGenAIBaseEnvID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/pkg/provider/user_mcp_tool_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_tool_metadata_resource_test.go
@@ -16,7 +16,7 @@ func TestAccUserMcpToolMetadataResource(t *testing.T) {
 	resourceName := "datarobot_user_mcp_tool_metadata." + toolResourceId
 	toolName := "test-tool-" + uuid.NewString()[:8]
 	toolType := "userTool"
-	baseEnvironmentID := "65f9b27eab986d30d4c64268" // [GenAI] Python 3.11 with Moderations
+	baseEnvironmentID := testGenAIBaseEnvID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/pkg/provider/user_mcp_tool_metadata_resource_test.go
+++ b/pkg/provider/user_mcp_tool_metadata_resource_test.go
@@ -20,7 +20,7 @@ func TestAccUserMcpToolMetadataResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccFeatureFlagPreCheck(t, "ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -162,7 +162,6 @@ func waitForTaskStatusToCompleteGeneric(ctx context.Context, s client.Service, i
 	expBackoff := getExponentialBackoff()
 
 	startTime := time.Now()
-	initialStatus := ""
 
 	operation := func() error {
 		var task *client.TaskStatusResponse
@@ -192,18 +191,13 @@ func waitForTaskStatusToCompleteGeneric(ctx context.Context, s client.Service, i
 
 		elapsed := time.Since(startTime).Round(time.Second)
 
-		// Track if the status has never changed from its initial value
-		if initialStatus == "" {
-			initialStatus = task.Status
-		}
-
-		// If the status has been stuck in the same non-progressing state for over 2 minutes,
-		// log a warning and return nil so the caller can check the resource directly
-		if task.Status == initialStatus && elapsed > 2*time.Minute {
-			tflog.Warn(ctx, "Task status appears stuck, proceeding to check resource directly", map[string]interface{}{
-				"task_id":        id,
-				"current_status": task.Status,
-				"elapsed":        elapsed.String(),
+		// If the task has been stuck in INITIALIZED for over 2 minutes,
+		// the status endpoint is likely not updating — proceed so the caller
+		// can check the resource directly.
+		if task.Status == "INITIALIZED" && elapsed > 2*time.Minute {
+			tflog.Warn(ctx, "Task stuck in INITIALIZED, proceeding to check resource directly", map[string]interface{}{
+				"task_id": id,
+				"elapsed": elapsed.String(),
 			})
 			return nil
 		}

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -161,6 +161,9 @@ func waitForTaskStatusToComplete(ctx context.Context, s client.Service, id strin
 func waitForTaskStatusToCompleteGeneric(ctx context.Context, s client.Service, id string, isGenAI bool) error {
 	expBackoff := getExponentialBackoff()
 
+	startTime := time.Now()
+	initialStatus := ""
+
 	operation := func() error {
 		var task *client.TaskStatusResponse
 		var err error
@@ -183,11 +186,34 @@ func waitForTaskStatusToCompleteGeneric(ctx context.Context, s client.Service, i
 			return backoff.Permanent(errors.New(task.Message))
 		}
 
-		if task.Status != "COMPLETED" {
-			return errors.New("task is not completed")
+		if task.Status == "COMPLETED" {
+			return nil
 		}
 
-		return nil
+		elapsed := time.Since(startTime).Round(time.Second)
+
+		// Track if the status has never changed from its initial value
+		if initialStatus == "" {
+			initialStatus = task.Status
+		}
+
+		// If the status has been stuck in the same non-progressing state for over 2 minutes,
+		// log a warning and return nil so the caller can check the resource directly
+		if task.Status == initialStatus && elapsed > 2*time.Minute {
+			tflog.Warn(ctx, "Task status appears stuck, proceeding to check resource directly", map[string]interface{}{
+				"task_id":        id,
+				"current_status": task.Status,
+				"elapsed":        elapsed.String(),
+			})
+			return nil
+		}
+
+		tflog.Info(ctx, "Waiting for task to complete", map[string]interface{}{
+			"task_id":        id,
+			"current_status": task.Status,
+			"elapsed":        elapsed.String(),
+		})
+		return fmt.Errorf("task %s is not completed (current status: %s, elapsed: %s)", id, task.Status, elapsed)
 	}
 
 	// Retry the operation using the backoff strategy

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -287,7 +287,7 @@ func TestCustomModelFromGitHub(t *testing.T) {
 	require.NotEmpty(customModel.ID)
 
 	_, _, err = s.CreateCustomModelVersionFromRemoteRepository(ctx, customModel.ID, &client.CreateCustomModelVersionFromRemoteRepositoryRequest{
-		BaseEnvironmentID: "65f9b27eab986d30d4c64268",
+		BaseEnvironmentID: getEnvOrDefault("DR_TEST_GENAI_BASE_ENV_ID", "67ab469cecdca772287de644"),
 		IsMajorUpdate:     true,
 		RepositoryID:      remoteRepository.ID,
 		Ref:               "master",
@@ -1269,4 +1269,11 @@ func initializeTest(t *testing.T) client.Service {
 	s := client.NewService(c)
 
 	return s
+}
+
+func getEnvOrDefault(envVar, defaultValue string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return defaultValue
 }


### PR DESCRIPTION
This pull request introduces a new feature flag mechanism to the service client, refactors test code to use shared test constants for environment and template IDs, and makes several improvements to test reliability and maintainability. Additionally, it fixes and enhances the handling of runtime parameters and deployment status polling, as well as improves error handling and logging. Below are the most important changes grouped by theme:

**Feature Flag Support:**

* Added a new `IsFeatureFlagEnabled` method to the `Service` interface and its implementation, allowing feature flag checks via the user's permissions (`internal/client/service.go`, `internal/client/user_service.go`) [[1]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccR231-R233) [[2]](diffhunk://#diff-02d8444b0fb48e06714ca18476076027403525e58b9c33fe286320e714aeb2ccR1003-R1010) [[3]](diffhunk://#diff-1e8151768de52ec1de3e2dd3d70ae81edd3ee30b11bf355790542552cb7e8fb0R10).
* Updated the mock service to support the new `IsFeatureFlagEnabled` method for testing (`mock/service.go`).

**Test Refactoring and Reliability:**

* Refactored test code to use shared test constants (e.g., `testStreamlitBaseEnvID`, `testCustomJobEnvID`, etc.) instead of hardcoded IDs for base environments and templates, improving maintainability and reducing flakiness (`pkg/provider/application_source_resource_test.go`, `pkg/provider/application_source_from_template_resource_test.go`, `pkg/provider/custom_application_resource_test.go`, `pkg/provider/custom_application_from_environment_resource_test.go`, `pkg/provider/custom_job_resource_test.go`, `pkg/provider/custom_metric_from_job_resource_test.go`, `pkg/provider/batch_prediction_job_definition_resource_test.go`) [[1]](diffhunk://#diff-f3ff159c2dff681face0d5e2815ee9a906c6d0f3fe9e84197d3c89958b0d994eL55-R56) [[2]](diffhunk://#diff-f3ff159c2dff681face0d5e2815ee9a906c6d0f3fe9e84197d3c89958b0d994eL401-R401) [[3]](diffhunk://#diff-f3ff159c2dff681face0d5e2815ee9a906c6d0f3fe9e84197d3c89958b0d994eL723-R723) [[4]](diffhunk://#diff-12f80b3d8b71bb7ebb10d36b15cfc5c7edccb37887f7aa710cefd2692b4fe854L48-R49) [[5]](diffhunk://#diff-12f80b3d8b71bb7ebb10d36b15cfc5c7edccb37887f7aa710cefd2692b4fe854L84-R87) [[6]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L208-R215) [[7]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L230-R230) [[8]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L359-R359) [[9]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L570-R570) [[10]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L771-R771) [[11]](diffhunk://#diff-9c05a9ab4f58df30ab36b0466d8a5893f1def39a50fe7799d0c6867d7c8bbf34L885-R885) [[12]](diffhunk://#diff-31dfec72ad7bc20f22d2b61c81ba1ffdcf79f7a75fdab8bcc5c0db7f79b31f19L481-R481) [[13]](diffhunk://#diff-2538eb49399e0323a2c4a0d3c9fc497f20852069bad0d663aea2a40afc9bb053L194-R197) [[14]](diffhunk://#diff-2538eb49399e0323a2c4a0d3c9fc497f20852069bad0d663aea2a40afc9bb053L206-R206) [[15]](diffhunk://#diff-2538eb49399e0323a2c4a0d3c9fc497f20852069bad0d663aea2a40afc9bb053R250-R252) [[16]](diffhunk://#diff-0a4a7453c09fa6ef173d06e0128172882afbe93d7b7fa6a09fc84d8a6a176401L34-R35) [[17]](diffhunk://#diff-55c5c9f476866883591f179849d733579bf9813a9f97e1dc7d3544fce75e62baL255-R285) [[18]](diffhunk://#diff-55c5c9f476866883591f179849d733579bf9813a9f97e1dc7d3544fce75e62baR322-R324).
* Added creation of a `metadata.yaml` file in the custom metric from job resource test to ensure runtime parameter definitions are present for the test (`pkg/provider/custom_metric_from_job_resource_test.go`).

**Deployment and Runtime Parameter Handling:**

* Improved deployment creation and update logic to handle edge cases: fixed polling getting stuck on `INITIALIZED`, improved logging, resolved race conditions, ensured readiness checks proceed even on polling failures, and fixed runtime parameter update issues for deployments and custom metric jobs (`CHANGELOG.md`, `pkg/provider/custom_metric_job_resource.go`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R14) [[2]](diffhunk://#diff-950792367d4b3e1d142db147f5a8555af69a5e21197d4be4e974a290a24b7da0L343-R351).

**Mock Service Maintenance:**

* Fixed and reordered mock method implementations to match the service interface, ensuring mocks are up to date and tests remain reliable (`mock/service.go`) [[1]](diffhunk://#diff-abc7a0658f54544ee7e7926dff547cf1685ebdeae9bbd8a903abda28536579b5L670-L684) [[2]](diffhunk://#diff-abc7a0658f54544ee7e7926dff547cf1685ebdeae9bbd8a903abda28536579b5R700-R714).

These changes collectively improve feature flag support, test reliability, deployment robustness, and maintainability across the codebase.


<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes deployment create/update/model-replacement sequencing and task polling behavior, which can affect real resource lifecycle and error handling. Most other changes are test-only refactors and client additions with low runtime impact.
> 
> **Overview**
> Improves deployment lifecycle robustness: task polling now logs status/elapsed time, treats long-running `INITIALIZED` as a signal to proceed, avoids deleting deployments on transient polling failures, activates inactive deployments before updates/model replacement, and applies runtime parameters *before* model replacement to avoid post-replacement API 500s.
> 
> Refactors registered model Update to reuse a new `createNewRegisteredModelVersion` helper for both custom model version and tag changes, and adds a guard-update fast path in `CustomModelResource` to skip guard API calls when nothing changed.
> 
> Cleans up acceptance tests by centralizing environment/template IDs via env vars (`test_env_config_test.go`), adding required model/deployment metadata/runtime parameters for Q&A and guard-related flows, and gating MCP metadata tests behind a server feature flag (adds `UserInfo.Permissions` plus `Service.IsFeatureFlagEnabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd04123eb55f236d7792d9973e640575a70d559a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->