### PR TITLE
[APP-5754] Totaly removed external sharing fields form Custom Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## [0.10.35] - 2026-04-28
+
+### Removed
+
+- Removed external sharing settings from `CustomApplicationSource`/`CustomApplication`.SS
+
 ### Added
 - `datarobot_artifact` resource was added. It creates Artifact objects in Workload API.
 

--- a/docs/resources/custom_application.md
+++ b/docs/resources/custom_application.md
@@ -25,10 +25,6 @@ resource "datarobot_custom_application" "example" {
   source_version_id = datarobot_application_source.example.version_id
 
   # optional settings
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 
   resources {
@@ -75,8 +71,6 @@ output "datarobot_custom_application_resources" {
 ### Optional
 
 - `allow_auto_stopping` (Boolean) Whether auto stopping is allowed for the Custom Application.
-- `external_access_enabled` (Boolean) Whether external access is enabled for the Custom Application.
-- `external_access_recipients` (List of String) The list of external email addresses that have access to the Custom Application.
 - `name` (String) The name of the Custom Application.
 - `required_key_scope_level` (String) The API key scope level required for requests to this custom application. Can be set to 'viewer', 'user', or 'admin'.
 - `resources` (Attributes) The resources for the Custom Application. If not specified, default values will be computed by the API based on the cluster configuration. (see [below for nested schema](#nestedatt--resources))

--- a/docs/resources/custom_application_from_environment.md
+++ b/docs/resources/custom_application_from_environment.md
@@ -17,11 +17,6 @@ resource "datarobot_custom_application_from_environment" "example" {
   name           = "example-custom-app-from-environment"
   environment_id = datarobot_execution_environment.example.id
 
-  # optional settings
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 
   resources {
@@ -59,8 +54,6 @@ output "datarobot_custom_application_resources" {
 ### Optional
 
 - `allow_auto_stopping` (Boolean) Whether auto stopping is allowed for the Custom Application.
-- `external_access_enabled` (Boolean) Whether external access is enabled for the Custom Application.
-- `external_access_recipients` (List of String) The list of external email addresses that have access to the Custom Application.
 - `resources` (Attributes) The resources for the Custom Application. If not specified, default values will be computed by the API based on the cluster configuration. (see [below for nested schema](#nestedatt--resources))
 - `use_case_ids` (List of String) The list of Use Case IDs to add the Custom Application to.
 

--- a/docs/resources/custom_application_from_environment.md
+++ b/docs/resources/custom_application_from_environment.md
@@ -17,6 +17,7 @@ resource "datarobot_custom_application_from_environment" "example" {
   name           = "example-custom-app-from-environment"
   environment_id = datarobot_execution_environment.example.id
 
+  # optional settings
   allow_auto_stopping = false
 
   resources {

--- a/docs/resources/qa_application.md
+++ b/docs/resources/qa_application.md
@@ -45,10 +45,6 @@ resource "datarobot_qa_application" "example" {
   deployment_id = datarobot_deployment.example.id
 
   # Optional
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 }
 
@@ -84,8 +80,6 @@ output "datarobot_qa_application_url" {
 ### Optional
 
 - `allow_auto_stopping` (Boolean) Whether auto stopping is allowed for the Q&A Application.
-- `external_access_enabled` (Boolean) Whether external access is enabled for the Q&A Application.
-- `external_access_recipients` (List of String) The list of external email addresses that have access to the Q&A Application.
 
 ### Read-Only
 

--- a/examples/resources/datarobot_custom_application/resource.tf
+++ b/examples/resources/datarobot_custom_application/resource.tf
@@ -10,10 +10,6 @@ resource "datarobot_custom_application" "example" {
   source_version_id = datarobot_application_source.example.version_id
 
   # optional settings
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 
   resources {

--- a/examples/resources/datarobot_custom_application_from_environment/resource.tf
+++ b/examples/resources/datarobot_custom_application_from_environment/resource.tf
@@ -3,10 +3,6 @@ resource "datarobot_custom_application_from_environment" "example" {
   environment_id = datarobot_execution_environment.example.id
 
   # optional settings
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 
   resources {

--- a/examples/resources/datarobot_qa_application/resource.tf
+++ b/examples/resources/datarobot_qa_application/resource.tf
@@ -30,10 +30,6 @@ resource "datarobot_qa_application" "example" {
   deployment_id = datarobot_deployment.example.id
 
   # Optional
-  external_access_enabled = true
-  external_access_recipients = [
-    "recipient@example.com",
-  ]
   allow_auto_stopping = false
 }
 

--- a/internal/client/application_service.go
+++ b/internal/client/application_service.go
@@ -78,8 +78,6 @@ type Application struct {
 	CustomApplicationSourceVersionID string                `json:"customApplicationSourceVersionId"`
 	EnvVersionID                     string                `json:"envVersionId"`
 	ApplicationUrl                   string                `json:"applicationUrl"`
-	ExternalAccessEnabled            bool                  `json:"externalAccessEnabled"`
-	ExternalAccessRecipients         []string              `json:"externalAccessRecipients"`
 	AllowAutoStopping                bool                  `json:"allowAutoStopping"`
 	Resources                        *ApplicationResources `json:"resources,omitempty"`
 	RequiredKeyScopeLevel            ScopeLevel            `json:"requiredKeyScopeLevel"`
@@ -88,8 +86,6 @@ type Application struct {
 type UpdateApplicationRequest struct {
 	Name                             string     `json:"name,omitempty"`
 	CustomApplicationSourceVersionID string     `json:"customApplicationSourceVersionId,omitempty"`
-	ExternalAccessEnabled            bool       `json:"externalAccessEnabled"`
-	ExternalAccessRecipients         []string   `json:"externalAccessRecipients"`
 	AllowAutoStopping                bool       `json:"allowAutoStopping"`
 	RequiredKeyScopeLevel            ScopeLevel `json:"requiredKeyScopeLevel,omitempty"`
 }

--- a/pkg/provider/custom_application_from_environment_resource.go
+++ b/pkg/provider/custom_application_from_environment_resource.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -69,23 +67,6 @@ func (r *CustomApplicationFromEnvironmentResource) Schema(ctx context.Context, r
 				MarkdownDescription: "The URL of the Custom Application.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"external_access_enabled": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "Whether external access is enabled for the Custom Application.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"external_access_recipients": schema.ListAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "The list of external email addresses that have access to the Custom Application.",
-				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"allow_auto_stopping": schema.BoolAttribute{
@@ -193,21 +174,9 @@ func (r *CustomApplicationFromEnvironmentResource) Create(ctx context.Context, r
 		return
 	}
 
-	enableExternalAccess := IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool()
-
-	if IsKnown(data.Name) || enableExternalAccess || !data.AllowAutoStopping.ValueBool() {
-		recipients := []string{}
-		if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-			if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-				resp.Diagnostics.Append(diags...)
-				return
-			}
-		}
-
+	if IsKnown(data.Name) || !data.AllowAutoStopping.ValueBool() {
 		updateRequest := &client.UpdateApplicationRequest{
-			ExternalAccessEnabled:    enableExternalAccess,
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
+			AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
 		}
 
 		if IsKnown(data.Name) {
@@ -232,13 +201,10 @@ func (r *CustomApplicationFromEnvironmentResource) Create(ctx context.Context, r
 	data.Name = types.StringValue(application.Name)
 	data.EnvironmentVersionID = types.StringValue(application.EnvVersionID)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	data.ExternalAccessRecipients = recipientsList
 
 	// Populate resources from API response (field is Computed).
 	if application.Resources != nil {
@@ -294,13 +260,6 @@ func (r *CustomApplicationFromEnvironmentResource) Read(ctx context.Context, req
 	data.Name = types.StringValue(application.Name)
 	data.EnvironmentVersionID = types.StringValue(application.EnvVersionID)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.ExternalAccessRecipients = recipientsList
 	data.AllowAutoStopping = types.BoolValue(application.AllowAutoStopping)
 
 	// Always populate resources from API response (field is Computed).
@@ -329,18 +288,8 @@ func (r *CustomApplicationFromEnvironmentResource) Update(ctx context.Context, r
 		return
 	}
 
-	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {

--- a/pkg/provider/custom_application_from_environment_resource.go
+++ b/pkg/provider/custom_application_from_environment_resource.go
@@ -201,10 +201,6 @@ func (r *CustomApplicationFromEnvironmentResource) Create(ctx context.Context, r
 	data.Name = types.StringValue(application.Name)
 	data.EnvironmentVersionID = types.StringValue(application.EnvVersionID)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Populate resources from API response (field is Computed).
 	if application.Resources != nil {

--- a/pkg/provider/custom_application_from_environment_resource_test.go
+++ b/pkg/provider/custom_application_from_environment_resource_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -48,8 +47,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 				Config: customApplicationFromEnvironmentResourceConfig(
 					name,
 					environmentID,
-					false,
-					[]string{},
 					&useCaseResourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
@@ -65,8 +62,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "environment_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "external_access_recipients"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_ids.0"),
 				),
 			},
@@ -75,8 +70,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 				Config: customApplicationFromEnvironmentResourceConfig(
 					newName,
 					environmentID,
-					true,
-					[]string{"test@test.com"},
 					&useCaseResourceName2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
@@ -96,8 +89,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "environment_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.0", "test@test.com"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_ids.0"),
 				),
 			},
@@ -106,8 +97,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 				Config: customApplicationFromEnvironmentResourceConfig(
 					newName,
 					environmentID2,
-					true,
-					[]string{"test2@test.com"},
 					nil),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
@@ -122,8 +111,6 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "environment_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.0", "test2@test.com"),
 					resource.TestCheckNoResourceAttr(resourceName, "use_case_ids.0"),
 				),
 			},
@@ -135,17 +122,8 @@ func TestAccCustomApplicationFromEnvironmentResource(t *testing.T) {
 func customApplicationFromEnvironmentResourceConfig(
 	name string,
 	environmentID string,
-	externalAccess bool,
-	externalAccessRecipients []string,
 	useCaseResourceName *string,
 ) string {
-	recipients := ""
-	if len(externalAccessRecipients) > 0 {
-		recipients = fmt.Sprintf(`
-		external_access_recipients = %q
-		`, externalAccessRecipients)
-	}
-
 	nameStr := ""
 	if name != "" {
 		nameStr = fmt.Sprintf(`
@@ -168,12 +146,10 @@ resource "datarobot_use_case" "test_new_custom_application_from_environment" {
 
 resource "datarobot_custom_application_from_environment" "test" {
 	environment_id = "%s"
-	external_access_enabled = %t
-	%s
 	%s
 	%s
 }
-`, environmentID, externalAccess, recipients, nameStr, useCaseIDsStr)
+`, environmentID, nameStr, useCaseIDsStr)
 }
 
 func checkCustomApplicationFromEnvironmentResourceExists() resource.TestCheckFunc {
@@ -202,18 +178,6 @@ func checkCustomApplicationFromEnvironmentResourceExists() resource.TestCheckFun
 		if application.Name == rs.Primary.Attributes["name"] &&
 			application.ApplicationUrl == rs.Primary.Attributes["application_url"] &&
 			application.EnvVersionID == rs.Primary.Attributes["environment_version_id"] {
-			b, err := strconv.ParseBool(rs.Primary.Attributes["external_access_enabled"])
-			if err == nil {
-				if application.ExternalAccessEnabled == b {
-					if len(application.ExternalAccessRecipients) > 0 {
-						if application.ExternalAccessRecipients[0] == rs.Primary.Attributes["external_access_recipients.0"] {
-							return nil
-						}
-					} else if rs.Primary.Attributes["external_access_recipients.0"] == "" {
-						return nil
-					}
-				}
-			}
 			return nil
 		}
 

--- a/pkg/provider/custom_application_resource.go
+++ b/pkg/provider/custom_application_resource.go
@@ -17,11 +17,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &CustomApplicationResource{}
 var _ resource.ResourceWithImportState = &CustomApplicationResource{}
+var _ resource.ResourceWithUpgradeState = &CustomApplicationResource{}
 
 func NewCustomApplicationResource() resource.Resource {
 	return &CustomApplicationResource{}
@@ -39,6 +41,7 @@ func (r *CustomApplicationResource) Schema(ctx context.Context, req resource.Sch
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Custom Application",
+		Version:             1,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -396,4 +399,76 @@ func (r *CustomApplicationResource) Delete(ctx context.Context, req resource.Del
 
 func (r *CustomApplicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *CustomApplicationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id":                schema.StringAttribute{Computed: true},
+					"source_id":         schema.StringAttribute{Computed: true},
+					"source_version_id": schema.StringAttribute{Required: true},
+					"name":              schema.StringAttribute{Optional: true, Computed: true},
+					"application_url":   schema.StringAttribute{Computed: true},
+					"external_access_enabled": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"external_access_recipients": schema.ListAttribute{
+						Optional:    true,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					"allow_auto_stopping": schema.BoolAttribute{Optional: true, Computed: true},
+					"resources": schema.SingleNestedAttribute{
+						Optional: true,
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"replicas":                          schema.Int64Attribute{Optional: true},
+							"resource_label":                    schema.StringAttribute{Optional: true},
+							"session_affinity":                  schema.BoolAttribute{Optional: true},
+							"service_web_requests_on_root_path": schema.BoolAttribute{Optional: true},
+							"health_endpoint_path":              schema.StringAttribute{Optional: true},
+						},
+					},
+					"use_case_ids": schema.ListAttribute{
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+					"required_key_scope_level": schema.StringAttribute{Optional: true},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var oldState struct {
+					ID                       types.String          `tfsdk:"id"`
+					SourceID                 types.String          `tfsdk:"source_id"`
+					SourceVersionID          types.String          `tfsdk:"source_version_id"`
+					Name                     types.String          `tfsdk:"name"`
+					ApplicationUrl           types.String          `tfsdk:"application_url"`
+					ExternalAccessEnabled    types.Bool            `tfsdk:"external_access_enabled"`
+					ExternalAccessRecipients types.List            `tfsdk:"external_access_recipients"`
+					AllowAutoStopping        types.Bool            `tfsdk:"allow_auto_stopping"`
+					Resources                basetypes.ObjectValue `tfsdk:"resources"`
+					UseCaseIDs               []types.String        `tfsdk:"use_case_ids"`
+					RequiredKeyScopeLevel    types.String          `tfsdk:"required_key_scope_level"`
+				}
+				resp.Diagnostics.Append(req.State.Get(ctx, &oldState)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, CustomApplicationResourceModel{
+					ID:                    oldState.ID,
+					SourceID:              oldState.SourceID,
+					SourceVersionID:       oldState.SourceVersionID,
+					Name:                  oldState.Name,
+					ApplicationUrl:        oldState.ApplicationUrl,
+					AllowAutoStopping:     oldState.AllowAutoStopping,
+					Resources:             oldState.Resources,
+					UseCaseIDs:            oldState.UseCaseIDs,
+					RequiredKeyScopeLevel: oldState.RequiredKeyScopeLevel,
+				})...)
+			},
+		},
+	}
 }

--- a/pkg/provider/custom_application_resource.go
+++ b/pkg/provider/custom_application_resource.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -71,23 +69,6 @@ func (r *CustomApplicationResource) Schema(ctx context.Context, req resource.Sch
 				MarkdownDescription: "The URL of the Custom Application.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"external_access_enabled": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "Whether external access is enabled for the Custom Application.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"external_access_recipients": schema.ListAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "The list of external email addresses that have access to the Custom Application.",
-				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"allow_auto_stopping": schema.BoolAttribute{
@@ -209,21 +190,9 @@ func (r *CustomApplicationResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	enableExternalAccess := IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool()
-
-	if IsKnown(data.Name) || enableExternalAccess || !data.AllowAutoStopping.ValueBool() {
-		recipients := []string{}
-		if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-			if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-				resp.Diagnostics.Append(diags...)
-				return
-			}
-		}
-
+	if IsKnown(data.Name) || !data.AllowAutoStopping.ValueBool() {
 		updateRequest := &client.UpdateApplicationRequest{
-			ExternalAccessEnabled:    enableExternalAccess,
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
+			AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
 		}
 
 		if IsKnown(data.Name) {
@@ -248,13 +217,6 @@ func (r *CustomApplicationResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringValue(application.Name)
 	data.SourceID = types.StringValue(application.CustomApplicationSourceID)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.ExternalAccessRecipients = recipientsList
 
 	// Populate resources from API response (field is Computed).
 	if application.Resources != nil {
@@ -314,13 +276,6 @@ func (r *CustomApplicationResource) Read(ctx context.Context, req resource.ReadR
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
 	data.SourceID = types.StringValue(application.CustomApplicationSourceID)
 	data.SourceVersionID = types.StringValue(application.CustomApplicationSourceVersionID)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.ExternalAccessRecipients = recipientsList
 	data.AllowAutoStopping = types.BoolValue(application.AllowAutoStopping)
 
 	// Don't read required_key_scope_level from API - keep user-configured value
@@ -352,18 +307,8 @@ func (r *CustomApplicationResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -965,11 +965,11 @@ func TestCustomApplicationUpgradeState_v0_to_v1(t *testing.T) {
 
 	t.Run("preserves all remaining fields and drops external_access fields", func(t *testing.T) {
 		got := runUpgrade(t, tftypes.NewValue(v0ObjType, map[string]tftypes.Value{
-			"id":               tftypes.NewValue(tftypes.String, "app-123"),
-			"source_id":        tftypes.NewValue(tftypes.String, "src-456"),
-			"source_version_id": tftypes.NewValue(tftypes.String, "ver-789"),
-			"name":             tftypes.NewValue(tftypes.String, "my-app"),
-			"application_url":  tftypes.NewValue(tftypes.String, "https://example.com"),
+			"id":                      tftypes.NewValue(tftypes.String, "app-123"),
+			"source_id":               tftypes.NewValue(tftypes.String, "src-456"),
+			"source_version_id":       tftypes.NewValue(tftypes.String, "ver-789"),
+			"name":                    tftypes.NewValue(tftypes.String, "my-app"),
+			"application_url":         tftypes.NewValue(tftypes.String, "https://example.com"),
 			"external_access_enabled": tftypes.NewValue(tftypes.Bool, true),
 			"external_access_recipients": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, "user@example.com"),

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -900,4 +903,129 @@ func checkCustomApplicationScopeLevel(resourceName, expectedLevel string) resour
 
 		return nil
 	}
+}
+
+func TestCustomApplicationUpgradeState_v0_to_v1(t *testing.T) {
+	ctx := context.Background()
+	r := &CustomApplicationResource{}
+
+	upgraders := r.UpgradeState(ctx)
+	upgrader, ok := upgraders[0]
+	if !ok {
+		t.Fatal("no upgrader registered for state version 0")
+	}
+
+	resourcesObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"replicas":                          tftypes.Number,
+			"resource_label":                    tftypes.String,
+			"session_affinity":                  tftypes.Bool,
+			"service_web_requests_on_root_path": tftypes.Bool,
+			"health_endpoint_path":              tftypes.String,
+		},
+	}
+
+	v0ObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id":                         tftypes.String,
+			"source_id":                  tftypes.String,
+			"source_version_id":          tftypes.String,
+			"name":                       tftypes.String,
+			"application_url":            tftypes.String,
+			"external_access_enabled":    tftypes.Bool,
+			"external_access_recipients": tftypes.List{ElementType: tftypes.String},
+			"allow_auto_stopping":        tftypes.Bool,
+			"resources":                  resourcesObjType,
+			"use_case_ids":               tftypes.List{ElementType: tftypes.String},
+			"required_key_scope_level":   tftypes.String,
+		},
+	}
+
+	schemaResp := &fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, schemaResp)
+
+	runUpgrade := func(t *testing.T, rawVal tftypes.Value) CustomApplicationResourceModel {
+		t.Helper()
+		upgradeResp := &fwresource.UpgradeStateResponse{
+			State: tfsdk.State{Schema: schemaResp.Schema},
+		}
+		upgrader.StateUpgrader(ctx, fwresource.UpgradeStateRequest{
+			State: &tfsdk.State{
+				Raw:    rawVal,
+				Schema: *upgrader.PriorSchema,
+			},
+		}, upgradeResp)
+		if upgradeResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", upgradeResp.Diagnostics)
+		}
+		var got CustomApplicationResourceModel
+		upgradeResp.State.Get(ctx, &got)
+		return got
+	}
+
+	t.Run("preserves all remaining fields and drops external_access fields", func(t *testing.T) {
+		got := runUpgrade(t, tftypes.NewValue(v0ObjType, map[string]tftypes.Value{
+			"id":               tftypes.NewValue(tftypes.String, "app-123"),
+			"source_id":        tftypes.NewValue(tftypes.String, "src-456"),
+			"source_version_id": tftypes.NewValue(tftypes.String, "ver-789"),
+			"name":             tftypes.NewValue(tftypes.String, "my-app"),
+			"application_url":  tftypes.NewValue(tftypes.String, "https://example.com"),
+			"external_access_enabled": tftypes.NewValue(tftypes.Bool, true),
+			"external_access_recipients": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "user@example.com"),
+			}),
+			"allow_auto_stopping":      tftypes.NewValue(tftypes.Bool, true),
+			"resources":                tftypes.NewValue(resourcesObjType, nil),
+			"use_case_ids":             tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
+			"required_key_scope_level": tftypes.NewValue(tftypes.String, nil),
+		}))
+
+		if got.ID.ValueString() != "app-123" {
+			t.Errorf("ID: got %q, want %q", got.ID.ValueString(), "app-123")
+		}
+		if got.SourceID.ValueString() != "src-456" {
+			t.Errorf("SourceID: got %q, want %q", got.SourceID.ValueString(), "src-456")
+		}
+		if got.SourceVersionID.ValueString() != "ver-789" {
+			t.Errorf("SourceVersionID: got %q, want %q", got.SourceVersionID.ValueString(), "ver-789")
+		}
+		if got.Name.ValueString() != "my-app" {
+			t.Errorf("Name: got %q, want %q", got.Name.ValueString(), "my-app")
+		}
+		if got.ApplicationUrl.ValueString() != "https://example.com" {
+			t.Errorf("ApplicationUrl: got %q, want %q", got.ApplicationUrl.ValueString(), "https://example.com")
+		}
+		if !got.AllowAutoStopping.ValueBool() {
+			t.Errorf("AllowAutoStopping: got false, want true")
+		}
+		if !got.Resources.IsNull() {
+			t.Errorf("Resources: expected null, got %v", got.Resources)
+		}
+		if !got.RequiredKeyScopeLevel.IsNull() {
+			t.Errorf("RequiredKeyScopeLevel: expected null, got %q", got.RequiredKeyScopeLevel.ValueString())
+		}
+	})
+
+	t.Run("no diagnostics when external_access_recipients is null", func(t *testing.T) {
+		got := runUpgrade(t, tftypes.NewValue(v0ObjType, map[string]tftypes.Value{
+			"id":                         tftypes.NewValue(tftypes.String, "app-999"),
+			"source_id":                  tftypes.NewValue(tftypes.String, "src-999"),
+			"source_version_id":          tftypes.NewValue(tftypes.String, "ver-999"),
+			"name":                       tftypes.NewValue(tftypes.String, "app"),
+			"application_url":            tftypes.NewValue(tftypes.String, "https://app.example.com"),
+			"external_access_enabled":    tftypes.NewValue(tftypes.Bool, false),
+			"external_access_recipients": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+			"allow_auto_stopping":        tftypes.NewValue(tftypes.Bool, false),
+			"resources":                  tftypes.NewValue(resourcesObjType, nil),
+			"use_case_ids":               tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
+			"required_key_scope_level":   tftypes.NewValue(tftypes.String, nil),
+		}))
+
+		if got.ID.ValueString() != "app-999" {
+			t.Errorf("ID: got %q, want %q", got.ID.ValueString(), "app-999")
+		}
+		if got.AllowAutoStopping.ValueBool() {
+			t.Errorf("AllowAutoStopping: got true, want false")
+		}
+	})
 }

--- a/pkg/provider/custom_application_resource_test.go
+++ b/pkg/provider/custom_application_resource_test.go
@@ -81,8 +81,6 @@ if __name__ == "__main__":
 					"",
 					1,
 					false,
-					[]string{},
-					false,
 					&useCaseResourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					compareValuesDiffer.AddStateValue(
@@ -97,19 +95,15 @@ if __name__ == "__main__":
 					resource.TestCheckResourceAttrSet(resourceName, "source_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_ids.0"),
 				),
 			},
-			// Update name, external access, and use case id
+			// Update name and use case id
 			{
 				Config: customApplicationResourceConfig(
 					newName,
 					1,
-					true,
-					[]string{"test@test.com"},
 					true,
 					&useCaseResourceName2),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -133,8 +127,6 @@ if __name__ == "__main__":
 					resource.TestCheckResourceAttrSet(resourceName, "source_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.0", "test@test.com"),
 					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "use_case_ids.0"),
 				),
@@ -144,8 +136,6 @@ if __name__ == "__main__":
 				Config: customApplicationResourceConfig(
 					newName,
 					2,
-					true,
-					[]string{"test2@test.com"},
 					true,
 					nil),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -165,26 +155,8 @@ if __name__ == "__main__":
 					resource.TestCheckResourceAttrSet(resourceName, "source_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.0", "test2@test.com"),
 					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "true"),
 					resource.TestCheckNoResourceAttr(resourceName, "use_case_ids.0"),
-				),
-			},
-			// Update without specifying external_access_recipients - they should be preserved
-			{
-				Config: customApplicationResourceConfig(
-					newName,
-					2,
-					true,
-					nil,
-					false,
-					nil),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkCustomApplicationResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "external_access_recipients.0", "test2@test.com"),
-					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "false"),
 				),
 			},
 			// Delete is tested automatically
@@ -195,18 +167,9 @@ if __name__ == "__main__":
 func customApplicationResourceConfig(
 	name string,
 	applicationSourceReplicas int,
-	externalAccess bool,
-	externalAccessRecipients []string,
 	allowAutoStopping bool,
 	useCaseResourceName *string,
 ) string {
-	recipients := ""
-	if len(externalAccessRecipients) > 0 {
-		recipients = fmt.Sprintf(`
-		external_access_recipients = %q
-		`, externalAccessRecipients)
-	}
-
 	nameStr := ""
 	if name != "" {
 		nameStr = fmt.Sprintf(`
@@ -237,13 +200,11 @@ resource "datarobot_application_source" "test" {
 
 resource "datarobot_custom_application" "test" {
 	source_version_id = "${datarobot_application_source.test.version_id}"
-	external_access_enabled = %t
 	allow_auto_stopping = %t
 	%s
 	%s
-	%s
 }
-`, nameSalt, nameSalt, applicationSourceReplicas, externalAccess, allowAutoStopping, recipients, nameStr, useCaseIDsStr)
+`, nameSalt, nameSalt, applicationSourceReplicas, allowAutoStopping, nameStr, useCaseIDsStr)
 }
 
 func checkCustomApplicationResourceExists() resource.TestCheckFunc {
@@ -280,16 +241,6 @@ func checkCustomApplicationResourceExists() resource.TestCheckFunc {
 				}
 			}
 
-			b, err = strconv.ParseBool(rs.Primary.Attributes["external_access_enabled"])
-			if err == nil {
-				if application.ExternalAccessEnabled == b {
-					if len(application.ExternalAccessRecipients) > 0 {
-						if application.ExternalAccessRecipients[0] != rs.Primary.Attributes["external_access_recipients.0"] {
-							return fmt.Errorf("ExternalAccessRecipient is %s but should be %s", application.ExternalAccessRecipients[0], rs.Primary.Attributes["external_access_recipients.0"])
-						}
-					}
-				}
-			}
 			return nil
 		}
 
@@ -396,7 +347,6 @@ numpy
 					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
 					resource.TestCheckResourceAttr(resourceName, "name", "Batch Files Test Custom Application "+testUniqueID),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "true"),
 
 					// Custom check to verify application is working
@@ -466,7 +416,6 @@ resource "datarobot_application_source" "batch_test" {
 resource "datarobot_custom_application" "batch_test" {
 	name = "Batch Files Test Custom Application %s"
 	source_version_id = datarobot_application_source.batch_test.version_id
-	external_access_enabled = false
 	allow_auto_stopping = true
 }
 `, nameSalt, baseEnvironmentID, folderPath, nameSalt)
@@ -610,7 +559,6 @@ numpy
 					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_url"),
 					resource.TestCheckResourceAttr(resourceName, "name", "Real-World Batch Files Custom App "+nameSalt),
-					resource.TestCheckResourceAttr(resourceName, "external_access_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "allow_auto_stopping", "true"),
 
 					// Custom validation to ensure the application was created successfully
@@ -712,7 +660,6 @@ resource "datarobot_application_source" "real_batch_test" {
 resource "datarobot_custom_application" "real_batch_test" {
 	name = "Real-World Batch Files Custom App %s"
 	source_version_id = datarobot_application_source.real_batch_test.version_id
-	external_access_enabled = false
 	allow_auto_stopping = true
 }
 `, nameSalt, baseEnvironmentID, folderPath, nameSalt)
@@ -805,7 +752,6 @@ resource "datarobot_application_source" "test" {
 resource "datarobot_custom_application" "test" {
 	name = "Resources Test App %s"
 	source_version_id = datarobot_application_source.test.version_id
-	external_access_enabled = false
 	allow_auto_stopping = true
 }
 `, nameSalt, folderPath, nameSalt)

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -687,15 +687,13 @@ type DREntity struct {
 // QAApplicationResourceModel describes the Q&A application resource.
 
 type QAApplicationResourceModel struct {
-	ID                       types.String `tfsdk:"id"`
-	SourceID                 types.String `tfsdk:"source_id"`
-	SourceVersionID          types.String `tfsdk:"source_version_id"`
-	Name                     types.String `tfsdk:"name"`
-	DeploymentID             types.String `tfsdk:"deployment_id"`
-	ApplicationUrl           types.String `tfsdk:"application_url"`
-	ExternalAccessEnabled    types.Bool   `tfsdk:"external_access_enabled"`
-	ExternalAccessRecipients types.List   `tfsdk:"external_access_recipients"`
-	AllowAutoStopping        types.Bool   `tfsdk:"allow_auto_stopping"`
+	ID                types.String `tfsdk:"id"`
+	SourceID          types.String `tfsdk:"source_id"`
+	SourceVersionID   types.String `tfsdk:"source_version_id"`
+	Name              types.String `tfsdk:"name"`
+	DeploymentID      types.String `tfsdk:"deployment_id"`
+	ApplicationUrl    types.String `tfsdk:"application_url"`
+	AllowAutoStopping types.Bool   `tfsdk:"allow_auto_stopping"`
 }
 
 type ApplicationSourceResourceModel struct {
@@ -729,31 +727,27 @@ type ApplicationSourceFromTemplateResourceModel struct {
 }
 
 type CustomApplicationResourceModel struct {
-	ID                       types.String          `tfsdk:"id"`
-	SourceID                 types.String          `tfsdk:"source_id"`
-	SourceVersionID          types.String          `tfsdk:"source_version_id"`
-	Name                     types.String          `tfsdk:"name"`
-	ApplicationUrl           types.String          `tfsdk:"application_url"`
-	ExternalAccessEnabled    types.Bool            `tfsdk:"external_access_enabled"`
-	ExternalAccessRecipients types.List            `tfsdk:"external_access_recipients"`
-	AllowAutoStopping        types.Bool            `tfsdk:"allow_auto_stopping"`
-	Resources                basetypes.ObjectValue `tfsdk:"resources"`
-	UseCaseIDs               []types.String        `tfsdk:"use_case_ids"`
-	RequiredKeyScopeLevel    types.String          `tfsdk:"required_key_scope_level"`
+	ID                    types.String          `tfsdk:"id"`
+	SourceID              types.String          `tfsdk:"source_id"`
+	SourceVersionID       types.String          `tfsdk:"source_version_id"`
+	Name                  types.String          `tfsdk:"name"`
+	ApplicationUrl        types.String          `tfsdk:"application_url"`
+	AllowAutoStopping     types.Bool            `tfsdk:"allow_auto_stopping"`
+	Resources             basetypes.ObjectValue `tfsdk:"resources"`
+	UseCaseIDs            []types.String        `tfsdk:"use_case_ids"`
+	RequiredKeyScopeLevel types.String          `tfsdk:"required_key_scope_level"`
 }
 
 type CustomApplicationFromEnvironmentResourceModel struct {
-	ID                       types.String          `tfsdk:"id"`
-	EnvironmentID            types.String          `tfsdk:"environment_id"`
-	EnvironmentVersionID     types.String          `tfsdk:"environment_version_id"`
-	Name                     types.String          `tfsdk:"name"`
-	ApplicationUrl           types.String          `tfsdk:"application_url"`
-	ExternalAccessEnabled    types.Bool            `tfsdk:"external_access_enabled"`
-	ExternalAccessRecipients types.List            `tfsdk:"external_access_recipients"`
-	AllowAutoStopping        types.Bool            `tfsdk:"allow_auto_stopping"`
-	Resources                basetypes.ObjectValue `tfsdk:"resources"`
-	UseCaseIDs               []types.String        `tfsdk:"use_case_ids"`
-	RequiredKeyScopeLevel    types.String          `tfsdk:"required_key_scope_level"`
+	ID                    types.String          `tfsdk:"id"`
+	EnvironmentID         types.String          `tfsdk:"environment_id"`
+	EnvironmentVersionID  types.String          `tfsdk:"environment_version_id"`
+	Name                  types.String          `tfsdk:"name"`
+	ApplicationUrl        types.String          `tfsdk:"application_url"`
+	AllowAutoStopping     types.Bool            `tfsdk:"allow_auto_stopping"`
+	Resources             basetypes.ObjectValue `tfsdk:"resources"`
+	UseCaseIDs            []types.String        `tfsdk:"use_case_ids"`
+	RequiredKeyScopeLevel types.String          `tfsdk:"required_key_scope_level"`
 }
 
 // CredentialResourceModel describes the credential resource.

--- a/pkg/provider/qa_application_resource.go
+++ b/pkg/provider/qa_application_resource.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -78,23 +76,6 @@ func (r *QAApplicationResource) Schema(ctx context.Context, req resource.SchemaR
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"external_access_enabled": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "Whether external access is enabled for the Q&A Application.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"external_access_recipients": schema.ListAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "The list of external email addresses that have access to the Q&A Application.",
-				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"allow_auto_stopping": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -137,22 +118,12 @@ func (r *QAApplicationResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	recipients := []string{}
-	if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-		if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
 	traceAPICall("UpdateApplication")
 	_, err = r.provider.service.UpdateApplication(ctx,
 		createResp.ID,
 		&client.UpdateApplicationRequest{
-			Name:                     data.Name.ValueString(),
-			ExternalAccessEnabled:    IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool(),
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
+			Name:              data.Name.ValueString(),
+			AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
 		})
 	if err != nil {
 		if errors.Is(err, &client.NotFoundError{}) {
@@ -176,13 +147,6 @@ func (r *QAApplicationResource) Create(ctx context.Context, req resource.CreateR
 	data.SourceID = types.StringValue(application.CustomApplicationSourceID)
 	data.SourceVersionID = types.StringValue(application.CustomApplicationSourceVersionID)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.ExternalAccessRecipients = recipientsList
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
@@ -216,13 +180,6 @@ func (r *QAApplicationResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	data.Name = types.StringValue(application.Name)
 	data.ApplicationUrl = types.StringValue(application.ApplicationUrl)
-	data.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
-	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.ExternalAccessRecipients = recipientsList
 	data.AllowAutoStopping = types.BoolValue(application.AllowAutoStopping)
 	data.SourceID = types.StringValue(application.CustomApplicationSourceID)
 	data.SourceVersionID = types.StringValue(application.CustomApplicationSourceVersionID)
@@ -272,18 +229,8 @@ func (r *QAApplicationResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary
Removed fields related to external sharing for preventing overriding user setting during application patch.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking schema change for users who configured `external_access_*`, and correctness depends on the new state upgrader preventing unexpected diffs or apply failures during upgrades.
> 
> **Overview**
> **Removes external sharing configuration from Terraform resources for Custom Apps.** The `external_access_enabled` and `external_access_recipients` attributes are dropped from `datarobot_custom_application`, `datarobot_custom_application_from_environment`, and `datarobot_qa_application`, including provider schemas, API request/response mapping (`Application`/`UpdateApplicationRequest`), and create/update logic so these values are no longer sent or read.
> 
> Docs and examples are updated to remove the fields, and acceptance/unit tests are adjusted to stop asserting or configuring them. `datarobot_custom_application` now declares schema `Version: 1` and adds a `ResourceWithUpgradeState` upgrader to migrate v0 state by discarding the removed `external_access_*` fields while preserving the remaining attributes; a dedicated test validates the upgrade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138a1ad8941f52fd7a9b618039b1a3376165cc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->