### PR TITLE
[FLEET-5577] Fix memory service feature flag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- `datarobot_memory_space` now checks the correct feature flag name `ENABLE_AGENTIC_MEMORY_API` (previously checked `AGENTIC_MEMORY_API`, which always evaluated to disabled even on accounts where Memory Spaces were enabled).
+
 ## [0.10.35] - 2026-05-11
 
 ### Added

--- a/docs/resources/memory_space.md
+++ b/docs/resources/memory_space.md
@@ -3,12 +3,12 @@
 page_title: "datarobot_memory_space Resource - datarobot"
 subcategory: ""
 description: |-
-  Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with AGENTIC_MEMORY_API flag.
+  Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with ENABLE_AGENTIC_MEMORY_API flag.
 ---
 
 # datarobot_memory_space (Resource)
 
-Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with `AGENTIC_MEMORY_API` flag.
+Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with `ENABLE_AGENTIC_MEMORY_API` flag.
 
 ## Example Usage
 

--- a/pkg/provider/memory_space_resource.go
+++ b/pkg/provider/memory_space_resource.go
@@ -31,7 +31,7 @@ func (r *MemorySpaceResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *MemorySpaceResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with `AGENTIC_MEMORY_API` flag.",
+		MarkdownDescription: "Memory Space is a DataRobot concept that serves as a logical container for Chat Histories (Sessions) and persistent Memories. Feature should be enabled before use with `ENABLE_AGENTIC_MEMORY_API` flag.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -71,7 +71,7 @@ func (r *MemorySpaceResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	enabled, err := r.provider.service.IsFeatureFlagEnabled(ctx, "AGENTIC_MEMORY_API")
+	enabled, err := r.provider.service.IsFeatureFlagEnabled(ctx, "ENABLE_AGENTIC_MEMORY_API")
 	if err != nil {
 		resp.Diagnostics.AddError("Error checking feature flag", err.Error())
 		return
@@ -79,7 +79,7 @@ func (r *MemorySpaceResource) Create(ctx context.Context, req resource.CreateReq
 	if !enabled {
 		resp.Diagnostics.AddError(
 			"Feature not enabled",
-			"The AGENTIC_MEMORY_API feature flag is not enabled. Please enable it in your DataRobot account settings to use Memory Spaces.",
+			"The ENABLE_AGENTIC_MEMORY_API feature flag is not enabled. Please enable it in your DataRobot account settings to use Memory Spaces.",
 		)
 		return
 	}

--- a/pkg/provider/memory_space_resource_test.go
+++ b/pkg/provider/memory_space_resource_test.go
@@ -37,7 +37,7 @@ func TestIntegrationMemorySpaceResource(t *testing.T) {
 	newDescription := "new_" + description
 
 	// Create
-	mockService.EXPECT().IsFeatureFlagEnabled(gomock.Any(), "AGENTIC_MEMORY_API").Return(true, nil)
+	mockService.EXPECT().IsFeatureFlagEnabled(gomock.Any(), "ENABLE_AGENTIC_MEMORY_API").Return(true, nil)
 	mockService.EXPECT().CreateMemorySpace(gomock.Any(), &client.MemorySpaceRequest{
 		Description: &description,
 	}).Return(&client.MemorySpaceResponse{
@@ -111,7 +111,7 @@ func TestIntegrationMemorySpaceResourceFeatureFlagDisabled(t *testing.T) {
 		t.Setenv(DataRobotApiKeyEnvVar, "fake")
 	}
 
-	mockService.EXPECT().IsFeatureFlagEnabled(gomock.Any(), "AGENTIC_MEMORY_API").Return(false, nil)
+	mockService.EXPECT().IsFeatureFlagEnabled(gomock.Any(), "ENABLE_AGENTIC_MEMORY_API").Return(false, nil)
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               true,
@@ -119,7 +119,7 @@ func TestIntegrationMemorySpaceResourceFeatureFlagDisabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      memorySpaceResourceConfig("test-description"),
-				ExpectError: regexp.MustCompile("AGENTIC_MEMORY_API feature flag is not enabled"),
+				ExpectError: regexp.MustCompile("ENABLE_AGENTIC_MEMORY_API feature flag is not enabled"),
 			},
 		},
 	})
@@ -129,7 +129,7 @@ func testMemorySpaceResource(t *testing.T, description string, isMock bool) {
 	resourceName := "datarobot_memory_space.test"
 	var preCheck func()
 	if !isMock {
-		preCheck = func() { testAccFeatureFlagPreCheck(t, "AGENTIC_MEMORY_API") }
+		preCheck = func() { testAccFeatureFlagPreCheck(t, "ENABLE_AGENTIC_MEMORY_API") }
 	}
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               isMock,


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary

DataRobot platform adds `ENABLE_` prefix to feature flag name. 

## Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact

When feature is not enabled for the user, they will get a correct message 

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: string/flag-name correction in `datarobot_memory_space` create precheck plus aligned docs/tests; behavior change is limited to gating and error messaging.
> 
> **Overview**
> Fixes `datarobot_memory_space` to gate creation on the correct feature flag name (`ENABLE_AGENTIC_MEMORY_API`), so accounts with Memory Spaces enabled no longer get blocked as if the feature were disabled.
> 
> Updates the resource’s schema description, user-facing error message, acceptance/unit tests, and `docs/resources/memory_space.md`, and adds a corresponding *Unreleased* changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b4012913e4cc1d8940c4d615112eb9ecf1ad32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->