### PR TITLE
[RAPTOR-17490] - added support for human-readable memory definition (like MiB, KiB, KB…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## Unreleased
+## [0.10.39] - 2026-05-28
 
 ### Fixed
-- added support of human-readable memory definitions in resource allocations in workload resource
 - changed credential_id into dr_credential_id to correspond to the Workload API vocab
+
+### Added
+- added support of human-readable memory definitions in resource allocations in workload resource
 
 ## [0.10.38] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+- added support of human-readable memory definitions in resource allocations in workload resource
+- changed credential_id into dr_credential_id to correspond to the Workload API vocab
+
 ## [0.10.38] - 2026-05-22
 
 ### Fixed

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -73,7 +73,7 @@ Required:
 
 Optional:
 
-- `credential_id` (String) DataRobot credential ID. Required when source is "dr-credential".
+- `dr_credential_id` (String) DataRobot credential ID. Required when source is "dr-credential".
 - `key` (String) Key within the credential. Required when source is "dr-credential".
 - `source` (String) Source type: "string" for plain text values, "dr-credential" for DataRobot credentials. Defaults to "string".
 - `value` (String) Value of the environment variable. Required when source is "string".

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -112,5 +112,5 @@ Optional:
 
 - `cpu` (Number) CPU cores allocated to this container.
 - `gpu` (Number) GPUs allocated to this container.
-- `gpu_memory` (Number) GPU VRAM allocated in bytes.
-- `memory` (Number) RAM allocated in bytes.
+- `gpu_memory` (String) GPU VRAM allocated. Accepts human-readable strings (e.g. `"15GB"`, `"512MB"`, `"4096Mi"`) or raw byte integers. 1000-based suffixes: KB, MB, GB, TB. 1024-based suffixes: Ki/KiB, Mi/MiB, Gi/GiB.
+- `memory` (String) RAM allocated. Accepts human-readable strings (e.g. `"8GB"`, `"512MB"`, `"4096Mi"`) or raw byte integers. 1000-based suffixes: KB, MB, GB, TB. 1024-based suffixes: Ki/KiB, Mi/MiB, Gi/GiB.

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -211,7 +211,7 @@ func (r *ArtifactResource) Schema(ctx context.Context, req resource.SchemaReques
 															Optional:            true,
 															MarkdownDescription: `Value of the environment variable. Required when source is "string".`,
 														},
-														"credential_id": schema.StringAttribute{
+														"dr_credential_id": schema.StringAttribute{
 															Optional:            true,
 															MarkdownDescription: `DataRobot credential ID. Required when source is "dr-credential".`,
 														},
@@ -452,7 +452,7 @@ func containersEqual(a, b ArtifactContainerModel) bool {
 		if !a.EnvironmentVars[i].Source.Equal(b.EnvironmentVars[i].Source) ||
 			!a.EnvironmentVars[i].Name.Equal(b.EnvironmentVars[i].Name) ||
 			!a.EnvironmentVars[i].Value.Equal(b.EnvironmentVars[i].Value) ||
-			!a.EnvironmentVars[i].CredentialID.Equal(b.EnvironmentVars[i].CredentialID) ||
+			!a.EnvironmentVars[i].DrCredentialID.Equal(b.EnvironmentVars[i].DrCredentialID) ||
 			!a.EnvironmentVars[i].Key.Equal(b.EnvironmentVars[i].Key) {
 			return false
 		}
@@ -520,10 +520,10 @@ func (r *ArtifactResource) ValidateConfig(ctx context.Context, req resource.Vali
 							"Missing value",
 							`"value" is required when source is "string".`)
 					}
-					if !ev.CredentialID.IsNull() && !ev.CredentialID.IsUnknown() {
-						resp.Diagnostics.AddAttributeError(evPath.AtName("credential_id"),
+					if !ev.DrCredentialID.IsNull() && !ev.DrCredentialID.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("dr_credential_id"),
 							"Unexpected field",
-							`"credential_id" must not be set when source is "string".`)
+							`"dr_credential_id" must not be set when source is "string".`)
 					}
 					if !ev.Key.IsNull() && !ev.Key.IsUnknown() {
 						resp.Diagnostics.AddAttributeError(evPath.AtName("key"),
@@ -531,10 +531,10 @@ func (r *ArtifactResource) ValidateConfig(ctx context.Context, req resource.Vali
 							`"key" must not be set when source is "string".`)
 					}
 				case client.EnvironmentVariableSourceCredential:
-					if ev.CredentialID.IsNull() || ev.CredentialID.IsUnknown() {
-						resp.Diagnostics.AddAttributeError(evPath.AtName("credential_id"),
-							"Missing credential_id",
-							`"credential_id" is required when source is "dr-credential".`)
+					if ev.DrCredentialID.IsNull() || ev.DrCredentialID.IsUnknown() {
+						resp.Diagnostics.AddAttributeError(evPath.AtName("dr_credential_id"),
+							"Missing dr_credential_id",
+							`"dr_credential_id" is required when source is "dr-credential".`)
 					}
 					if ev.Key.IsNull() || ev.Key.IsUnknown() {
 						resp.Diagnostics.AddAttributeError(evPath.AtName("key"),
@@ -630,7 +630,7 @@ func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContaine
 				Name:   ev.Name.ValueString(),
 			}
 			if ev.Source.ValueString() == client.EnvironmentVariableSourceCredential {
-				envVar.DrCredentialID = ev.CredentialID.ValueString()
+				envVar.DrCredentialID = ev.DrCredentialID.ValueString()
 				envVar.Key = ev.Key.ValueString()
 			} else {
 				envVar.Value = ev.Value.ValueString()
@@ -769,11 +769,11 @@ func loadContainerFromAPI(c client.ArtifactContainer, prior *ArtifactContainerMo
 				Source:       types.StringValue(ev.Source),
 				Name:         types.StringValue(ev.Name),
 				Value:        types.StringNull(),
-				CredentialID: types.StringNull(),
+				DrCredentialID: types.StringNull(),
 				Key:          types.StringNull(),
 			}
 			if ev.Source == client.EnvironmentVariableSourceCredential {
-				m.CredentialID = types.StringValue(ev.DrCredentialID)
+				m.DrCredentialID = types.StringValue(ev.DrCredentialID)
 				m.Key = types.StringValue(ev.Key)
 			} else {
 				m.Value = types.StringValue(ev.Value)

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -766,11 +766,11 @@ func loadContainerFromAPI(c client.ArtifactContainer, prior *ArtifactContainerMo
 		model.EnvironmentVars = make([]ArtifactEnvironmentVariableModel, len(c.EnvironmentVars))
 		for i, ev := range c.EnvironmentVars {
 			m := ArtifactEnvironmentVariableModel{
-				Source:       types.StringValue(ev.Source),
-				Name:         types.StringValue(ev.Name),
-				Value:        types.StringNull(),
+				Source:         types.StringValue(ev.Source),
+				Name:           types.StringValue(ev.Name),
+				Value:          types.StringNull(),
 				DrCredentialID: types.StringNull(),
-				Key:          types.StringNull(),
+				Key:            types.StringNull(),
 			}
 			if ev.Source == client.EnvironmentVariableSourceCredential {
 				m.DrCredentialID = types.StringValue(ev.DrCredentialID)

--- a/pkg/provider/artifact_resource_test.go
+++ b/pkg/provider/artifact_resource_test.go
@@ -416,9 +416,9 @@ func TestArtifactCredentialEnvVarValidation(t *testing.T) {
 		expectError string
 	}{
 		{
-			name:        "credential env var missing credential_id",
+			name:        "credential env var missing dr_credential_id",
 			config:      artifactConfigWithCredentialEnvVar("dr-credential", "", "token", ""),
-			expectError: `"credential_id" is required`,
+			expectError: `"dr_credential_id" is required`,
 		},
 		{
 			name:        "credential env var missing key",
@@ -460,11 +460,11 @@ func TestArtifactCredentialEnvVarValidation(t *testing.T) {
 }
 
 // artifactConfigWithCredentialEnvVar builds a config with a credential env var.
-// Pass empty strings for credential_id, key, or value to omit those fields.
+// Pass empty strings for dr_credential_id, key, or value to omit those fields.
 func artifactConfigWithCredentialEnvVar(source, credentialID, key, value string) string {
 	credentialIDLine := ""
 	if credentialID != "" {
-		credentialIDLine = fmt.Sprintf("credential_id = %q\n", credentialID)
+		credentialIDLine = fmt.Sprintf("dr_credential_id = %q\n", credentialID)
 	}
 	keyLine := ""
 	if key != "" {

--- a/pkg/provider/memory_utils.go
+++ b/pkg/provider/memory_utils.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var memoryPattern = regexp.MustCompile(`^(\d+\.?\d*)\s*([a-zA-Z]*)$`)
+
+// parseMemoryBytes converts a human-readable memory string or raw integer string to bytes.
+// Supports SI units (KB, MB, GB, TB — 1000-based) and IEC units (Ki/KiB, Mi/MiB, Gi/GiB, Ti/TiB — 1024-based).
+func parseMemoryBytes(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("memory value must not be empty")
+	}
+
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n, nil
+	}
+
+	m := memoryPattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("invalid memory format %q: expected a number with optional unit (e.g. \"4GB\", \"512MB\", \"4096Mi\")", s)
+	}
+
+	value, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value in %q", s)
+	}
+
+	var multiplier float64
+	switch strings.ToLower(m[2]) {
+	case "", "b":
+		multiplier = 1
+	case "kb":
+		multiplier = 1e3
+	case "mb":
+		multiplier = 1e6
+	case "gb":
+		multiplier = 1e9
+	case "tb":
+		multiplier = 1e12
+	case "k", "ki", "kib":
+		multiplier = 1 << 10
+	case "m", "mi", "mib":
+		multiplier = 1 << 20
+	case "g", "gi", "gib":
+		multiplier = 1 << 30
+	case "t", "ti", "tib":
+		multiplier = 1 << 40
+	default:
+		return 0, fmt.Errorf("unknown memory unit %q in %q: use B, KB, MB, GB, TB (1000-based) or Ki/Mi/Gi/Ti (1024-based)", m[2], s)
+	}
+
+	return int64(value * multiplier), nil
+}
+
+type memoryStringValidator struct{}
+
+var _ validator.String = memoryStringValidator{}
+
+func (memoryStringValidator) Description(_ context.Context) string {
+	return "Validates a memory value string (e.g. \"4GB\", \"512MB\", \"4096Mi\", or raw bytes integer)."
+}
+
+func (memoryStringValidator) MarkdownDescription(_ context.Context) string {
+	return "Validates a memory value string (e.g. `\"4GB\"`, `\"512MB\"`, `\"4096Mi\"`, or raw bytes integer)."
+}
+
+func (memoryStringValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, err := parseMemoryBytes(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid memory value", err.Error())
+	}
+}

--- a/pkg/provider/memory_utils_test.go
+++ b/pkg/provider/memory_utils_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestParseMemoryBytes(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{input: "0", want: 0},
+		{input: "1024", want: 1024},
+		{input: "536870912", want: 536870912},
+
+		// SI (1000-based)
+		{input: "1B", want: 1},
+		{input: "1KB", want: 1000},
+		{input: "1MB", want: 1_000_000},
+		{input: "1GB", want: 1_000_000_000},
+		{input: "4GB", want: 4_000_000_000},
+		{input: "512MB", want: 512_000_000},
+		{input: "15GB", want: 15_000_000_000},
+
+		// IEC (1024-based)
+		{input: "1Ki", want: 1024},
+		{input: "1KiB", want: 1024},
+		{input: "1Mi", want: 1 << 20},
+		{input: "1MiB", want: 1 << 20},
+		{input: "1Gi", want: 1 << 30},
+		{input: "1GiB", want: 1 << 30},
+		{input: "4096Mi", want: 4096 * (1 << 20)},
+		{input: "4096MiB", want: 4096 * (1 << 20)},
+
+		// Short IEC aliases
+		{input: "1K", want: 1024},
+		{input: "1M", want: 1 << 20},
+		{input: "1G", want: 1 << 30},
+
+		// Whitespace tolerance
+		{input: "  4GB  ", want: 4_000_000_000},
+		{input: "4 GB", want: 4_000_000_000},
+
+		// Errors
+		{input: "", wantErr: true},
+		{input: "abc", wantErr: true},
+		{input: "4XB", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parseMemoryBytes(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseMemoryBytes(%q) expected error, got %d", tc.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseMemoryBytes(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseMemoryBytes(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1062,8 +1062,8 @@ type WorkloadContainerOverrideModel struct {
 type WorkloadResourceAllocationModel struct {
 	CPU       types.Float64 `tfsdk:"cpu"`
 	GPU       types.Float64 `tfsdk:"gpu"`
-	GPUMemory types.Int64   `tfsdk:"gpu_memory"`
-	Memory    types.Int64   `tfsdk:"memory"`
+	GPUMemory types.String  `tfsdk:"gpu_memory"`
+	Memory    types.String  `tfsdk:"memory"`
 }
 
 type WorkloadAutoscalingModel struct {

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1011,11 +1011,11 @@ type ArtifactContainerModel struct {
 }
 
 type ArtifactEnvironmentVariableModel struct {
-	Source       types.String `tfsdk:"source"`
-	Name         types.String `tfsdk:"name"`
-	Value        types.String `tfsdk:"value"`
-	CredentialID types.String `tfsdk:"credential_id"`
-	Key          types.String `tfsdk:"key"`
+	Source         types.String `tfsdk:"source"`
+	Name           types.String `tfsdk:"name"`
+	Value          types.String `tfsdk:"value"`
+	DrCredentialID types.String `tfsdk:"dr_credential_id"`
+	Key            types.String `tfsdk:"key"`
 }
 
 type ArtifactProbeConfigModel struct {

--- a/pkg/provider/workload_resource.go
+++ b/pkg/provider/workload_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/datarobot-community/terraform-provider-datarobot/internal/client"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -193,13 +195,19 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 														Optional:            true,
 														MarkdownDescription: "GPUs allocated to this container.",
 													},
-													"gpu_memory": schema.Int64Attribute{
+													"gpu_memory": schema.StringAttribute{
 														Optional:            true,
-														MarkdownDescription: "GPU VRAM allocated in bytes.",
+														MarkdownDescription: "GPU VRAM allocated. Accepts human-readable strings (e.g. `\"15GB\"`, `\"512MB\"`, `\"4096Mi\"`) or raw byte integers. 1000-based suffixes: KB, MB, GB, TB. 1024-based suffixes: Ki/KiB, Mi/MiB, Gi/GiB.",
+														Validators: []validator.String{
+															memoryStringValidator{},
+														},
 													},
-													"memory": schema.Int64Attribute{
+													"memory": schema.StringAttribute{
 														Optional:            true,
-														MarkdownDescription: "RAM allocated in bytes.",
+														MarkdownDescription: "RAM allocated. Accepts human-readable strings (e.g. `\"8GB\"`, `\"512MB\"`, `\"4096Mi\"`) or raw byte integers. 1000-based suffixes: KB, MB, GB, TB. 1024-based suffixes: Ki/KiB, Mi/MiB, Gi/GiB.",
+														Validators: []validator.String{
+															memoryStringValidator{},
+														},
 													},
 												},
 											},
@@ -574,11 +582,11 @@ func containerOverrideToClient(c WorkloadContainerOverrideModel) client.Containe
 			ra.GPU = &v
 		}
 		if !c.ResourceAllocation.GPUMemory.IsNull() && !c.ResourceAllocation.GPUMemory.IsUnknown() {
-			v := c.ResourceAllocation.GPUMemory.ValueInt64()
+			v, _ := parseMemoryBytes(c.ResourceAllocation.GPUMemory.ValueString())
 			ra.GPUMemory = &v
 		}
 		if !c.ResourceAllocation.Memory.IsNull() && !c.ResourceAllocation.Memory.IsUnknown() {
-			v := c.ResourceAllocation.Memory.ValueInt64()
+			v, _ := parseMemoryBytes(c.ResourceAllocation.Memory.ValueString())
 			ra.Memory = &v
 		}
 		co.ResourceAllocation = ra
@@ -592,6 +600,7 @@ func containerOverrideToClient(c WorkloadContainerOverrideModel) client.Containe
 //   - container_groups=nil (user omitted the block) must stay nil even if the API returns groups.
 //   - resource_bundles=nil (user omitted the field) must stay nil even if the API injects defaults.
 //   - bundle_selection_policy=null (user omitted the field) must stay null even if the API returns a default.
+//   - memory/gpu_memory: API normalizes to bytes; restore the user's original string format if values are semantically equal.
 func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) {
 	if desired.Description.IsNull() && data.Description.ValueString() == "" {
 		data.Description = types.StringNull()
@@ -612,6 +621,35 @@ func applySentinels(desired WorkloadResourceModel, data *WorkloadResourceModel) 
 			data.Runtime.ContainerGroups[i].ResourceBundles = nil
 		}
 		data.Runtime.ContainerGroups[i].BundleSelectionPolicy = dg.BundleSelectionPolicy
+		for j := range dg.Containers {
+			if j >= len(data.Runtime.ContainerGroups[i].Containers) {
+				break
+			}
+			restoreMemoryFormat(dg.Containers[j], &data.Runtime.ContainerGroups[i].Containers[j])
+		}
+	}
+}
+
+// restoreMemoryFormat keeps the user's original memory string in state when its byte value matches
+// what the API returned, preventing perpetual diffs caused by the API normalizing to raw bytes.
+func restoreMemoryFormat(desired WorkloadContainerOverrideModel, data *WorkloadContainerOverrideModel) {
+	if desired.ResourceAllocation == nil || data.ResourceAllocation == nil {
+		return
+	}
+	ra := desired.ResourceAllocation
+	if !ra.Memory.IsNull() && !data.ResourceAllocation.Memory.IsNull() {
+		if desiredBytes, err := parseMemoryBytes(ra.Memory.ValueString()); err == nil {
+			if dataBytes, err := parseMemoryBytes(data.ResourceAllocation.Memory.ValueString()); err == nil && desiredBytes == dataBytes {
+				data.ResourceAllocation.Memory = ra.Memory
+			}
+		}
+	}
+	if !ra.GPUMemory.IsNull() && !data.ResourceAllocation.GPUMemory.IsNull() {
+		if desiredBytes, err := parseMemoryBytes(ra.GPUMemory.ValueString()); err == nil {
+			if dataBytes, err := parseMemoryBytes(data.ResourceAllocation.GPUMemory.ValueString()); err == nil && desiredBytes == dataBytes {
+				data.ResourceAllocation.GPUMemory = ra.GPUMemory
+			}
+		}
 	}
 }
 
@@ -735,14 +773,14 @@ func loadContainerOverrideFromAPI(c client.ContainerOverride) WorkloadContainerO
 			ra.GPU = types.Float64Null()
 		}
 		if c.ResourceAllocation.GPUMemory != nil {
-			ra.GPUMemory = types.Int64Value(*c.ResourceAllocation.GPUMemory)
+			ra.GPUMemory = types.StringValue(strconv.FormatInt(*c.ResourceAllocation.GPUMemory, 10))
 		} else {
-			ra.GPUMemory = types.Int64Null()
+			ra.GPUMemory = types.StringNull()
 		}
 		if c.ResourceAllocation.Memory != nil {
-			ra.Memory = types.Int64Value(*c.ResourceAllocation.Memory)
+			ra.Memory = types.StringValue(strconv.FormatInt(*c.ResourceAllocation.Memory, 10))
 		} else {
-			ra.Memory = types.Int64Null()
+			ra.Memory = types.StringNull()
 		}
 		m.ResourceAllocation = ra
 	}

--- a/pkg/provider/workload_resource_test.go
+++ b/pkg/provider/workload_resource_test.go
@@ -1061,6 +1061,63 @@ func TestIntegrationWorkloadBundleSelectionPolicySentinel(t *testing.T) {
 	})
 }
 
+func TestIntegrationWorkloadStringMemoryNormalization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return mockService
+	})()
+
+	if globalTestCfg.ApiKey == "" {
+		t.Setenv(DataRobotApiKeyEnvVar, "fake")
+	}
+
+	id := uuid.NewString()
+	artifactID := uuid.NewString()
+	name := "workload-" + uuid.NewString()[:8]
+	replicaCount := int64(1)
+	endpoint := "https://workloads.example.com/" + id
+
+	// "512Mi" normalizes to 536870912 bytes; API returns that as int64.
+	cpu := 1.0
+	mem := int64(536870912) // 512 * 1024^2
+	apiWorkload := workloadFixture(id, artifactID, name, "", client.WorkloadImportanceLow, &replicaCount, &endpoint)
+	apiWorkload.Runtime.ContainerGroups[0].Containers = []client.ContainerOverride{
+		{Name: "main", ResourceAllocation: &client.ResourceAllocation{CPU: &cpu, Memory: &mem}},
+	}
+
+	mockService.EXPECT().CreateWorkload(gomock.Any(), gomock.Any()).Return(apiWorkload, nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // waitForRunning
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil) // post-create Read
+
+	// Destroy
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(apiWorkload, nil)
+	mockService.EXPECT().DeleteWorkload(gomock.Any(), id).Return(nil)
+	mockService.EXPECT().GetWorkload(gomock.Any(), id).Return(nil, client.NewNotFoundError("workload"))
+
+	resourceName := "datarobot_workload.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// "512Mi" is sent as bytes to the API; the original string is preserved in state
+				// because the sentinel restores it when the byte values match.
+				Config: workloadConfigWithStringMemory(name, artifactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName,
+						"runtime.container_groups.0.containers.0.resource_allocation.memory",
+						"512Mi"),
+				),
+			},
+		},
+	})
+}
+
 func workloadConfigWithResourceAllocation(name, artifactID string) string {
 	return fmt.Sprintf(`
 resource "datarobot_workload" "test" {
@@ -1076,6 +1133,31 @@ resource "datarobot_workload" "test" {
             resource_allocation = {
               cpu    = 1
               memory = 536870912
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+`, name, artifactID)
+}
+
+func workloadConfigWithStringMemory(name, artifactID string) string {
+	return fmt.Sprintf(`
+resource "datarobot_workload" "test" {
+  name        = %q
+  artifact_id = %q
+  runtime = {
+    container_groups = [
+      {
+        replica_count = 1
+        containers = [
+          {
+            name = "main"
+            resource_allocation = {
+              cpu    = 1
+              memory = "512Mi"
             }
           }
         ]


### PR DESCRIPTION
## Summary
This PR adds support for human-readable memory definition (like MiB, KiB, KB, GB and etc).

## Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema renames and type changes for workload memory and artifact credentials; incorrect parsing could mis-size allocations, though validation and unit tests mitigate this.
> 
> **Overview**
> Adds **human-readable memory** for `datarobot_workload` container `resource_allocation`: `memory` and `gpu_memory` are now **strings** (e.g. `"8GB"`, `"512Mi"`, or raw byte integers) with validation and conversion to bytes for the API. **State sentinels** keep the user’s string when the API returns the same value as normalized bytes, avoiding plan drift.
> 
> Renames **`credential_id` → `dr_credential_id`** on `datarobot_artifact` container `environment_vars` when `source = "dr-credential"` to align with the Workload API (schema, validation, models, docs, and tests updated).
> 
> **Breaking:** existing configs must switch artifact credential attribute name and workload memory from numeric bytes to strings if they relied on the old types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3126fae419806511868b52532f9b298e3df006fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->