### PR TITLE
chore: update changelog and version about release 0.10.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-## Unreleased
+## [0.10.35] - 2026-05-11
 
 ### Added
-- `datarobot_artifact` & `datarobot_workload` resources are added. It creates Artifact objects in Workload API.
 
-## [0.10.35] - 2026-04-30
+- `datarobot_artifact` & `datarobot_workload` resources are added. It creates Artifact objects in Workload API.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.10.33
+VERSION=0.10.35
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-prep change: only updates `CHANGELOG.md` and bumps the Makefile `VERSION` used for build/install artifacts.
> 
> **Overview**
> Prepares the `0.10.35` release by updating `CHANGELOG.md` (new release date and moving the entry for the new `datarobot_artifact`/`datarobot_workload` resources into the `0.10.35` section).
> 
> Bumps the Makefile `VERSION` from `0.10.33` to `0.10.35` so generated binaries and local install paths use the new release version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b186d3d5a6c6ea34117292af34f8ec841b9f7f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->