### PR TITLE
[APP-5647] Enable custom health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Added `health_endpoint_path` field to Application Source, Application Source From Template, Custom Application, and Custom Application From Environment resources. When set, this path is used for Kubernetes liveness and readiness probes instead of the path derived from `service_web_requests_on_root_path`.
+
 ### Fixed
 
 - Fixed deployment creation task status polling getting stuck when the status API returns `INITIALIZED` indefinitely. After 2 minutes of `INITIALIZED` with no progress, the provider now skips the status check and verifies the deployment readiness directly

--- a/docs/resources/application_source.md
+++ b/docs/resources/application_source.md
@@ -80,6 +80,7 @@ output "datarobot_application_source_resources" {
 
 Optional:
 
+- `health_endpoint_path` (String) Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.
 - `replicas` (Number) The number of replicas for the Application Source. Computed by API if not specified.
 - `resource_label` (String) The resource label for the Application Source (e.g., 'cpu.small', 'cpu.medium'). Computed by API if not specified.
 - `service_web_requests_on_root_path` (Boolean) Whether to service web requests on the root path for the Application Source. Computed by API if not specified.

--- a/docs/resources/application_source_from_template.md
+++ b/docs/resources/application_source_from_template.md
@@ -83,6 +83,7 @@ output "datarobot_application_source_resources" {
 
 Optional:
 
+- `health_endpoint_path` (String) Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.
 - `replicas` (Number) The number of replicas for the Application Source. Computed by API if not specified.
 - `resource_label` (String) The resource label for the Application Source (e.g., 'cpu.small', 'cpu.medium'). Computed by API if not specified.
 - `service_web_requests_on_root_path` (Boolean) Whether to service web requests on the root path for the Application Source. Computed by API if not specified.

--- a/docs/resources/custom_application.md
+++ b/docs/resources/custom_application.md
@@ -93,6 +93,7 @@ output "datarobot_custom_application_resources" {
 
 Optional:
 
+- `health_endpoint_path` (String) Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.
 - `replicas` (Number) The number of replicas for the Custom Application. Computed by API if not specified.
 - `resource_label` (String) The resource label for the Custom Application (e.g., 'cpu.small', 'cpu.medium'). Computed by API if not specified.
 - `service_web_requests_on_root_path` (Boolean) Whether to service web requests on the root path for the Custom Application. Computed by API if not specified.

--- a/docs/resources/custom_application_from_environment.md
+++ b/docs/resources/custom_application_from_environment.md
@@ -75,6 +75,7 @@ output "datarobot_custom_application_resources" {
 
 Optional:
 
+- `health_endpoint_path` (String) Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.
 - `replicas` (Number) The number of replicas for the Custom Application. Computed by API if not specified.
 - `resource_label` (String) The resource label for the Custom Application (e.g., 'cpu.small', 'cpu.medium'). Computed by API if not specified.
 - `service_web_requests_on_root_path` (Boolean) Whether to service web requests on the root path for the Custom Application. Computed by API if not specified.

--- a/internal/client/application_service.go
+++ b/internal/client/application_service.go
@@ -150,6 +150,7 @@ type ApplicationResources struct {
 	ResourceLabel                *string `json:"resourceLabel,omitempty"`
 	SessionAffinity              *bool   `json:"sessionAffinity,omitempty"`
 	ServiceWebRequestsOnRootPath *bool   `json:"serviceWebRequestsOnRootPath,omitempty"`
+	HealthEndpointPath           *string `json:"healthEndpointPath,omitempty"`
 }
 
 type CustomTemplate struct {

--- a/pkg/provider/application_source_from_template_resource.go
+++ b/pkg/provider/application_source_from_template_resource.go
@@ -119,6 +119,11 @@ func (r *ApplicationSourceFromTemplateResource) Schema(ctx context.Context, req 
 						Computed:            true,
 						MarkdownDescription: "Whether to service web requests on the root path for the Application Source. Computed by API if not specified.",
 					},
+					"health_endpoint_path": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.",
+					},
 				},
 			},
 			"runtime_parameter_values": schema.ListNestedAttribute{

--- a/pkg/provider/application_source_resource.go
+++ b/pkg/provider/application_source_resource.go
@@ -112,6 +112,11 @@ func (r *ApplicationSourceResource) Schema(ctx context.Context, req resource.Sch
 						Computed:            true,
 						MarkdownDescription: "Whether to service web requests on the root path for the Application Source. Computed by API if not specified.",
 					},
+					"health_endpoint_path": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.",
+					},
 				},
 			},
 			"runtime_parameter_values": schema.ListNestedAttribute{

--- a/pkg/provider/custom_application_from_environment_resource.go
+++ b/pkg/provider/custom_application_from_environment_resource.go
@@ -129,6 +129,10 @@ func (r *CustomApplicationFromEnvironmentResource) Schema(ctx context.Context, r
 						Optional:            true,
 						MarkdownDescription: "Whether to service web requests on the root path for the Custom Application. Computed by API if not specified.",
 					},
+					"health_endpoint_path": schema.StringAttribute{
+						Optional:            true,
+						MarkdownDescription: "Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.",
+					},
 				},
 			},
 			"use_case_ids": schema.ListAttribute{

--- a/pkg/provider/custom_application_resource.go
+++ b/pkg/provider/custom_application_resource.go
@@ -134,6 +134,10 @@ func (r *CustomApplicationResource) Schema(ctx context.Context, req resource.Sch
 						Optional:            true,
 						MarkdownDescription: "Whether to service web requests on the root path for the Custom Application. Computed by API if not specified.",
 					},
+					"health_endpoint_path": schema.StringAttribute{
+						Optional:            true,
+						MarkdownDescription: "Path used by the Kubernetes liveness and readiness probes. When set, takes precedence over the path derived from `service_web_requests_on_root_path`. Use this to expose a dedicated health endpoint (e.g. `/healthz`) instead of probing the root path.",
+					},
 				},
 			},
 			"use_case_ids": schema.ListAttribute{

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -1317,6 +1317,7 @@ func applicationResourcesAttrTypes() map[string]attr.Type {
 		"resource_label":                    types.StringType,
 		"session_affinity":                  types.BoolType,
 		"service_web_requests_on_root_path": types.BoolType,
+		"health_endpoint_path":              types.StringType,
 	}
 }
 
