### PR TITLE
[RAPTOR-17500] - adding credentials to the env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- added credential type for environment variables on the `datarobot_artifact` resource
+
 ## [0.10.37] - 2026-05-20
 
 ### Fixed

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -70,7 +70,13 @@ Optional:
 Required:
 
 - `name` (String) Name of the environment variable.
-- `value` (String) Value of the environment variable.
+
+Optional:
+
+- `credential_id` (String) DataRobot credential ID. Required when source is "dr-credential".
+- `key` (String) Key within the credential. Required when source is "dr-credential".
+- `source` (String) Source type: "string" for plain text values, "dr-credential" for DataRobot credentials. Defaults to "string".
+- `value` (String) Value of the environment variable. Required when source is "string".
 
 
 <a id="nestedatt--spec--container_groups--containers--liveness_probe"></a>

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -110,9 +110,17 @@ const (
 	ArtifactTypeNim     ArtifactType = "nim"
 )
 
+const (
+	EnvironmentVariableSourceString     = "string"
+	EnvironmentVariableSourceCredential = "dr-credential"
+)
+
 type ArtifactEnvironmentVariable struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Source         string `json:"source,omitempty"`
+	Name           string `json:"name"`
+	Value          string `json:"value,omitempty"`
+	DrCredentialID string `json:"drCredentialId,omitempty"`
+	Key            string `json:"key,omitempty"`
 }
 
 type ArtifactProbeConfig struct {

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -197,13 +197,27 @@ func (r *ArtifactResource) Schema(ctx context.Context, req resource.SchemaReques
 												MarkdownDescription: "Environment variables for the container.",
 												NestedObject: schema.NestedAttributeObject{
 													Attributes: map[string]schema.Attribute{
+														"source": schema.StringAttribute{
+															Optional:            true,
+															Computed:            true,
+															Default:             stringdefault.StaticString(client.EnvironmentVariableSourceString),
+															MarkdownDescription: `Source type: "string" for plain text values, "dr-credential" for DataRobot credentials. Defaults to "string".`,
+														},
 														"name": schema.StringAttribute{
 															Required:            true,
 															MarkdownDescription: "Name of the environment variable.",
 														},
 														"value": schema.StringAttribute{
-															Required:            true,
-															MarkdownDescription: "Value of the environment variable.",
+															Optional:            true,
+															MarkdownDescription: `Value of the environment variable. Required when source is "string".`,
+														},
+														"credential_id": schema.StringAttribute{
+															Optional:            true,
+															MarkdownDescription: `DataRobot credential ID. Required when source is "dr-credential".`,
+														},
+														"key": schema.StringAttribute{
+															Optional:            true,
+															MarkdownDescription: `Key within the credential. Required when source is "dr-credential".`,
 														},
 													},
 												},
@@ -435,8 +449,11 @@ func containersEqual(a, b ArtifactContainerModel) bool {
 		return false
 	}
 	for i := range a.EnvironmentVars {
-		if !a.EnvironmentVars[i].Name.Equal(b.EnvironmentVars[i].Name) ||
-			!a.EnvironmentVars[i].Value.Equal(b.EnvironmentVars[i].Value) {
+		if !a.EnvironmentVars[i].Source.Equal(b.EnvironmentVars[i].Source) ||
+			!a.EnvironmentVars[i].Name.Equal(b.EnvironmentVars[i].Name) ||
+			!a.EnvironmentVars[i].Value.Equal(b.EnvironmentVars[i].Value) ||
+			!a.EnvironmentVars[i].CredentialID.Equal(b.EnvironmentVars[i].CredentialID) ||
+			!a.EnvironmentVars[i].Key.Equal(b.EnvironmentVars[i].Key) {
 			return false
 		}
 	}
@@ -478,6 +495,64 @@ func (r *ArtifactResource) ValidateConfig(ctx context.Context, req resource.Vali
 			"Too many container groups",
 			"Currently, Workload API supports only 1 container group.",
 		)
+	}
+
+	for gi, group := range data.Spec.ContainerGroups {
+		for ci, container := range group.Containers {
+			for ei, ev := range container.EnvironmentVars {
+				if ev.Source.IsUnknown() {
+					continue
+				}
+				evPath := path.Root("spec").
+					AtName("container_groups").AtListIndex(gi).
+					AtName("containers").AtListIndex(ci).
+					AtName("environment_vars").AtListIndex(ei)
+
+				source := ev.Source.ValueString()
+				if ev.Source.IsNull() {
+					source = client.EnvironmentVariableSourceString
+				}
+
+				switch source {
+				case client.EnvironmentVariableSourceString:
+					if ev.Value.IsNull() || ev.Value.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("value"),
+							"Missing value",
+							`"value" is required when source is "string".`)
+					}
+					if !ev.CredentialID.IsNull() && !ev.CredentialID.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("credential_id"),
+							"Unexpected field",
+							`"credential_id" must not be set when source is "string".`)
+					}
+					if !ev.Key.IsNull() && !ev.Key.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("key"),
+							"Unexpected field",
+							`"key" must not be set when source is "string".`)
+					}
+				case client.EnvironmentVariableSourceCredential:
+					if ev.CredentialID.IsNull() || ev.CredentialID.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("credential_id"),
+							"Missing credential_id",
+							`"credential_id" is required when source is "dr-credential".`)
+					}
+					if ev.Key.IsNull() || ev.Key.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("key"),
+							"Missing key",
+							`"key" is required when source is "dr-credential".`)
+					}
+					if !ev.Value.IsNull() && !ev.Value.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("value"),
+							"Unexpected field",
+							`"value" must not be set when source is "dr-credential".`)
+					}
+				default:
+					resp.Diagnostics.AddAttributeError(evPath.AtName("source"),
+						"Invalid source",
+						fmt.Sprintf(`Invalid source %q. Allowed values: "string", "dr-credential".`, source))
+				}
+			}
+		}
 	}
 }
 
