### PR TITLE
[APP-5754] Fix external sharing for good

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Added
 - `datarobot_artifact` & `datarobot_workload` resources are added. It creates Artifact objects in Workload API.
 
+## [0.10.35] - 2026-04-30
+
+### Fixed
+
+- Fixed external sharing settings being stripped on `CustomApplicationSource`/`CustomApplication` updates even better
+
 ## [0.10.34] - 2026-04-20
 
 ### Fixed

--- a/internal/client/application_service.go
+++ b/internal/client/application_service.go
@@ -88,8 +88,8 @@ type Application struct {
 type UpdateApplicationRequest struct {
 	Name                             string     `json:"name,omitempty"`
 	CustomApplicationSourceVersionID string     `json:"customApplicationSourceVersionId,omitempty"`
-	ExternalAccessEnabled            bool       `json:"externalAccessEnabled"`
-	ExternalAccessRecipients         []string   `json:"externalAccessRecipients"`
+	ExternalAccessEnabled            *bool      `json:"externalAccessEnabled,omitempty"`
+	ExternalAccessRecipients         *[]string  `json:"externalAccessRecipients,omitempty"`
 	AllowAutoStopping                bool       `json:"allowAutoStopping"`
 	RequiredKeyScopeLevel            ScopeLevel `json:"requiredKeyScopeLevel,omitempty"`
 }

--- a/pkg/provider/custom_application_from_environment_resource.go
+++ b/pkg/provider/custom_application_from_environment_resource.go
@@ -193,27 +193,30 @@ func (r *CustomApplicationFromEnvironmentResource) Create(ctx context.Context, r
 		return
 	}
 
-	enableExternalAccess := IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool()
+	updateRequest := &client.UpdateApplicationRequest{
+		AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
+	}
+	needsUpdate := IsKnown(data.Name) || !data.AllowAutoStopping.ValueBool()
 
-	if IsKnown(data.Name) || enableExternalAccess || !data.AllowAutoStopping.ValueBool() {
-		recipients := []string{}
-		if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-			if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-				resp.Diagnostics.Append(diags...)
-				return
-			}
+	if IsKnown(data.Name) {
+		updateRequest.Name = data.Name.ValueString()
+	}
+	if !data.ExternalAccessEnabled.IsNull() && !data.ExternalAccessEnabled.IsUnknown() {
+		v := data.ExternalAccessEnabled.ValueBool()
+		updateRequest.ExternalAccessEnabled = &v
+		needsUpdate = true
+	}
+	if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
+		r := []string{}
+		if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
 		}
+		updateRequest.ExternalAccessRecipients = &r
+		needsUpdate = true
+	}
 
-		updateRequest := &client.UpdateApplicationRequest{
-			ExternalAccessEnabled:    enableExternalAccess,
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
-		}
-
-		if IsKnown(data.Name) {
-			updateRequest.Name = data.Name.ValueString()
-		}
-
+	if needsUpdate {
 		traceAPICall("UpdateCustomApplication")
 		_, err = r.provider.service.UpdateApplication(ctx, application.ID, updateRequest)
 		if err != nil {
@@ -329,34 +332,30 @@ func (r *CustomApplicationFromEnvironmentResource) Update(ctx context.Context, r
 		return
 	}
 
-	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
-	effectiveRecipients := plan.ExternalAccessRecipients
-	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
-		effectiveRecipients = state.ExternalAccessRecipients
-	}
-	recipients := []string{}
-	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
-		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
-	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
-	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
-		if IsKnown(state.ExternalAccessEnabled) {
-			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
-		}
+	var config CustomApplicationFromEnvironmentResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    externalAccessEnabled,
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {
 		updateRequest.Name = plan.Name.ValueString()
+	}
+	if !config.ExternalAccessEnabled.IsNull() && !config.ExternalAccessEnabled.IsUnknown() {
+		v := config.ExternalAccessEnabled.ValueBool()
+		updateRequest.ExternalAccessEnabled = &v
+	}
+	if !config.ExternalAccessRecipients.IsNull() && !config.ExternalAccessRecipients.IsUnknown() {
+		r := []string{}
+		if diags := config.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		updateRequest.ExternalAccessRecipients = &r
 	}
 
 	traceAPICall("UpdateCustomApplication")

--- a/pkg/provider/custom_application_from_environment_resource.go
+++ b/pkg/provider/custom_application_from_environment_resource.go
@@ -329,16 +329,28 @@ func (r *CustomApplicationFromEnvironmentResource) Update(ctx context.Context, r
 		return
 	}
 
+	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
+	effectiveRecipients := plan.ExternalAccessRecipients
+	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
+		effectiveRecipients = state.ExternalAccessRecipients
+	}
 	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
+	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
+		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
 	}
 
+	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
+	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
+		if IsKnown(state.ExternalAccessEnabled) {
+			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
+		}
+	}
+
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
+		ExternalAccessEnabled:    externalAccessEnabled,
 		ExternalAccessRecipients: recipients,
 		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
 	}
@@ -369,6 +381,14 @@ func (r *CustomApplicationFromEnvironmentResource) Update(ctx context.Context, r
 		resp.Diagnostics.AddError("Custom Application is not ready", err.Error())
 		return
 	}