@@ -1329,6 +1330,7 @@ func ApplicationResourcesFromAPI(ctx context.Context, apiResources client.Applic
 		"resource_label":                    StringPointerValue(apiResources.ResourceLabel),
 		"session_affinity":                  BoolPointerValue(apiResources.SessionAffinity),
 		"service_web_requests_on_root_path": BoolPointerValue(apiResources.ServiceWebRequestsOnRootPath),
+		"health_endpoint_path":              StringPointerValue(apiResources.HealthEndpointPath),
 	}
 
 	objValue, diags := types.ObjectValue(attrTypes, attrValues)
@@ -1385,6 +1387,14 @@ func ApplicationResourcesToAPI(ctx context.Context, resources basetypes.ObjectVa
 		if rootPathVal, ok := rootPathAttr.(types.Bool); ok && !rootPathVal.IsNull() && !rootPathVal.IsUnknown() {
 			val := rootPathVal.ValueBool()
 			apiResources.ServiceWebRequestsOnRootPath = &val
+		}
+	}
+
+	// Extract health_endpoint_path
+	if healthPathAttr, ok := attrs["health_endpoint_path"]; ok {
+		if healthPathVal, ok := healthPathAttr.(types.String); ok && !healthPathVal.IsNull() && !healthPathVal.IsUnknown() {
+			val := healthPathVal.ValueString()
+			apiResources.HealthEndpointPath = &val
 		}
 	}
 


### PR DESCRIPTION
## Summary

* Support new Custom Application field introduced by https://github.com/datarobot/DataRobot/pull/152461

## Type
- [X] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes resource schemas and update behavior for applications/models/jobs, and introduces retry/conditional API-call logic that could affect apply semantics if not aligned with backend expectations.
> 
> **Overview**
> Adds support for configuring `resources.health_endpoint_path` across Application Source and Custom Application resources (and their variants), wiring it through Terraform schema, state conversion helpers, and the underlying `ApplicationResources` API model; docs and the changelog are updated accordingly.
> 
> Fixes several 422 error cases by avoiding problematic API calls: `custom_metric_job` now only sends `runtimeParameterValues` when explicitly set/non-empty, and custom model guard updates now (a) early-exit when there are no guard configs and (b) retry guard override creation with exponential backoff when the backend guard schema isn’t initialized yet. A related acceptance test config is updated (`qa_application_resource_test.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bb53f2bda6280b6bdc7bd35cd170ad23e512c9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->