@@ -550,10 +625,17 @@ func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContaine
 	if len(c.EnvironmentVars) > 0 {
 		container.EnvironmentVars = make([]client.ArtifactEnvironmentVariable, len(c.EnvironmentVars))
 		for i, ev := range c.EnvironmentVars {
-			container.EnvironmentVars[i] = client.ArtifactEnvironmentVariable{
-				Name:  ev.Name.ValueString(),
-				Value: ev.Value.ValueString(),
+			envVar := client.ArtifactEnvironmentVariable{
+				Source: ev.Source.ValueString(),
+				Name:   ev.Name.ValueString(),
 			}
+			if ev.Source.ValueString() == client.EnvironmentVariableSourceCredential {
+				envVar.DrCredentialID = ev.CredentialID.ValueString()
+				envVar.Key = ev.Key.ValueString()
+			} else {
+				envVar.Value = ev.Value.ValueString()
+			}
+			container.EnvironmentVars[i] = envVar
 		}
 	}
 
@@ -627,18 +709,18 @@ func loadArtifactSpecFromAPI(spec client.ArtifactSpec, prior *ArtifactSpecModel)
 	for i, g := range spec.ContainerGroups {
 		containers := make([]ArtifactContainerModel, len(g.Containers))
 		for j, c := range g.Containers {
-			var priorDescription types.String
+			var priorContainer *ArtifactContainerModel
 			if prior != nil && i < len(prior.ContainerGroups) && j < len(prior.ContainerGroups[i].Containers) {
-				priorDescription = prior.ContainerGroups[i].Containers[j].Description
+				priorContainer = &prior.ContainerGroups[i].Containers[j]
 			}
-			containers[j] = loadContainerFromAPI(c, priorDescription)
+			containers[j] = loadContainerFromAPI(c, priorContainer)
 		}
 		groups[i] = ArtifactContainerGroupModel{Containers: containers}
 	}
 	return ArtifactSpecModel{ContainerGroups: groups}
 }
 