+
+	plan.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
+	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ExternalAccessRecipients = recipientsList
 
 	// Populate resources from API response (field is Computed).
 	if application.Resources != nil {

--- a/pkg/provider/custom_application_resource.go
+++ b/pkg/provider/custom_application_resource.go
@@ -209,27 +209,30 @@ func (r *CustomApplicationResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	enableExternalAccess := IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool()
+	updateRequest := &client.UpdateApplicationRequest{
+		AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
+	}
+	needsUpdate := IsKnown(data.Name) || !data.AllowAutoStopping.ValueBool()
 
-	if IsKnown(data.Name) || enableExternalAccess || !data.AllowAutoStopping.ValueBool() {
-		recipients := []string{}
-		if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-			if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-				resp.Diagnostics.Append(diags...)
-				return
-			}
+	if IsKnown(data.Name) {
+		updateRequest.Name = data.Name.ValueString()
+	}
+	if !data.ExternalAccessEnabled.IsNull() && !data.ExternalAccessEnabled.IsUnknown() {
+		v := data.ExternalAccessEnabled.ValueBool()
+		updateRequest.ExternalAccessEnabled = &v
+		needsUpdate = true
+	}
+	if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
+		r := []string{}
+		if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
 		}
+		updateRequest.ExternalAccessRecipients = &r
+		needsUpdate = true
+	}
 
-		updateRequest := &client.UpdateApplicationRequest{
-			ExternalAccessEnabled:    enableExternalAccess,
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
-		}
-
-		if IsKnown(data.Name) {
-			updateRequest.Name = data.Name.ValueString()
-		}
-
+	if needsUpdate {
 		traceAPICall("UpdateCustomApplication")
 		_, err = r.provider.service.UpdateApplication(ctx, application.ID, updateRequest)
 		if err != nil {
@@ -352,30 +355,29 @@ func (r *CustomApplicationResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
-	effectiveRecipients := plan.ExternalAccessRecipients
-	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
-		effectiveRecipients = state.ExternalAccessRecipients
-	}
-	recipients := []string{}
-	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
-		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
-	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
-	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
-		if IsKnown(state.ExternalAccessEnabled) {
-			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
-		}
+	// Read config (what the user explicitly wrote) to avoid treating prior-state
+	// values that bled into the plan as intentional user configuration.
+	var config CustomApplicationResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    externalAccessEnabled,
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
+	}
+
+	if !config.ExternalAccessEnabled.IsNull() && !config.ExternalAccessEnabled.IsUnknown() {
+		v := config.ExternalAccessEnabled.ValueBool()
+		updateRequest.ExternalAccessEnabled = &v
+	}
+	if !config.ExternalAccessRecipients.IsNull() && !config.ExternalAccessRecipients.IsUnknown() {
+		r := []string{}
+		if diags := config.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		updateRequest.ExternalAccessRecipients = &r
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {

--- a/pkg/provider/custom_application_resource.go
+++ b/pkg/provider/custom_application_resource.go
@@ -352,16 +352,28 @@ func (r *CustomApplicationResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
+	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
+	effectiveRecipients := plan.ExternalAccessRecipients
+	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
+		effectiveRecipients = state.ExternalAccessRecipients
+	}
 	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
+	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
+		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
 	}
 
+	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
+	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
+		if IsKnown(state.ExternalAccessEnabled) {
+			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
+		}
+	}
+
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
+		ExternalAccessEnabled:    externalAccessEnabled,
 		ExternalAccessRecipients: recipients,
 		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
 	}
@@ -404,6 +416,13 @@ func (r *CustomApplicationResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 	plan.SourceID = types.StringValue(application.CustomApplicationSourceID)
+	plan.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
+	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ExternalAccessRecipients = recipientsList
 
 	// Don't read required_key_scope_level from API - keep user-configured value
 	// (field is Optional, not Computed)

--- a/pkg/provider/qa_application_resource.go
+++ b/pkg/provider/qa_application_resource.go
@@ -272,16 +272,28 @@ func (r *QAApplicationResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
+	effectiveRecipients := plan.ExternalAccessRecipients
+	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
+		effectiveRecipients = state.ExternalAccessRecipients
+	}
 	recipients := []string{}
-	if !plan.ExternalAccessRecipients.IsNull() && !plan.ExternalAccessRecipients.IsUnknown() {
-		if diags := plan.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
+	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
+		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
 	}
 
+	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
+	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
+		if IsKnown(state.ExternalAccessEnabled) {
+			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
+		}
+	}
+
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool(),
+		ExternalAccessEnabled:    externalAccessEnabled,
 		ExternalAccessRecipients: recipients,
 		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
 	}
@@ -307,11 +319,19 @@ func (r *QAApplicationResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	_, err = waitForApplicationToBeReady(ctx, r.provider.service, plan.ID.ValueString())
+	application, err := waitForApplicationToBeReady(ctx, r.provider.service, plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Application not ready", err.Error())
 		return
 	}
+
+	plan.ExternalAccessEnabled = types.BoolValue(application.ExternalAccessEnabled)
+	recipientsList, diags := types.ListValueFrom(ctx, types.StringType, application.ExternalAccessRecipients)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ExternalAccessRecipients = recipientsList
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }

--- a/pkg/provider/qa_application_resource.go
+++ b/pkg/provider/qa_application_resource.go
@@ -137,23 +137,27 @@ func (r *QAApplicationResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	recipients := []string{}
+	createUpdateRequest := &client.UpdateApplicationRequest{
+		Name:              data.Name.ValueString(),
+		AllowAutoStopping: data.AllowAutoStopping.ValueBool(),
+	}
+	if !data.ExternalAccessEnabled.IsNull() && !data.ExternalAccessEnabled.IsUnknown() {
+		v := data.ExternalAccessEnabled.ValueBool()
+		createUpdateRequest.ExternalAccessEnabled = &v
+	}
 	if !data.ExternalAccessRecipients.IsNull() && !data.ExternalAccessRecipients.IsUnknown() {
-		if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
+		r := []string{}
+		if diags := data.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
+		createUpdateRequest.ExternalAccessRecipients = &r
 	}
 
 	traceAPICall("UpdateApplication")
 	_, err = r.provider.service.UpdateApplication(ctx,
 		createResp.ID,
-		&client.UpdateApplicationRequest{
-			Name:                     data.Name.ValueString(),
-			ExternalAccessEnabled:    IsKnown(data.ExternalAccessEnabled) && data.ExternalAccessEnabled.ValueBool(),
-			ExternalAccessRecipients: recipients,
-			AllowAutoStopping:        data.AllowAutoStopping.ValueBool(),
-		})
+		createUpdateRequest)
 	if err != nil {
 		if errors.Is(err, &client.NotFoundError{}) {
 			resp.Diagnostics.AddWarning(
@@ -272,34 +276,30 @@ func (r *QAApplicationResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	// When plan is null/unknown (user didn't set the field), fall back to state to preserve the existing value.
-	effectiveRecipients := plan.ExternalAccessRecipients
-	if effectiveRecipients.IsNull() || effectiveRecipients.IsUnknown() {
-		effectiveRecipients = state.ExternalAccessRecipients
-	}
-	recipients := []string{}
-	if !effectiveRecipients.IsNull() && !effectiveRecipients.IsUnknown() {
-		if diags := effectiveRecipients.ElementsAs(ctx, &recipients, false); diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-	}
-
-	externalAccessEnabled := IsKnown(plan.ExternalAccessEnabled) && plan.ExternalAccessEnabled.ValueBool()
-	if plan.ExternalAccessEnabled.IsNull() || plan.ExternalAccessEnabled.IsUnknown() {
-		if IsKnown(state.ExternalAccessEnabled) {
-			externalAccessEnabled = state.ExternalAccessEnabled.ValueBool()
-		}
+	var config QAApplicationResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	updateRequest := &client.UpdateApplicationRequest{
-		ExternalAccessEnabled:    externalAccessEnabled,
-		ExternalAccessRecipients: recipients,
-		AllowAutoStopping:        plan.AllowAutoStopping.ValueBool(),
+		AllowAutoStopping: plan.AllowAutoStopping.ValueBool(),
 	}
 
 	if state.Name.ValueString() != plan.Name.ValueString() {
 		updateRequest.Name = plan.Name.ValueString()
+	}
+	if !config.ExternalAccessEnabled.IsNull() && !config.ExternalAccessEnabled.IsUnknown() {
+		v := config.ExternalAccessEnabled.ValueBool()
+		updateRequest.ExternalAccessEnabled = &v
+	}
+	if !config.ExternalAccessRecipients.IsNull() && !config.ExternalAccessRecipients.IsUnknown() {
+		r := []string{}
+		if diags := config.ExternalAccessRecipients.ElementsAs(ctx, &r, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		updateRequest.ExternalAccessRecipients = &r
 	}
 
 	traceAPICall("UpdateApplication")


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary

Fixes Terraform update behavior for CustomApplication, CustomApplicationFromEnvironment, and QAApplication so external sharing settings are preserved when external_access_enabled/external_access_recipients are null/unknown in the plan (i.e., not explicitly set).

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PATCH request construction for multiple application resources to avoid unintentionally clearing external sharing settings when attributes are unset, which could alter update behavior and state reconciliation. Risk is moderate due to behavior changes in resource Update/Create flows but is limited to application external access fields.
> 
> **Overview**
> Fixes Terraform provider update behavior so **external sharing settings are no longer unintentionally stripped** when `external_access_enabled` / `external_access_recipients` are omitted (null/unknown).
> 
> This makes `UpdateApplicationRequest` treat external sharing fields as optional by switching them to pointer types and only sending them in PATCH requests when explicitly set in config (not when values bleed from state into the plan). After updates, resources now refresh `external_access_*` in state from the API response.
> 
> Updates apply across `custom_application`, `custom_application_from_environment`, and `qa_application`, and the changelog adds release note `0.10.35` documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4a738b46929d7605fe88af90a2d7c6cf3d0d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->