### PR TITLE
[RAPTOR-17337] - align artifact and workload resources with updated Workload API schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## [Unreleased]
+
+### Fixed
+
+- dropped resource_request attribute from `datarobot_artifact` resource and added container groups to the `datarobot_workload`. Now resources are managed via resource_allocation for each container in the container_group in workload resources
+
 ## [0.10.36] - 2026-05-12
 
 ### Fixed
 
 - `datarobot_memory_space` now checks the correct feature flag name `ENABLE_AGENTIC_MEMORY_API` (previously checked `AGENTIC_MEMORY_API`, which always evaluated to disabled even on accounts where Memory Spaces were enabled)
-- dropped resource_request attribute from `datarobot_artifact` resource and added container groups to the `datarobot_workload`. Now resources are managed via resource_allocation for each container in the container_group in workload resources
 
 ## [0.10.35] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixed
 
-- `datarobot_memory_space` now checks the correct feature flag name `ENABLE_AGENTIC_MEMORY_API` (previously checked `AGENTIC_MEMORY_API`, which always evaluated to disabled even on accounts where Memory Spaces were enabled).
+- `datarobot_memory_space` now checks the correct feature flag name `ENABLE_AGENTIC_MEMORY_API` (previously checked `AGENTIC_MEMORY_API`, which always evaluated to disabled even on accounts where Memory Spaces were enabled)
+- dropped resource_request attribute from `datarobot_artifact` resource and added container groups to the `datarobot_workload`. Now resources are managed via resource_allocation for each container in the container_group in workload resources
 
 ## [0.10.35] - 2026-05-11
 

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -51,7 +51,6 @@ Required:
 Required:
 
 - `image_uri` (String) Docker image URI.