-func loadContainerFromAPI(c client.ArtifactContainer, priorDescription types.String) ArtifactContainerModel {
+func loadContainerFromAPI(c client.ArtifactContainer, prior *ArtifactContainerModel) ArtifactContainerModel {
 	model := ArtifactContainerModel{
 		ImageURI: types.StringValue(c.ImageURI),
 	}
@@ -649,6 +731,10 @@ func loadContainerFromAPI(c client.ArtifactContainer, priorDescription types.Str
 		model.Name = types.StringNull()
 	}
 
+	var priorDescription types.String
+	if prior != nil {
+		priorDescription = prior.Description
+	}
 	if c.Description != "" {
 		model.Description = types.StringValue(c.Description)
 	} else if priorDescription.IsUnknown() {
@@ -679,11 +765,23 @@ func loadContainerFromAPI(c client.ArtifactContainer, priorDescription types.Str
 	if len(c.EnvironmentVars) > 0 {
 		model.EnvironmentVars = make([]ArtifactEnvironmentVariableModel, len(c.EnvironmentVars))
 		for i, ev := range c.EnvironmentVars {
-			model.EnvironmentVars[i] = ArtifactEnvironmentVariableModel{
-				Name:  types.StringValue(ev.Name),
-				Value: types.StringValue(ev.Value),
+			m := ArtifactEnvironmentVariableModel{
+				Source:       types.StringValue(ev.Source),
+				Name:         types.StringValue(ev.Name),
+				Value:        types.StringNull(),
+				CredentialID: types.StringNull(),
+				Key:          types.StringNull(),
 			}
+			if ev.Source == client.EnvironmentVariableSourceCredential {
+				m.CredentialID = types.StringValue(ev.DrCredentialID)
+				m.Key = types.StringValue(ev.Key)
+			} else {
+				m.Value = types.StringValue(ev.Value)
+			}
+			model.EnvironmentVars[i] = m
 		}
+	} else if prior != nil && prior.EnvironmentVars != nil {
+		model.EnvironmentVars = []ArtifactEnvironmentVariableModel{}
 	}
 
 	model.StartupProbe = loadProbeFromAPI(c.StartupProbe)

--- a/pkg/provider/artifact_resource_test.go
+++ b/pkg/provider/artifact_resource_test.go
@@ -291,8 +291,9 @@ resource "datarobot_artifact" "test" {
 
             environment_vars = [
               {
-                name  = "ENV"
-                value = "production"
+                source = "string"
+                name   = "ENV"
+                value  = "production"
               }
             ]
 
@@ -336,7 +337,7 @@ func artifactFixture(id string, repoID *string, name, imageURI string) *client.A
 							Port:        &port,
 							Entrypoint:  []string{"python", "-m", "app"},
 							EnvironmentVars: []client.ArtifactEnvironmentVariable{
-								{Name: "ENV", Value: "production"},
+								{Source: client.EnvironmentVariableSourceString, Name: "ENV", Value: "production"},
 							},
 							ReadinessProbe: &client.ArtifactProbeConfig{
 								Path:             "/health",
@@ -391,6 +392,143 @@ resource "datarobot_artifact" "test" {
         containers = [{ image_uri = "image-b:latest" }]
       }
     ]
+  }
+}
+`
+}
+
+func TestArtifactCredentialEnvVarValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	cases := []struct {
+		name        string
+		config      string
+		expectError string
+	}{
+		{
+			name:        "credential env var missing credential_id",
+			config:      artifactConfigWithCredentialEnvVar("dr-credential", "", "token", ""),
+			expectError: `"credential_id" is required`,
+		},
+		{
+			name:        "credential env var missing key",
+			config:      artifactConfigWithCredentialEnvVar("dr-credential", "cred-abc", "", ""),
+			expectError: `"key" is required`,
+		},
+		{
+			name:        "credential env var with unexpected value",
+			config:      artifactConfigWithCredentialEnvVar("dr-credential", "cred-abc", "token", "should-not-be-here"),
+			expectError: `"value" must not be set`,
+		},
+		{
+			name:        "string env var missing value",
+			config:      artifactConfigWithStringEnvVarMissingValue(),
+			expectError: `"value" is required`,
+		},
+		{
+			name:        "invalid source type",
+			config:      artifactConfigWithInvalidSource(),
+			expectError: `Invalid source`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				IsUnitTest:               true,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:      tc.config,
+						ExpectError: regexp.MustCompile(tc.expectError),
+					},
+				},
+			})
+		})
+	}
+}
+
+// artifactConfigWithCredentialEnvVar builds a config with a credential env var.
+// Pass empty strings for credential_id, key, or value to omit those fields.
+func artifactConfigWithCredentialEnvVar(source, credentialID, key, value string) string {
+	credentialIDLine := ""
+	if credentialID != "" {
+		credentialIDLine = fmt.Sprintf("credential_id = %q\n", credentialID)
+	}
+	keyLine := ""
+	if key != "" {
+		keyLine = fmt.Sprintf("key = %q\n", key)
+	}
+	valueLine := ""
+	if value != "" {
+		valueLine = fmt.Sprintf("value = %q\n", value)
+	}
+	return fmt.Sprintf(`
+resource "datarobot_artifact" "test" {
+  name = "cred-env-test"
+  spec = {
+    container_groups = [{
+      containers = [{
+        image_uri = "nginx:latest"
+        primary   = true
+        port      = 8080
+        environment_vars = [{
+          source = %q
+          name   = "MY_SECRET"
+          %s%s%s
+        }]
+      }]
+    }]
+  }
+}
+`, source, credentialIDLine, keyLine, valueLine)
+}
+
+func artifactConfigWithStringEnvVarMissingValue() string {
+	return `
+resource "datarobot_artifact" "test" {
+  name = "missing-value-test"
+  spec = {
+    container_groups = [{
+      containers = [{
+        image_uri = "nginx:latest"
+        environment_vars = [{
+          source = "string"
+          name   = "ENV"
+        }]
+      }]
+    }]
+  }
+}
+`
+}
+
+func artifactConfigWithInvalidSource() string {
+	return `
+resource "datarobot_artifact" "test" {
+  name = "invalid-source-test"
+  spec = {
+    container_groups = [{
+      containers = [{
+        image_uri = "nginx:latest"
+        environment_vars = [{
+          source = "unknown-type"
+          name   = "ENV"
+          value  = "foo"
+        }]
+      }]
+    }]
   }
 }
 `

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1011,8 +1011,11 @@ type ArtifactContainerModel struct {
 }
 
 type ArtifactEnvironmentVariableModel struct {
-	Name  types.String `tfsdk:"name"`
-	Value types.String `tfsdk:"value"`
+	Source       types.String `tfsdk:"source"`
+	Name         types.String `tfsdk:"name"`
+	Value        types.String `tfsdk:"value"`
+	CredentialID types.String `tfsdk:"credential_id"`
+	Key          types.String `tfsdk:"key"`
 }
 
 type ArtifactProbeConfigModel struct {


### PR DESCRIPTION
## Summary
This PR implements credential type for environment variables. Now you can define both string & credential type of env vars.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the `datarobot_artifact` schema and request/response mapping for a new env-var source type, which could affect plan diffs/state and API payloads for existing users. Validation reduces misconfiguration risk but introduces new conditional required/forbidden fields.
> 
> **Overview**
> Adds a new `environment_vars.source` field (defaulting to `"string"`) so `datarobot_artifact` containers can define env vars as either plain `value` strings or DataRobot credential references (`credential_id` + `key`).
> 
> Updates client/API structs, provider models, diff detection (`containersEqual`), and plan→API / API→state conversions to handle credential-backed env vars, and adds config validation plus unit tests to enforce the conditional field requirements and reject invalid sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccec21121cc40d2acd09bb192b3b14bacc860c84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->