-- `resource_request` (Attributes) Resource requirements for the container. (see [below for nested schema](#nestedatt--spec--container_groups--containers--resource_request))
 
 Optional:
 
@@ -64,20 +63,6 @@ Optional:
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
-
-<a id="nestedatt--spec--container_groups--containers--resource_request"></a>
-### Nested Schema for `spec.container_groups.containers.resource_request`
-
-Required:
-
-- `cpu` (Number) Number of CPU cores required.
-- `memory` (Number) Memory required in bytes.
-
-Optional:
-
-- `gpu` (Number) Number of GPUs required.
-- `gpu_type` (String) GPU type required (e.g., NVIDIA-A100).
-
 
 <a id="nestedatt--spec--container_groups--containers--environment_vars"></a>
 ### Nested Schema for `spec.container_groups.containers.environment_vars`

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -50,23 +50,36 @@ lifecycle {
 
 Optional:
 
-- `autoscaling` (Attributes) Autoscaling configuration. When set, takes precedence over replica_count. (see [below for nested schema](#nestedatt--runtime--autoscaling))
-- `replica_count` (Number) Number of replicas to run. Cannot be used together with `autoscaling`. Omitting this field retains the current value. Set to `0` to explicitly clear it (e.g. when switching to autoscaling).
-- `resources` (Attributes List) Resource bundles assigned to the Workload. When empty the server infers an appropriate bundle. (see [below for nested schema](#nestedatt--runtime--resources))
+- `container_groups` (Attributes List) Per-group runtime configuration. (see [below for nested schema](#nestedatt--runtime--container_groups))
 
-<a id="nestedatt--runtime--autoscaling"></a>
-### Nested Schema for `runtime.autoscaling`
+<a id="nestedatt--runtime--container_groups"></a>
+### Nested Schema for `runtime.container_groups`
+
+Optional:
+
+- `autoscaling` (Attributes) Autoscaling configuration. When set, takes precedence over `replica_count`. (see [below for nested schema](#nestedatt--runtime--container_groups--autoscaling))
+- `bundle_selection_policy` (String) How to select among `resource_bundles`. Defaults to `availability`.
+- `containers` (Attributes List) Per-container resource allocation overrides. (see [below for nested schema](#nestedatt--runtime--container_groups--containers))
+- `replica_count` (Number) Number of replicas. Cannot be set alongside `autoscaling.enabled=true`. Set to `0` to explicitly clear it.
+- `resource_bundles` (List of String) Ordered list of resource bundle IDs. One is selected at scheduling time.
+
+Read-Only:
+
+- `name` (String) Container group name (server-assigned, always `default`).
+
+<a id="nestedatt--runtime--container_groups--autoscaling"></a>
+### Nested Schema for `runtime.container_groups.autoscaling`
 
 Required:
 
-- `policies` (Attributes List) Scaling policies that define when and how to scale. (see [below for nested schema](#nestedatt--runtime--autoscaling--policies))
+- `policies` (Attributes List) Scaling policies that define when and how to scale. (see [below for nested schema](#nestedatt--runtime--container_groups--autoscaling--policies))
 
 Optional:
 
 - `enabled` (Boolean) Whether autoscaling is enabled. Defaults to true.
 
-<a id="nestedatt--runtime--autoscaling--policies"></a>
-### Nested Schema for `runtime.autoscaling.policies`
+<a id="nestedatt--runtime--container_groups--autoscaling--policies"></a>
+### Nested Schema for `runtime.container_groups.autoscaling.policies`
 
 Required:
 
@@ -81,9 +94,23 @@ Optional:
 
 
 
-<a id="nestedatt--runtime--resources"></a>
-### Nested Schema for `runtime.resources`
+<a id="nestedatt--runtime--container_groups--containers"></a>
+### Nested Schema for `runtime.container_groups.containers`
 
 Required:
 
-- `resource_bundle_id` (String) ID of the resource bundle (e.g. `cpu.nano`).
+- `name` (String) Container name. Must match a container declared in the artifact group.
+
+Optional:
+
+- `resource_allocation` (Attributes) Resource allocation for this container. (see [below for nested schema](#nestedatt--runtime--container_groups--containers--resource_allocation))
+
+<a id="nestedatt--runtime--container_groups--containers--resource_allocation"></a>
+### Nested Schema for `runtime.container_groups.containers.resource_allocation`
+
+Optional:
+
+- `cpu` (Number) CPU cores allocated to this container.
+- `gpu` (Number) GPUs allocated to this container.
+- `gpu_memory` (Number) GPU VRAM allocated in bytes.
+- `memory` (Number) RAM allocated in bytes.

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -36,8 +36,8 @@ type AutoscalingProperties struct {
 type ResourceAllocation struct {
 	CPU       *float64 `json:"cpu,omitempty"`
 	GPU       *float64 `json:"gpu,omitempty"`
-	GPUMemory *string  `json:"gpuMemory,omitempty"`
-	Memory    *string  `json:"memory,omitempty"`
+	GPUMemory *int64   `json:"gpuMemory,omitempty"`
+	Memory    *int64   `json:"memory,omitempty"`
 }
 
 type ContainerOverride struct {

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -141,8 +141,8 @@ type ArtifactContainer struct {
 }
 
 type ArtifactContainerGroup struct {
-	Name       string               `json:"name,omitempty"`
-	Containers []ArtifactContainer  `json:"containers"`
+	Name       string              `json:"name,omitempty"`
+	Containers []ArtifactContainer `json:"containers"`
 }
 
 type ArtifactSpec struct {

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -33,15 +33,29 @@ type AutoscalingProperties struct {
 	Policies []AutoscalingPolicy `json:"policies"`
 }
 
-type ResourceBundleResources struct {
-	Type             string `json:"type"`
-	ResourceBundleID string `json:"resourceBundleId"`
+type ResourceAllocation struct {
+	CPU       *float64 `json:"cpu,omitempty"`
+	GPU       *float64 `json:"gpu,omitempty"`
+	GPUMemory *string  `json:"gpuMemory,omitempty"`
+	Memory    *string  `json:"memory,omitempty"`
 }
 
-type ProtonRuntime struct {
-	ReplicaCount *int64                    `json:"replicaCount,omitempty"`
-	Autoscaling  *AutoscalingProperties    `json:"autoscaling,omitempty"`
-	Resources    []ResourceBundleResources `json:"resources,omitempty"`
+type ContainerOverride struct {
+	Name               string              `json:"name"`
+	ResourceAllocation *ResourceAllocation `json:"resourceAllocation,omitempty"`
+}
+
+type GroupRuntime struct {
+	Name                  string                 `json:"name,omitempty"`
+	Containers            []ContainerOverride    `json:"containers,omitempty"`
+	Autoscaling           *AutoscalingProperties `json:"autoscaling,omitempty"`
+	BundleSelectionPolicy *string                `json:"bundleSelectionPolicy,omitempty"`
+	ReplicaCount          *int64                 `json:"replicaCount,omitempty"`
+	ResourceBundles       []string               `json:"resourceBundles,omitempty"`
+}
+
+type WorkloadRuntime struct {
+	ContainerGroups []GroupRuntime `json:"containerGroups,omitempty"`
 }
 
 type Workload struct {
@@ -52,12 +66,12 @@ type Workload struct {
 	Importance  WorkloadImportance `json:"importance"`
 	ArtifactID  *string            `json:"artifactId"`
 	Endpoint    *string            `json:"endpoint"`
-	Runtime     ProtonRuntime      `json:"runtime"`
+	Runtime     WorkloadRuntime    `json:"runtime"`
 }
 
 type CreateWorkloadRequest struct {
 	Name        string             `json:"name"`
-	Runtime     ProtonRuntime      `json:"runtime"`
+	Runtime     WorkloadRuntime    `json:"runtime"`
 	ArtifactID  *string            `json:"artifactId,omitempty"`
 	Description string             `json:"description,omitempty"`
 	Importance  WorkloadImportance `json:"importance,omitempty"`
@@ -113,13 +127,6 @@ type ArtifactProbeConfig struct {
 	FailureThreshold    *int64            `json:"failureThreshold,omitempty"`
 }
 
-type ArtifactResourceRequest struct {
-	CPU     int64   `json:"cpu"`
-	Memory  int64   `json:"memory"`
-	GPU     *int64  `json:"gpu,omitempty"`
-	GPUType *string `json:"gpuType,omitempty"`
-}
-
 type ArtifactContainer struct {
 	Name            *string                       `json:"name,omitempty"`
 	ImageURI        string                        `json:"imageUri"`
@@ -128,14 +135,14 @@ type ArtifactContainer struct {
 	Port            *int64                        `json:"port,omitempty"`
 	Entrypoint      []string                      `json:"entrypoint,omitempty"`
 	EnvironmentVars []ArtifactEnvironmentVariable `json:"environmentVars,omitempty"`
-	ResourceRequest ArtifactResourceRequest       `json:"resourceRequest"`
 	StartupProbe    *ArtifactProbeConfig          `json:"startupProbe,omitempty"`
 	ReadinessProbe  *ArtifactProbeConfig          `json:"readinessProbe,omitempty"`
 	LivenessProbe   *ArtifactProbeConfig          `json:"livenessProbe,omitempty"`
 }
 
 type ArtifactContainerGroup struct {
-	Containers []ArtifactContainer `json:"containers"`
+	Name       string               `json:"name,omitempty"`
+	Containers []ArtifactContainer  `json:"containers"`
 }
 
 type ArtifactSpec struct {

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -466,7 +466,13 @@ func (r *ArtifactResource) ValidateConfig(ctx context.Context, req resource.Vali
 	if resp.Diagnostics.HasError() || data.Spec == nil {
 		return
 	}
-	if len(data.Spec.ContainerGroups) > 1 {
+	if len(data.Spec.ContainerGroups) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("spec").AtName("container_groups"),
+			"Missing container groups",
+			"At least one container group must be defined in the artifact spec.",
+		)
+	} else if len(data.Spec.ContainerGroups) > 1 {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("spec").AtName("container_groups"),
 			"Too many container groups",

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -20,6 +20,7 @@ import (
 var _ resource.Resource = &ArtifactResource{}
 var _ resource.ResourceWithImportState = &ArtifactResource{}
 var _ resource.ResourceWithModifyPlan = &ArtifactResource{}
+var _ resource.ResourceWithValidateConfig = &ArtifactResource{}
 
 func NewArtifactResource() resource.Resource {
 	return &ArtifactResource{}
@@ -204,28 +205,6 @@ func (r *ArtifactResource) Schema(ctx context.Context, req resource.SchemaReques
 															Required:            true,
 															MarkdownDescription: "Value of the environment variable.",
 														},
-													},
-												},
-											},
-											"resource_request": schema.SingleNestedAttribute{
-												Required:            true,
-												MarkdownDescription: "Resource requirements for the container.",
-												Attributes: map[string]schema.Attribute{
-													"cpu": schema.Int64Attribute{
-														Required:            true,
-														MarkdownDescription: "Number of CPU cores required.",
-													},
-													"memory": schema.Int64Attribute{
-														Required:            true,
-														MarkdownDescription: "Memory required in bytes.",
-													},
-													"gpu": schema.Int64Attribute{
-														Optional:            true,
-														MarkdownDescription: "Number of GPUs required.",
-													},
-													"gpu_type": schema.StringAttribute{
-														Optional:            true,
-														MarkdownDescription: "GPU type required (e.g., NVIDIA-A100).",
 													},
 												},
 											},
@@ -439,7 +418,6 @@ func containersEqual(a, b ArtifactContainerModel) bool {
 		!a.Primary.Equal(b.Primary) ||
 		!a.Description.Equal(b.Description) ||
 		!a.Port.Equal(b.Port) ||
-		!resourceRequestsEqual(a.ResourceRequest, b.ResourceRequest) ||
 		!probesEqual(a.StartupProbe, b.StartupProbe) ||
 		!probesEqual(a.ReadinessProbe, b.ReadinessProbe) ||
 		!probesEqual(a.LivenessProbe, b.LivenessProbe) {
@@ -482,11 +460,19 @@ func probesEqual(a, b *ArtifactProbeConfigModel) bool {
 		a.FailureThreshold.Equal(b.FailureThreshold)
 }
 
-func resourceRequestsEqual(a, b ArtifactResourceRequestModel) bool {
-	return a.CPU.Equal(b.CPU) &&
-		a.Memory.Equal(b.Memory) &&
-		a.GPU.Equal(b.GPU) &&
-		a.GPUType.Equal(b.GPUType)
+func (r *ArtifactResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data ArtifactResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.Spec == nil {
+		return
+	}
+	if len(data.Spec.ContainerGroups) > 1 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("spec").AtName("container_groups"),
+			"Too many container groups",
+			"Currently, Workload API supports only 1 container group.",
+		)
+	}
 }
 
 func (r *ArtifactResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -529,9 +515,8 @@ func artifactContainerGroupToClient(g ArtifactContainerGroupModel) client.Artifa
 
 func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContainer {
 	container := client.ArtifactContainer{
-		ImageURI:        c.ImageURI.ValueString(),
-		Description:     c.Description.ValueString(),
-		ResourceRequest: artifactResourceRequestToClient(c.ResourceRequest),
+		ImageURI:    c.ImageURI.ValueString(),
+		Description: c.Description.ValueString(),
 	}
 
 	if !c.Name.IsNull() && !c.Name.IsUnknown() {
@@ -571,22 +556,6 @@ func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContaine
 	container.LivenessProbe = artifactProbeToClient(c.LivenessProbe)
 
 	return container
-}
-
-func artifactResourceRequestToClient(rr ArtifactResourceRequestModel) client.ArtifactResourceRequest {
-	req := client.ArtifactResourceRequest{
-		CPU:    rr.CPU.ValueInt64(),
-		Memory: rr.Memory.ValueInt64(),
-	}
-	if !rr.GPU.IsNull() && !rr.GPU.IsUnknown() {
-		gpu := rr.GPU.ValueInt64()
-		req.GPU = &gpu
-	}
-	if !rr.GPUType.IsNull() && !rr.GPUType.IsUnknown() {
-		gpuType := rr.GPUType.ValueString()
-		req.GPUType = &gpuType
-	}
-	return req
 }
 
 func artifactProbeToClient(probe *ArtifactProbeConfigModel) *client.ArtifactProbeConfig {
@@ -666,10 +635,6 @@ func loadArtifactSpecFromAPI(spec client.ArtifactSpec, prior *ArtifactSpecModel)
 func loadContainerFromAPI(c client.ArtifactContainer, priorDescription types.String) ArtifactContainerModel {
 	model := ArtifactContainerModel{
 		ImageURI: types.StringValue(c.ImageURI),
-		ResourceRequest: ArtifactResourceRequestModel{
-			CPU:    types.Int64Value(c.ResourceRequest.CPU),
-			Memory: types.Int64Value(c.ResourceRequest.Memory),
-		},
 	}
 
 	if c.Name != nil {
@@ -696,18 +661,6 @@ func loadContainerFromAPI(c client.ArtifactContainer, priorDescription types.Str
 		model.Port = types.Int64Value(*c.Port)
 	} else {
 		model.Port = types.Int64Null()
-	}
-
-	if c.ResourceRequest.GPU != nil && *c.ResourceRequest.GPU != 0 {
-		model.ResourceRequest.GPU = types.Int64Value(*c.ResourceRequest.GPU)
-	} else {
-		model.ResourceRequest.GPU = types.Int64Null()
-	}
-
-	if c.ResourceRequest.GPUType != nil {
-		model.ResourceRequest.GPUType = types.StringValue(*c.ResourceRequest.GPUType)
-	} else {
-		model.ResourceRequest.GPUType = types.StringNull()
 	}
 
 	if len(c.Entrypoint) > 0 {

--- a/pkg/provider/artifact_resource_test.go
+++ b/pkg/provider/artifact_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/datarobot-community/terraform-provider-datarobot/internal/client"
@@ -295,11 +296,6 @@ resource "datarobot_artifact" "test" {
               }
             ]
 
-            resource_request = {
-              cpu    = 1
-              memory = 536870912
-            }
-
             readiness_probe = {
               path = "/health"
               port = 8080
@@ -314,8 +310,6 @@ resource "datarobot_artifact" "test" {
 }
 
 func artifactFixture(id string, repoID *string, name, imageURI string) *client.Artifact {
-	cpu := int64(1)
-	memory := int64(536870912)
 	port := int64(8080)
 	primary := true
 	containerName := "main"
@@ -344,10 +338,6 @@ func artifactFixture(id string, repoID *string, name, imageURI string) *client.A
 							EnvironmentVars: []client.ArtifactEnvironmentVariable{
 								{Name: "ENV", Value: "production"},
 							},
-							ResourceRequest: client.ArtifactResourceRequest{
-								CPU:    cpu,
-								Memory: memory,
-							},
 							ReadinessProbe: &client.ArtifactProbeConfig{
 								Path:             "/health",
 								Port:             &port,
@@ -360,4 +350,48 @@ func artifactFixture(id string, repoID *string, name, imageURI string) *client.A
 			},
 		},
 	}
+}
+
+func TestArtifactTooManyContainerGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      artifactConfigWithMultipleGroups(),
+				ExpectError: regexp.MustCompile("Too many container groups"),
+			},
+		},
+	})
+}
+
+func artifactConfigWithMultipleGroups() string {
+	return `
+resource "datarobot_artifact" "test" {
+  name = "multi-group-test"
+  spec = {
+    container_groups = [
+      {
+        containers = [{ image_uri = "image-a:latest" }]
+      },
+      {
+        containers = [{ image_uri = "image-b:latest" }]
+      }
+    ]
+  }
+}
+`
 }

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1005,7 +1005,6 @@ type ArtifactContainerModel struct {
 	Port            types.Int64                        `tfsdk:"port"`
 	Entrypoint      []types.String                     `tfsdk:"entrypoint"`
 	EnvironmentVars []ArtifactEnvironmentVariableModel `tfsdk:"environment_vars"`
-	ResourceRequest ArtifactResourceRequestModel       `tfsdk:"resource_request"`
 	StartupProbe    *ArtifactProbeConfigModel          `tfsdk:"startup_probe"`
 	ReadinessProbe  *ArtifactProbeConfigModel          `tfsdk:"readiness_probe"`
 	LivenessProbe   *ArtifactProbeConfigModel          `tfsdk:"liveness_probe"`
@@ -1014,13 +1013,6 @@ type ArtifactContainerModel struct {
 type ArtifactEnvironmentVariableModel struct {
 	Name  types.String `tfsdk:"name"`
 	Value types.String `tfsdk:"value"`
-}
-
-type ArtifactResourceRequestModel struct {
-	CPU     types.Int64  `tfsdk:"cpu"`
-	Memory  types.Int64  `tfsdk:"memory"`
-	GPU     types.Int64  `tfsdk:"gpu"`
-	GPUType types.String `tfsdk:"gpu_type"`
 }
 
 type ArtifactProbeConfigModel struct {
@@ -1047,9 +1039,28 @@ type WorkloadResourceModel struct {
 }
 
 type WorkloadRuntimeModel struct {
-	ReplicaCount types.Int64                   `tfsdk:"replica_count"`
-	Autoscaling  *WorkloadAutoscalingModel     `tfsdk:"autoscaling"`
-	Resources    []WorkloadResourceBundleModel `tfsdk:"resources"`
+	ContainerGroups []WorkloadGroupRuntimeModel `tfsdk:"container_groups"`
+}
+
+type WorkloadGroupRuntimeModel struct {
+	Name                  types.String                     `tfsdk:"name"`
+	ReplicaCount          types.Int64                      `tfsdk:"replica_count"`
+	Autoscaling           *WorkloadAutoscalingModel        `tfsdk:"autoscaling"`
+	ResourceBundles       []types.String                   `tfsdk:"resource_bundles"`
+	BundleSelectionPolicy types.String                     `tfsdk:"bundle_selection_policy"`
+	Containers            []WorkloadContainerOverrideModel `tfsdk:"containers"`
+}
+
+type WorkloadContainerOverrideModel struct {
+	Name               types.String                     `tfsdk:"name"`
+	ResourceAllocation *WorkloadResourceAllocationModel `tfsdk:"resource_allocation"`
+}
+
+type WorkloadResourceAllocationModel struct {
+	CPU       types.Float64 `tfsdk:"cpu"`
+	GPU       types.Float64 `tfsdk:"gpu"`
+	GPUMemory types.String  `tfsdk:"gpu_memory"`
+	Memory    types.String  `tfsdk:"memory"`
 }
 
 type WorkloadAutoscalingModel struct {
@@ -1063,8 +1074,4 @@ type WorkloadAutoscalingPolicyModel struct {
 	MinCount      types.Int64   `tfsdk:"min_count"`
 	MaxCount      types.Int64   `tfsdk:"max_count"`
 	Priority      types.Int64   `tfsdk:"priority"`
-}
-
-type WorkloadResourceBundleModel struct {
-	ResourceBundleID types.String `tfsdk:"resource_bundle_id"`
 }

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1059,8 +1059,8 @@ type WorkloadContainerOverrideModel struct {
 type WorkloadResourceAllocationModel struct {
 	CPU       types.Float64 `tfsdk:"cpu"`
 	GPU       types.Float64 `tfsdk:"gpu"`
-	GPUMemory types.String  `tfsdk:"gpu_memory"`
-	Memory    types.String  `tfsdk:"memory"`
+	GPUMemory types.Int64   `tfsdk:"gpu_memory"`
+	Memory    types.Int64   `tfsdk:"memory"`
 }
 
 type WorkloadAutoscalingModel struct {

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -95,68 +95,116 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 					objectplanmodifier.RequiresReplace(),
 				},
 				Attributes: map[string]schema.Attribute{
-					"replica_count": schema.Int64Attribute{
+					"container_groups": schema.ListNestedAttribute{
 						Optional:            true,
-						Computed:            true,
-						MarkdownDescription: "Number of replicas to run. Cannot be used together with `autoscaling`. Omitting this field retains the current value. Set to `0` to explicitly clear it (e.g. when switching to autoscaling).",
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.UseStateForUnknown(),
-						},
-					},
-					"autoscaling": schema.SingleNestedAttribute{
-						Optional:            true,
-						MarkdownDescription: "Autoscaling configuration. When set, takes precedence over replica_count.",
-						Attributes: map[string]schema.Attribute{
-							"enabled": schema.BoolAttribute{
-								Optional:            true,
-								Computed:            true,
-								MarkdownDescription: "Whether autoscaling is enabled. Defaults to true.",
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.UseStateForUnknown(),
+						MarkdownDescription: "Per-group runtime configuration.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "Container group name (server-assigned, always `default`).",
+									PlanModifiers: []planmodifier.String{
+										stringplanmodifier.UseStateForUnknown(),
+									},
 								},
-							},
-							"policies": schema.ListNestedAttribute{
-								Required:            true,
-								MarkdownDescription: "Scaling policies that define when and how to scale.",
-								NestedObject: schema.NestedAttributeObject{
+								"replica_count": schema.Int64Attribute{
+									Optional:            true,
+									Computed:            true,
+									MarkdownDescription: "Number of replicas. Cannot be set alongside `autoscaling.enabled=true`. Set to `0` to explicitly clear it.",
+									PlanModifiers: []planmodifier.Int64{
+										int64planmodifier.UseStateForUnknown(),
+									},
+								},
+								"autoscaling": schema.SingleNestedAttribute{
+									Optional:            true,
+									MarkdownDescription: "Autoscaling configuration. When set, takes precedence over `replica_count`.",
 									Attributes: map[string]schema.Attribute{
-										"scaling_metric": schema.StringAttribute{
-											Required:            true,
-											MarkdownDescription: "Metric used for scaling decisions: `cpuAverageUtilization`, `httpRequestsConcurrency`, `gpuCacheUtilization`, or `gpuRequestQueueDepth`.",
-										},
-										"target": schema.Float64Attribute{
-											Required:            true,
-											MarkdownDescription: "Target value for the scaling metric.",
-										},
-										"min_count": schema.Int64Attribute{
-											Required:            true,
-											MarkdownDescription: "Minimum number of replicas.",
-										},
-										"max_count": schema.Int64Attribute{
-											Required:            true,
-											MarkdownDescription: "Maximum number of replicas.",
-										},
-										"priority": schema.Int64Attribute{
+										"enabled": schema.BoolAttribute{
 											Optional:            true,
 											Computed:            true,
-											MarkdownDescription: "Policy priority when multiple policies are defined.",
-											PlanModifiers: []planmodifier.Int64{
-												int64planmodifier.UseStateForUnknown(),
+											MarkdownDescription: "Whether autoscaling is enabled. Defaults to true.",
+											PlanModifiers: []planmodifier.Bool{
+												boolplanmodifier.UseStateForUnknown(),
+											},
+										},
+										"policies": schema.ListNestedAttribute{
+											Required:            true,
+											MarkdownDescription: "Scaling policies that define when and how to scale.",
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: map[string]schema.Attribute{
+													"scaling_metric": schema.StringAttribute{
+														Required:            true,
+														MarkdownDescription: "Metric used for scaling decisions: `cpuAverageUtilization`, `httpRequestsConcurrency`, `gpuCacheUtilization`, or `gpuRequestQueueDepth`.",
+													},
+													"target": schema.Float64Attribute{
+														Required:            true,
+														MarkdownDescription: "Target value for the scaling metric.",
+													},
+													"min_count": schema.Int64Attribute{
+														Required:            true,
+														MarkdownDescription: "Minimum number of replicas.",
+													},
+													"max_count": schema.Int64Attribute{
+														Required:            true,
+														MarkdownDescription: "Maximum number of replicas.",
+													},
+													"priority": schema.Int64Attribute{
+														Optional:            true,
+														Computed:            true,
+														MarkdownDescription: "Policy priority when multiple policies are defined.",
+														PlanModifiers: []planmodifier.Int64{
+															int64planmodifier.UseStateForUnknown(),
+														},
+													},
+												},
 											},
 										},
 									},
 								},
-							},
-						},
-					},
-					"resources": schema.ListNestedAttribute{
-						Optional:            true,
-						MarkdownDescription: "Resource bundles assigned to the Workload. When empty the server infers an appropriate bundle.",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"resource_bundle_id": schema.StringAttribute{
-									Required:            true,
-									MarkdownDescription: "ID of the resource bundle (e.g. `cpu.nano`).",
+								"resource_bundles": schema.ListAttribute{
+									Optional:            true,
+									ElementType:         types.StringType,
+									MarkdownDescription: "Ordered list of resource bundle IDs. One is selected at scheduling time.",
+								},
+								"bundle_selection_policy": schema.StringAttribute{
+									Optional:            true,
+									Computed:            true,
+									Default:             stringdefault.StaticString("availability"),
+									MarkdownDescription: "How to select among `resource_bundles`. Defaults to `availability`.",
+								},
+								"containers": schema.ListNestedAttribute{
+									Optional:            true,
+									MarkdownDescription: "Per-container resource allocation overrides.",
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"name": schema.StringAttribute{
+												Required:            true,
+												MarkdownDescription: "Container name. Must match a container declared in the artifact group.",
+											},
+											"resource_allocation": schema.SingleNestedAttribute{
+												Optional:            true,
+												MarkdownDescription: "Resource allocation for this container.",
+												Attributes: map[string]schema.Attribute{
+													"cpu": schema.Float64Attribute{
+														Optional:            true,
+														MarkdownDescription: "CPU cores allocated to this container.",
+													},
+													"gpu": schema.Float64Attribute{
+														Optional:            true,
+														MarkdownDescription: "GPUs allocated to this container.",
+													},
+													"gpu_memory": schema.StringAttribute{
+														Optional:            true,
+														MarkdownDescription: "GPU VRAM allocated (e.g. `15GB`, `16GiB`, or raw bytes as a string).",
+													},
+													"memory": schema.StringAttribute{
+														Optional:            true,
+														MarkdownDescription: "RAM allocated (e.g. `8GB`, `512MiB`, or raw bytes as a string).",
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -292,7 +340,9 @@ func (r *WorkloadResource) Delete(ctx context.Context, req resource.DeleteReques
 
 func (r *WorkloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("runtime"), WorkloadRuntimeModel{})...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("runtime"), WorkloadRuntimeModel{
+		ContainerGroups: []WorkloadGroupRuntimeModel{},
+	})...)
 }
 
 func (r *WorkloadResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -302,21 +352,32 @@ func (r *WorkloadResource) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 
-	replicaCountSet := !data.Runtime.ReplicaCount.IsNull() &&
-		!data.Runtime.ReplicaCount.IsUnknown() &&
-		data.Runtime.ReplicaCount.ValueInt64() != 0
-
-	autoscalingSet := data.Runtime.Autoscaling != nil &&
-		!data.Runtime.Autoscaling.Enabled.IsNull() &&
-		!data.Runtime.Autoscaling.Enabled.IsUnknown() &&
-		data.Runtime.Autoscaling.Enabled.ValueBool()
-
-	if replicaCountSet && autoscalingSet {
+	if len(data.Runtime.ContainerGroups) > 1 {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("runtime"),
-			"Conflicting runtime configuration",
-			"Cannot specify both replica_count and autoscaling. Set replica_count to 0 (or omit it) when using autoscaling or disable autoscaling.",
+			path.Root("runtime").AtName("container_groups"),
+			"Too many container groups",
+			"Currently, Workload API supports only 1 container group.",
 		)
+		return
+	}
+
+	for i, g := range data.Runtime.ContainerGroups {
+		replicaCountSet := !g.ReplicaCount.IsNull() &&
+			!g.ReplicaCount.IsUnknown() &&
+			g.ReplicaCount.ValueInt64() != 0
+
+		autoscalingSet := g.Autoscaling != nil &&
+			!g.Autoscaling.Enabled.IsNull() &&
+			!g.Autoscaling.Enabled.IsUnknown() &&
+			g.Autoscaling.Enabled.ValueBool()
+
+		if replicaCountSet && autoscalingSet {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("runtime").AtName("container_groups").AtListIndex(i),
+				"Conflicting runtime configuration",
+				"Cannot specify both replica_count and autoscaling. Set replica_count to 0 (or omit it) when using autoscaling or disable autoscaling.",
+			)
+		}
 	}
 }
 
@@ -397,24 +458,44 @@ func workloadUpdateRequest(data WorkloadResourceModel) *client.UpdateWorkloadReq
 	return req
 }
 
-func workloadRuntimeToClient(runtime WorkloadRuntimeModel) client.ProtonRuntime {
-	r := client.ProtonRuntime{}
+func workloadRuntimeToClient(runtime WorkloadRuntimeModel) client.WorkloadRuntime {
+	r := client.WorkloadRuntime{}
 
-	if !runtime.ReplicaCount.IsNull() && !runtime.ReplicaCount.IsUnknown() && runtime.ReplicaCount.ValueInt64() != 0 {
-		v := runtime.ReplicaCount.ValueInt64()
-		r.ReplicaCount = &v
+	if len(runtime.ContainerGroups) > 0 {
+		r.ContainerGroups = make([]client.GroupRuntime, len(runtime.ContainerGroups))
+		for i, g := range runtime.ContainerGroups {
+			r.ContainerGroups[i] = groupRuntimeToClient(g)
+		}
 	}
 
-	if runtime.Autoscaling != nil {
-		r.Autoscaling = &client.AutoscalingProperties{}
+	return r
+}
 
-		if !runtime.Autoscaling.Enabled.IsNull() && !runtime.Autoscaling.Enabled.IsUnknown() {
-			enabled := runtime.Autoscaling.Enabled.ValueBool()
-			r.Autoscaling.Enabled = &enabled
+func groupRuntimeToClient(g WorkloadGroupRuntimeModel) client.GroupRuntime {
+	gr := client.GroupRuntime{}
+
+	if !g.Name.IsNull() && !g.Name.IsUnknown() {
+		gr.Name = g.Name.ValueString()
+	}
+
+	if !g.ReplicaCount.IsNull() && !g.ReplicaCount.IsUnknown() && g.ReplicaCount.ValueInt64() != 0 {
+		v := g.ReplicaCount.ValueInt64()
+		gr.ReplicaCount = &v
+	}
+
+	if !g.BundleSelectionPolicy.IsNull() && !g.BundleSelectionPolicy.IsUnknown() {
+		v := g.BundleSelectionPolicy.ValueString()
+		gr.BundleSelectionPolicy = &v
+	}
+
+	if g.Autoscaling != nil {
+		gr.Autoscaling = &client.AutoscalingProperties{}
+		if !g.Autoscaling.Enabled.IsNull() && !g.Autoscaling.Enabled.IsUnknown() {
+			enabled := g.Autoscaling.Enabled.ValueBool()
+			gr.Autoscaling.Enabled = &enabled
 		}
-
-		r.Autoscaling.Policies = make([]client.AutoscalingPolicy, len(runtime.Autoscaling.Policies))
-		for i, p := range runtime.Autoscaling.Policies {
+		gr.Autoscaling.Policies = make([]client.AutoscalingPolicy, len(g.Autoscaling.Policies))
+		for i, p := range g.Autoscaling.Policies {
 			policy := client.AutoscalingPolicy{
 				ScalingMetric: p.ScalingMetric.ValueString(),
 				Target:        p.Target.ValueFloat64(),
@@ -425,43 +506,72 @@ func workloadRuntimeToClient(runtime WorkloadRuntimeModel) client.ProtonRuntime 
 				v := p.Priority.ValueInt64()
 				policy.Priority = &v
 			}
-			r.Autoscaling.Policies[i] = policy
+			gr.Autoscaling.Policies[i] = policy
 		}
 	}
 
-	if len(runtime.Resources) > 0 {
-		r.Resources = make([]client.ResourceBundleResources, len(runtime.Resources))
-		for i, rb := range runtime.Resources {
-			r.Resources[i] = client.ResourceBundleResources{
-				Type:             "resource_bundle",
-				ResourceBundleID: rb.ResourceBundleID.ValueString(),
-			}
+	if len(g.ResourceBundles) > 0 {
+		gr.ResourceBundles = make([]string, len(g.ResourceBundles))
+		for i, rb := range g.ResourceBundles {
+			gr.ResourceBundles[i] = rb.ValueString()
 		}
 	}
 
-	return r
+	if len(g.Containers) > 0 {
+		gr.Containers = make([]client.ContainerOverride, len(g.Containers))
+		for i, c := range g.Containers {
+			gr.Containers[i] = containerOverrideToClient(c)
+		}
+	}
+
+	return gr
+}
+
+func containerOverrideToClient(c WorkloadContainerOverrideModel) client.ContainerOverride {
+	co := client.ContainerOverride{Name: c.Name.ValueString()}
+	if c.ResourceAllocation != nil {
+		ra := &client.ResourceAllocation{}
+		if !c.ResourceAllocation.CPU.IsNull() && !c.ResourceAllocation.CPU.IsUnknown() {
+			v := c.ResourceAllocation.CPU.ValueFloat64()
+			ra.CPU = &v
+		}
+		if !c.ResourceAllocation.GPU.IsNull() && !c.ResourceAllocation.GPU.IsUnknown() {
+			v := c.ResourceAllocation.GPU.ValueFloat64()
+			ra.GPU = &v
+		}
+		if !c.ResourceAllocation.GPUMemory.IsNull() && !c.ResourceAllocation.GPUMemory.IsUnknown() {
+			v := c.ResourceAllocation.GPUMemory.ValueString()
+			ra.GPUMemory = &v
+		}
+		if !c.ResourceAllocation.Memory.IsNull() && !c.ResourceAllocation.Memory.IsUnknown() {
+			v := c.ResourceAllocation.Memory.ValueString()
+			ra.Memory = &v
+		}
+		co.ResourceAllocation = ra
+	}
+	return co
 }
 
 // applySentinels reconciles state values that the API would otherwise misrepresent:
-//   - replica_count=0 signals "explicitly cleared"; the API omits the field so we
-//     write 0 back to state to prevent a perpetual diff.
-//   - description="" is indistinguishable from "not set" in the API response; when
-//     the prior value was null (user omitted it), we restore null so the plan stays clean.
-//   - resources=nil (user omitted the block) must stay nil even when the API assigns a
-//     default bundle; otherwise Terraform raises "was null, but now has value".
-//   - resources=[] (explicit empty list): the API may assign a default bundle, so we
-//     discard whatever the API returned and keep an empty slice to match the config.
+//   - replica_count=0 per group signals "explicitly cleared"; restore it to prevent a perpetual diff.
+//   - description="" is indistinguishable from "not set"; restore null when user omitted it.
+//   - container_groups=nil (user omitted the block) must stay nil even if the API returns groups.
 func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) {
-	if !desired.Runtime.ReplicaCount.IsNull() && !desired.Runtime.ReplicaCount.IsUnknown() && desired.Runtime.ReplicaCount.ValueInt64() == 0 {
-		data.Runtime.ReplicaCount = desired.Runtime.ReplicaCount
-	}
 	if desired.Description.IsNull() && data.Description.ValueString() == "" {
 		data.Description = types.StringNull()
 	}
-	if desired.Runtime.Resources == nil {
-		data.Runtime.Resources = nil
-	} else if len(desired.Runtime.Resources) == 0 {
-		data.Runtime.Resources = []WorkloadResourceBundleModel{}
+	if desired.Runtime.ContainerGroups == nil {
+		data.Runtime.ContainerGroups = nil
+		return
+	}
+	for i := range desired.Runtime.ContainerGroups {
+		if i >= len(data.Runtime.ContainerGroups) {
+			break
+		}
+		dg := desired.Runtime.ContainerGroups[i]
+		if !dg.ReplicaCount.IsNull() && !dg.ReplicaCount.IsUnknown() && dg.ReplicaCount.ValueInt64() == 0 {
+			data.Runtime.ContainerGroups[i].ReplicaCount = dg.ReplicaCount
+		}
 	}
 }
 
@@ -492,26 +602,49 @@ func loadWorkloadIntoModel(workload *client.Workload, data *WorkloadResourceMode
 	data.Runtime = loadWorkloadRuntimeFromAPI(workload.Runtime)
 }
 
-func loadWorkloadRuntimeFromAPI(runtime client.ProtonRuntime) WorkloadRuntimeModel {
+func loadWorkloadRuntimeFromAPI(runtime client.WorkloadRuntime) WorkloadRuntimeModel {
 	model := WorkloadRuntimeModel{}
 
-	if runtime.ReplicaCount != nil {
-		model.ReplicaCount = types.Int64Value(*runtime.ReplicaCount)
-	} else {
-		model.ReplicaCount = types.Int64Null()
+	if len(runtime.ContainerGroups) > 0 {
+		model.ContainerGroups = make([]WorkloadGroupRuntimeModel, len(runtime.ContainerGroups))
+		for i, g := range runtime.ContainerGroups {
+			model.ContainerGroups[i] = loadGroupRuntimeFromAPI(g)
+		}
 	}
 
-	if runtime.Autoscaling != nil {
-		autoscaling := &WorkloadAutoscalingModel{}
+	return model
+}
 
-		if runtime.Autoscaling.Enabled != nil {
-			autoscaling.Enabled = types.BoolValue(*runtime.Autoscaling.Enabled)
+func loadGroupRuntimeFromAPI(g client.GroupRuntime) WorkloadGroupRuntimeModel {
+	name := g.Name
+	if name == "" {
+		name = "default"
+	}
+	m := WorkloadGroupRuntimeModel{
+		Name: types.StringValue(name),
+	}
+
+	if g.ReplicaCount != nil {
+		m.ReplicaCount = types.Int64Value(*g.ReplicaCount)
+	} else {
+		m.ReplicaCount = types.Int64Null()
+	}
+
+	bundleSelectionPolicy := "availability"
+	if g.BundleSelectionPolicy != nil {
+		bundleSelectionPolicy = *g.BundleSelectionPolicy
+	}
+	m.BundleSelectionPolicy = types.StringValue(bundleSelectionPolicy)
+
+	if g.Autoscaling != nil {
+		autoscaling := &WorkloadAutoscalingModel{}
+		if g.Autoscaling.Enabled != nil {
+			autoscaling.Enabled = types.BoolValue(*g.Autoscaling.Enabled)
 		} else {
 			autoscaling.Enabled = types.BoolNull()
 		}
-
-		autoscaling.Policies = make([]WorkloadAutoscalingPolicyModel, len(runtime.Autoscaling.Policies))
-		for i, p := range runtime.Autoscaling.Policies {
+		autoscaling.Policies = make([]WorkloadAutoscalingPolicyModel, len(g.Autoscaling.Policies))
+		for i, p := range g.Autoscaling.Policies {
 			policy := WorkloadAutoscalingPolicyModel{
 				ScalingMetric: types.StringValue(p.ScalingMetric),
 				Target:        types.Float64Value(p.Target),
@@ -525,18 +658,53 @@ func loadWorkloadRuntimeFromAPI(runtime client.ProtonRuntime) WorkloadRuntimeMod
 			}
 			autoscaling.Policies[i] = policy
 		}
-
-		model.Autoscaling = autoscaling
+		m.Autoscaling = autoscaling
 	}
 
-	if len(runtime.Resources) > 0 {
-		model.Resources = make([]WorkloadResourceBundleModel, len(runtime.Resources))
-		for i, rb := range runtime.Resources {
-			model.Resources[i] = WorkloadResourceBundleModel{
-				ResourceBundleID: types.StringValue(rb.ResourceBundleID),
-			}
+	if len(g.ResourceBundles) > 0 {
+		m.ResourceBundles = make([]types.String, len(g.ResourceBundles))
+		for i, rb := range g.ResourceBundles {
+			m.ResourceBundles[i] = types.StringValue(rb)
 		}
 	}
 
-	return model
+	if len(g.Containers) > 0 {
+		m.Containers = make([]WorkloadContainerOverrideModel, len(g.Containers))
+		for i, c := range g.Containers {
+			m.Containers[i] = loadContainerOverrideFromAPI(c)
+		}
+	}
+
+	return m
+}
+
+func loadContainerOverrideFromAPI(c client.ContainerOverride) WorkloadContainerOverrideModel {
+	m := WorkloadContainerOverrideModel{
+		Name: types.StringValue(c.Name),
+	}
+	if c.ResourceAllocation != nil {
+		ra := &WorkloadResourceAllocationModel{}
+		if c.ResourceAllocation.CPU != nil {
+			ra.CPU = types.Float64Value(*c.ResourceAllocation.CPU)
+		} else {
+			ra.CPU = types.Float64Null()
+		}
+		if c.ResourceAllocation.GPU != nil {
+			ra.GPU = types.Float64Value(*c.ResourceAllocation.GPU)
+		} else {
+			ra.GPU = types.Float64Null()
+		}
+		if c.ResourceAllocation.GPUMemory != nil {
+			ra.GPUMemory = types.StringValue(*c.ResourceAllocation.GPUMemory)
+		} else {
+			ra.GPUMemory = types.StringNull()
+		}
+		if c.ResourceAllocation.Memory != nil {
+			ra.Memory = types.StringValue(*c.ResourceAllocation.Memory)
+		} else {
+			ra.Memory = types.StringNull()
+		}
+		m.ResourceAllocation = ra
+	}
+	return m
 }

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -341,7 +341,7 @@ func (r *WorkloadResource) Delete(ctx context.Context, req resource.DeleteReques
 func (r *WorkloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("runtime"), WorkloadRuntimeModel{
-		ContainerGroups: []WorkloadGroupRuntimeModel{},
+		ContainerGroups: nil,
 	})...)
 }
 
@@ -380,6 +380,13 @@ func (r *WorkloadResource) ValidateConfig(ctx context.Context, req resource.Vali
 		}
 
 		if len(g.ResourceBundles) == 0 {
+			if len(g.Containers) == 0 {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("runtime").AtName("container_groups").AtListIndex(i).AtName("containers"),
+					"Missing containers",
+					"At least one container must be defined when resource_bundles is not set.",
+				)
+			}
 			for j, c := range g.Containers {
 				if c.ResourceAllocation == nil {
 					resp.Diagnostics.AddAttributeError(
@@ -569,6 +576,7 @@ func containerOverrideToClient(c WorkloadContainerOverrideModel) client.Containe
 //   - description="" is indistinguishable from "not set"; restore null when user omitted it.
 //   - container_groups=nil (user omitted the block) must stay nil even if the API returns groups.
 //   - resource_bundles=nil (user omitted the field) must stay nil even if the API injects defaults.
+//   - bundle_selection_policy=null (user omitted the field) must stay null even if the API returns a default.
 func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) {
 	if desired.Description.IsNull() && data.Description.ValueString() == "" {
 		data.Description = types.StringNull()
@@ -588,6 +596,7 @@ func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) 
 		if dg.ResourceBundles == nil {
 			data.Runtime.ContainerGroups[i].ResourceBundles = nil
 		}
+		data.Runtime.ContainerGroups[i].BundleSelectionPolicy = dg.BundleSelectionPolicy
 	}
 }
 

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -339,10 +339,25 @@ func (r *WorkloadResource) Delete(ctx context.Context, req resource.DeleteReques
 }
 
 func (r *WorkloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("runtime"), WorkloadRuntimeModel{
-		ContainerGroups: nil,
-	})...)
+	traceAPICall("GetWorkload")
+	workload, err := r.provider.service.GetWorkload(ctx, req.ID)
+	if err != nil {
+		if _, ok := err.(*client.NotFoundError); ok {
+			resp.Diagnostics.AddError("Workload not found",
+				fmt.Sprintf("Workload with ID %s is not found.", req.ID))
+		} else {
+			resp.Diagnostics.AddError("Error importing Workload", err.Error())
+		}
+		return
+	}
+
+	var data WorkloadResourceModel
+	data.ID = types.StringValue(req.ID)
+	loadWorkloadIntoModel(workload, &data)
+	if data.Description.ValueString() == "" {
+		data.Description = types.StringNull()
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *WorkloadResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -193,13 +193,13 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 														Optional:            true,
 														MarkdownDescription: "GPUs allocated to this container.",
 													},
-													"gpu_memory": schema.StringAttribute{
+													"gpu_memory": schema.Int64Attribute{
 														Optional:            true,
-														MarkdownDescription: "GPU VRAM allocated (e.g. `15GB`, `16GiB`, or raw bytes as a string).",
+														MarkdownDescription: "GPU VRAM allocated in bytes.",
 													},
-													"memory": schema.StringAttribute{
+													"memory": schema.Int64Attribute{
 														Optional:            true,
-														MarkdownDescription: "RAM allocated (e.g. `8GB`, `512MiB`, or raw bytes as a string).",
+														MarkdownDescription: "RAM allocated in bytes.",
 													},
 												},
 											},
@@ -378,6 +378,18 @@ func (r *WorkloadResource) ValidateConfig(ctx context.Context, req resource.Vali
 				"Cannot specify both replica_count and autoscaling. Set replica_count to 0 (or omit it) when using autoscaling or disable autoscaling.",
 			)
 		}
+
+		if len(g.ResourceBundles) == 0 {
+			for j, c := range g.Containers {
+				if c.ResourceAllocation == nil {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("runtime").AtName("container_groups").AtListIndex(i).AtName("containers").AtListIndex(j).AtName("resource_allocation"),
+						"Missing resource configuration",
+						"resource_allocation is required for each container when resource_bundles is not set.",
+					)
+				}
+			}
+		}
 	}
 }
 
@@ -540,11 +552,11 @@ func containerOverrideToClient(c WorkloadContainerOverrideModel) client.Containe
 			ra.GPU = &v
 		}
 		if !c.ResourceAllocation.GPUMemory.IsNull() && !c.ResourceAllocation.GPUMemory.IsUnknown() {
-			v := c.ResourceAllocation.GPUMemory.ValueString()
+			v := c.ResourceAllocation.GPUMemory.ValueInt64()
 			ra.GPUMemory = &v
 		}
 		if !c.ResourceAllocation.Memory.IsNull() && !c.ResourceAllocation.Memory.IsUnknown() {
-			v := c.ResourceAllocation.Memory.ValueString()
+			v := c.ResourceAllocation.Memory.ValueInt64()
 			ra.Memory = &v
 		}
 		co.ResourceAllocation = ra
@@ -695,14 +707,14 @@ func loadContainerOverrideFromAPI(c client.ContainerOverride) WorkloadContainerO
 			ra.GPU = types.Float64Null()
 		}
 		if c.ResourceAllocation.GPUMemory != nil {
-			ra.GPUMemory = types.StringValue(*c.ResourceAllocation.GPUMemory)
+			ra.GPUMemory = types.Int64Value(*c.ResourceAllocation.GPUMemory)
 		} else {
-			ra.GPUMemory = types.StringNull()
+			ra.GPUMemory = types.Int64Null()
 		}
 		if c.ResourceAllocation.Memory != nil {
-			ra.Memory = types.StringValue(*c.ResourceAllocation.Memory)
+			ra.Memory = types.Int64Value(*c.ResourceAllocation.Memory)
 		} else {
-			ra.Memory = types.StringNull()
+			ra.Memory = types.Int64Null()
 		}
 		m.ResourceAllocation = ra
 	}

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -568,6 +568,7 @@ func containerOverrideToClient(c WorkloadContainerOverrideModel) client.Containe
 //   - replica_count=0 per group signals "explicitly cleared"; restore it to prevent a perpetual diff.
 //   - description="" is indistinguishable from "not set"; restore null when user omitted it.
 //   - container_groups=nil (user omitted the block) must stay nil even if the API returns groups.
+//   - resource_bundles=nil (user omitted the field) must stay nil even if the API injects defaults.
 func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) {
 	if desired.Description.IsNull() && data.Description.ValueString() == "" {
 		data.Description = types.StringNull()
@@ -583,6 +584,9 @@ func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) 
 		dg := desired.Runtime.ContainerGroups[i]
 		if !dg.ReplicaCount.IsNull() && !dg.ReplicaCount.IsUnknown() && dg.ReplicaCount.ValueInt64() == 0 {
 			data.Runtime.ContainerGroups[i].ReplicaCount = dg.ReplicaCount
+		}
+		if dg.ResourceBundles == nil {
+			data.Runtime.ContainerGroups[i].ResourceBundles = nil
 		}
 	}
 }

--- a/pkg/provider/workload_resource_test.go
+++ b/pkg/provider/workload_resource_test.go
@@ -918,6 +918,186 @@ resource "datarobot_workload" "test" {
 `, artifactID)
 }
 
+func TestWorkloadEmptyContainers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	artifactID := uuid.NewString()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      workloadConfigEmptyContainers(artifactID),
+				ExpectError: regexp.MustCompile("Missing containers"),
+			},
+		},
+	})
+}
+
+func TestIntegrationWorkloadResourceBundlesSentinel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	id := uuid.NewString()
+	artifactID := uuid.NewString()
+	name := "workload-" + uuid.NewString()[:8]
+	replicaCount := int64(1)
+	endpoint := "https://workloads.example.com/" + id
+
+	// API injects resource_bundles even though the plan has none.
+	apiWorkload := workloadFixtureWithResources(id, artifactID, name, &replicaCount, &endpoint, []string{"api-injected-bundle"})
+	cpu := 1.0
+	mem := int64(536870912)
+	apiWorkload.Runtime.ContainerGroups[0].Containers = []client.ContainerOverride{
+		{Name: "main", ResourceAllocation: &client.ResourceAllocation{CPU: &cpu, Memory: &mem}},
+	}
+
+	mockService.EXPECT().CreateWorkload(gomock.Any(), gomock.Any()).Return(apiWorkload, nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // waitForRunning
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // post-create Read
+
+	// Destroy
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil)
+	mockService.EXPECT().DeleteWorkload(gomock.Any(), id).Return(nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(nil, client.NewNotFoundError("workload"))
+
+	resourceName := "datarobot_workload.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: workloadConfigWithResourceAllocation(name, artifactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "runtime.container_groups.0.resource_bundles.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestIntegrationWorkloadBundleSelectionPolicySentinel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	id := uuid.NewString()
+	artifactID := uuid.NewString()
+	name := "workload-" + uuid.NewString()[:8]
+	replicaCount := int64(1)
+	endpoint := "https://workloads.example.com/" + id
+
+	// API returns a different bundle_selection_policy than what the plan has.
+	apiWorkload := workloadFixture(id, artifactID, name, "", client.WorkloadImportanceLow, &replicaCount, &endpoint)
+	apiPolicy := "latency"
+	apiWorkload.Runtime.ContainerGroups[0].BundleSelectionPolicy = &apiPolicy
+	cpu := 1.0
+	mem := int64(536870912)
+	apiWorkload.Runtime.ContainerGroups[0].Containers = []client.ContainerOverride{
+		{Name: "main", ResourceAllocation: &client.ResourceAllocation{CPU: &cpu, Memory: &mem}},
+	}
+
+	mockService.EXPECT().CreateWorkload(gomock.Any(), gomock.Any()).Return(apiWorkload, nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // waitForRunning
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // post-create Read
+
+	// Destroy
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil)
+	mockService.EXPECT().DeleteWorkload(gomock.Any(), id).Return(nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(nil, client.NewNotFoundError("workload"))
+
+	resourceName := "datarobot_workload.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// User omits bundle_selection_policy; schema Default gives "availability".
+				// API returns "latency". State must reflect the plan value, not the API value.
+				Config: workloadConfigWithResourceAllocation(name, artifactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.bundle_selection_policy", "availability"),
+				),
+			},
+		},
+	})
+}
+
+func workloadConfigWithResourceAllocation(name, artifactID string) string {
+	return fmt.Sprintf(`
+resource "datarobot_workload" "test" {
+  name        = %q
+  artifact_id = %q
+  runtime = {
+    container_groups = [
+      {
+        replica_count = 1
+        containers = [
+          {
+            name = "main"
+            resource_allocation = {
+              cpu    = 1
+              memory = 536870912
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+`, name, artifactID)
+}
+
+func workloadConfigEmptyContainers(artifactID string) string {
+	return fmt.Sprintf(`
+resource "datarobot_workload" "test" {
+  name        = "empty-containers-test"
+  artifact_id = %q
+  runtime = {
+    container_groups = [
+      {
+        replica_count = 1
+        containers    = []
+      }
+    ]
+  }
+}
+`, artifactID)
+}
+
 func workloadConfigWithMultipleGroups(artifactID string) string {
 	return fmt.Sprintf(`
 resource "datarobot_workload" "test" {

--- a/pkg/provider/workload_resource_test.go
+++ b/pkg/provider/workload_resource_test.go
@@ -49,7 +49,7 @@ func TestAccWorkloadResource(t *testing.T) {
 			{
 				Config: workloadAccConfig("updated-"+name, "test description", "high", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.replica_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.replica_count", "2"),
 					checkWorkloadIDChanged(&initialID),
 					checkWorkloadExistsInAPI("updated-"+name, false),
 				),
@@ -357,10 +357,10 @@ func TestIntegrationWorkloadReplaceOnResourcesChange(t *testing.T) {
 	endpoint1 := "https://workloads.example.com/" + id1
 	endpoint2 := "https://workloads.example.com/" + id2
 
-	workload1 := workloadFixtureWithResources(id1, artifactID, name, &replicaCount, &endpoint1, nil)
-	workload2 := workloadFixtureWithResources(id2, artifactID, name, &replicaCount, &endpoint2, []string{"cpu.small"})
+	workload1 := workloadFixtureWithResources(id1, artifactID, name, &replicaCount, &endpoint1, []string{"cpu.small"})
+	workload2 := workloadFixtureWithResources(id2, artifactID, name, &replicaCount, &endpoint2, []string{"cpu.large"})
 
-	// Step 1: Create without resources
+	// Step 1: Create with baseline resource bundle
 	mockService.EXPECT().CreateWorkload(gomock.Any(), gomock.Any()).Return(workload1, nil)
 	mockService.EXPECT().GetWorkload(gomock.Any(), id1).Return(workload1, nil) // waitForRunning
 	mockService.EXPECT().GetWorkload(gomock.Any(), id1).Return(workload1, nil) // post-create Read
@@ -396,9 +396,9 @@ func TestIntegrationWorkloadReplaceOnResourcesChange(t *testing.T) {
 				),
 			},
 			{
-				Config: workloadConfigWithReplicasAndResources(name, "", "low", artifactID, 1, "cpu.small"),
+				Config: workloadConfigWithReplicasAndResources(name, "", "low", artifactID, 1, "cpu.large"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.resource_bundles.0", "cpu.small"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.resource_bundles.0", "cpu.large"),
 					checkWorkloadIDChanged(&initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -504,8 +504,9 @@ func TestIntegrationWorkloadImportState(t *testing.T) {
 	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(workload, nil) // waitForRunning
 	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(workload, nil) // post-create Read
 
-	// Step 2: ImportState
-	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(workload, nil) // import Read
+	// Step 2: ImportState — ImportState fetches workload, then framework calls Read again
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(workload, nil) // ImportState fetch
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(workload, nil) // post-import Read
 
 	// Destroy
 	mockService.EXPECT().DeleteWorkload(gomock.Any(), id).Return(nil)
@@ -682,7 +683,8 @@ resource "datarobot_workload" "test" {
   runtime = {
     container_groups = [
       {
-        replica_count = %d
+        replica_count    = %d
+        resource_bundles = ["cpu.small"]
       }
     ]
   }
@@ -727,6 +729,7 @@ resource "datarobot_workload" "test" {
   runtime = {
     container_groups = [
       {
+        resource_bundles = ["cpu.small"]
         autoscaling = {
           enabled = true
           policies = [
@@ -808,7 +811,8 @@ resource "datarobot_workload" "test" {
   runtime = {
     container_groups = [
       {
-        replica_count = %d
+        replica_count    = %d
+        resource_bundles = ["cpu.small"]
       }
     ]
   }
@@ -829,7 +833,7 @@ func workloadFixture(id, artifactID, name, description string, importance client
 		Endpoint:    endpoint,
 		Runtime: client.WorkloadRuntime{
 			ContainerGroups: []client.GroupRuntime{
-				{Name: "default", ReplicaCount: replicaCount},
+				{Name: "default", ReplicaCount: replicaCount, ResourceBundles: []string{"cpu.small"}},
 			},
 		},
 	}
@@ -853,7 +857,8 @@ func workloadFixtureWithAutoscaling(id, artifactID, name string, endpoint *strin
 		Runtime: client.WorkloadRuntime{
 			ContainerGroups: []client.GroupRuntime{
 				{
-					Name: "default",
+					Name:            "default",
+					ResourceBundles: []string{"cpu.small"},
 					Autoscaling: &client.AutoscalingProperties{
 						Enabled: &enabled,
 						Policies: []client.AutoscalingPolicy{

--- a/pkg/provider/workload_resource_test.go
+++ b/pkg/provider/workload_resource_test.go
@@ -871,6 +871,53 @@ func workloadFixtureWithAutoscaling(id, artifactID, name string, endpoint *strin
 	}
 }
 
+func TestWorkloadMissingResourceConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	artifactID := uuid.NewString()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      workloadConfigMissingResourceAllocation(artifactID),
+				ExpectError: regexp.MustCompile("Missing resource configuration"),
+			},
+		},
+	})
+}
+
+func workloadConfigMissingResourceAllocation(artifactID string) string {
+	return fmt.Sprintf(`
+resource "datarobot_workload" "test" {
+  name        = "missing-resource-test"
+  artifact_id = %q
+  runtime = {
+    container_groups = [
+      {
+        replica_count = 1
+        containers = [
+          { name = "main" }
+        ]
+      }
+    ]
+  }
+}
+`, artifactID)
+}
+
 func workloadConfigWithMultipleGroups(artifactID string) string {
 	return fmt.Sprintf(`
 resource "datarobot_workload" "test" {

--- a/pkg/provider/workload_resource_test.go
+++ b/pkg/provider/workload_resource_test.go
@@ -319,7 +319,7 @@ func TestIntegrationWorkloadReplaceOnReplicaCountChange(t *testing.T) {
 			{
 				Config: workloadConfigWithReplicas(name, "", "low", artifactID, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.replica_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.replica_count", "1"),
 					captureAttr(resourceName, "id", &initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -327,7 +327,7 @@ func TestIntegrationWorkloadReplaceOnReplicaCountChange(t *testing.T) {
 			{
 				Config: workloadConfigWithReplicas(name, "", "low", artifactID, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.replica_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.replica_count", "3"),
 					checkWorkloadIDChanged(&initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -358,9 +358,7 @@ func TestIntegrationWorkloadReplaceOnResourcesChange(t *testing.T) {
 	endpoint2 := "https://workloads.example.com/" + id2
 
 	workload1 := workloadFixtureWithResources(id1, artifactID, name, &replicaCount, &endpoint1, nil)
-	workload2 := workloadFixtureWithResources(id2, artifactID, name, &replicaCount, &endpoint2, []client.ResourceBundleResources{
-		{Type: "resource_bundle", ResourceBundleID: "cpu.small"},
-	})
+	workload2 := workloadFixtureWithResources(id2, artifactID, name, &replicaCount, &endpoint2, []string{"cpu.small"})
 
 	// Step 1: Create without resources
 	mockService.EXPECT().CreateWorkload(gomock.Any(), gomock.Any()).Return(workload1, nil)
@@ -400,7 +398,7 @@ func TestIntegrationWorkloadReplaceOnResourcesChange(t *testing.T) {
 			{
 				Config: workloadConfigWithReplicasAndResources(name, "", "low", artifactID, 1, "cpu.small"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.resources.0.resource_bundle_id", "cpu.small"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.resource_bundles.0", "cpu.small"),
 					checkWorkloadIDChanged(&initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -463,7 +461,7 @@ func TestIntegrationWorkloadReplaceOnAutoscalingChange(t *testing.T) {
 				Config: workloadConfigWithAutoscaling(name, "", "low", artifactID, 1, 3, 50.0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "runtime.autoscaling.policies.0.min_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.autoscaling.policies.0.min_count", "1"),
 					captureAttr(resourceName, "id", &initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -471,7 +469,7 @@ func TestIntegrationWorkloadReplaceOnAutoscalingChange(t *testing.T) {
 			{
 				Config: workloadConfigWithAutoscaling(name, "", "low", artifactID, 2, 5, 70.0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime.autoscaling.policies.0.min_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime.container_groups.0.autoscaling.policies.0.min_count", "2"),
 					checkWorkloadIDChanged(&initialID),
 					checkWorkloadExistsInAPI(name, true),
 				),
@@ -567,6 +565,34 @@ func TestWorkloadConflictingRuntimeConfig(t *testing.T) {
 	})
 }
 
+func TestWorkloadTooManyContainerGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	artifactID := uuid.NewString()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      workloadConfigWithMultipleGroups(artifactID),
+				ExpectError: regexp.MustCompile("Too many container groups"),
+			},
+		},
+	})
+}
+
 // ─── matchers ─────────────────────────────────────────────────────────────────
 
 type updateDescriptionMatcher string
@@ -654,7 +680,11 @@ resource "datarobot_workload" "test" {
   artifact_id = %q
   %s
   runtime = {
-    replica_count = %d
+    container_groups = [
+      {
+        replica_count = %d
+      }
+    ]
   }
 }
 `, name, importance, artifactID, desc, replicaCount)
@@ -672,9 +702,11 @@ resource "datarobot_workload" "test" {
   artifact_id = %q
   %s
   runtime = {
-    replica_count = %d
-    resources = [
-      { resource_bundle_id = %q }
+    container_groups = [
+      {
+        replica_count    = %d
+        resource_bundles = [%q]
+      }
     ]
   }
 }
@@ -693,17 +725,21 @@ resource "datarobot_workload" "test" {
   artifact_id = %q
   %s
   runtime = {
-    autoscaling = {
-      enabled = true
-      policies = [
-        {
-          scaling_metric = "cpuAverageUtilization"
-          target         = %g
-          min_count      = %d
-          max_count      = %d
+    container_groups = [
+      {
+        autoscaling = {
+          enabled = true
+          policies = [
+            {
+              scaling_metric = "cpuAverageUtilization"
+              target         = %g
+              min_count      = %d
+              max_count      = %d
+            }
+          ]
         }
-      ]
-    }
+      }
+    ]
   }
 }
 `, name, importance, artifactID, desc, target, minCount, maxCount)
@@ -715,18 +751,22 @@ resource "datarobot_workload" "test" {
   name        = "conflict-test"
   artifact_id = %q
   runtime = {
-    replica_count = 2
-    autoscaling = {
-      enabled = true
-      policies = [
-        {
-          scaling_metric = "cpuAverageUtilization"
-          target         = 50
-          min_count      = 1
-          max_count      = 4
+    container_groups = [
+      {
+        replica_count = 2
+        autoscaling = {
+          enabled = true
+          policies = [
+            {
+              scaling_metric = "cpuAverageUtilization"
+              target         = 50
+              min_count      = 1
+              max_count      = 4
+            }
+          ]
         }
-      ]
-    }
+      }
+    ]
   }
 }
 `, artifactID)
@@ -753,10 +793,6 @@ resource "datarobot_artifact" "test_artifact" {
             port      = 8080
             primary   = true
             entrypoint = ["/whoami", "--port", "8080"]
-            resource_request = {
-              cpu    = 1
-              memory = 536870912
-            }
           }
         ]
       }
@@ -770,7 +806,11 @@ resource "datarobot_workload" "test" {
   artifact_id = datarobot_artifact.test_artifact.artifact_id
   %s
   runtime = {
-    replica_count = %d
+    container_groups = [
+      {
+        replica_count = %d
+      }
+    ]
   }
 }
 `, artifactName, name, importance, desc, replicaCount)
@@ -787,15 +827,17 @@ func workloadFixture(id, artifactID, name, description string, importance client
 		Importance:  importance,
 		ArtifactID:  &artifactID,
 		Endpoint:    endpoint,
-		Runtime: client.ProtonRuntime{
-			ReplicaCount: replicaCount,
+		Runtime: client.WorkloadRuntime{
+			ContainerGroups: []client.GroupRuntime{
+				{Name: "default", ReplicaCount: replicaCount},
+			},
 		},
 	}
 }
 
-func workloadFixtureWithResources(id, artifactID, name string, replicaCount *int64, endpoint *string, resources []client.ResourceBundleResources) *client.Workload {
+func workloadFixtureWithResources(id, artifactID, name string, replicaCount *int64, endpoint *string, resourceBundles []string) *client.Workload {
 	w := workloadFixture(id, artifactID, name, "", client.WorkloadImportanceLow, replicaCount, endpoint)
-	w.Runtime.Resources = resources
+	w.Runtime.ContainerGroups[0].ResourceBundles = resourceBundles
 	return w
 }
 
@@ -808,18 +850,38 @@ func workloadFixtureWithAutoscaling(id, artifactID, name string, endpoint *strin
 		Importance: client.WorkloadImportanceLow,
 		ArtifactID: &artifactID,
 		Endpoint:   endpoint,
-		Runtime: client.ProtonRuntime{
-			Autoscaling: &client.AutoscalingProperties{
-				Enabled: &enabled,
-				Policies: []client.AutoscalingPolicy{
-					{
-						ScalingMetric: "cpuAverageUtilization",
-						Target:        target,
-						MinCount:      minCount,
-						MaxCount:      maxCount,
+		Runtime: client.WorkloadRuntime{
+			ContainerGroups: []client.GroupRuntime{
+				{
+					Name: "default",
+					Autoscaling: &client.AutoscalingProperties{
+						Enabled: &enabled,
+						Policies: []client.AutoscalingPolicy{
+							{
+								ScalingMetric: "cpuAverageUtilization",
+								Target:        target,
+								MinCount:      minCount,
+								MaxCount:      maxCount,
+							},
+						},
 					},
 				},
 			},
 		},
 	}
+}
+
+func workloadConfigWithMultipleGroups(artifactID string) string {
+	return fmt.Sprintf(`
+resource "datarobot_workload" "test" {
+  name        = "multi-group-test"
+  artifact_id = %q
+  runtime = {
+    container_groups = [
+      { replica_count = 1 },
+      { replica_count = 2 }
+    ]
+  }
+}
+`, artifactID)
 }


### PR DESCRIPTION
## Summary
The Workload API removed `resourceRequest` from artifact container definitions and restructured the workload `runtime` from a flat model to a `containerGroups`-based hierarchy. This PR aligns the provider schema with those API changes.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact

**Breaking changes:**

- `datarobot_artifact`: `spec.container_groups[*].containers[*].resource_request` block removed — resource sizing is no longer declared in the artifact.
- `datarobot_workload`: flat `runtime.replica_count`, `runtime.autoscaling`, `runtime.resources` replaced by `runtime.container_groups[*]` list. Each group now holds its own `replica_count`, `autoscaling`, `resource_bundles`, `bundle_selection_policy`, and per-container `resource_allocation`.
- `resource_bundles` is a flat `list(string)` per group (was `resources[*].resource_bundle_id`).
- New `runtime.container_groups[*].containers[*].resource_allocation` block for per-container CPU/GPU/memory overrides (supports human-readable strings like `"8GB"`).
- Both resources now validate that only 1 container group is provided ("Currently, Workload API supports only 1 container group.").
- Container group `name` is now computed-only (server always assigns `"default"`).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)

## Testing
All existing integration and unit tests updated and passing. New tests added for the single-group validation on both artifact and workload resources.

## Additional Notes
`bundle_selection_policy` defaults to `"availability"` to match the API default and prevent spurious plan diffs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces breaking schema/model changes for `datarobot_artifact` and `datarobot_workload` (state shape changes, replacement triggers, and request/response mappings) that can force resource recreation or diffs if edge cases aren’t covered.
> 
> **Overview**
> **Aligns provider + client models to the updated Workload API schema.** Workload runtime is refactored from a flat `runtime` (`replica_count`, `autoscaling`, `resources`) into `runtime.container_groups[*]`, including per-group `resource_bundles`, `bundle_selection_policy` (default `availability`), and per-container `resource_allocation` overrides.
> 
> **Removes artifact container resource sizing.** The `datarobot_artifact` schema/client mapping drops `spec.container_groups[*].containers[*].resource_request` entirely.
> 
> **Adds guardrails + updates tests.** Both resources now validate that only a single container group is provided, updates import/sentinel handling to avoid perpetual diffs under the new shape, and adjusts/extends unit+integration tests for the new nested attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12393bf68fd874131f999cccaccab526e24623e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->