### PR TITLE
Add review-router workflow and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @datarobot-community/dsx

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,0 +1,17 @@
+---
+name: Review Router
+
+on:
+  pull_request_target:
+    types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+jobs:
+  route:
+    if: >-
+      github.event_name != 'issue_comment' || contains(github.event.comment.body, '/review')
+    uses: datarobot-community/.github/.github/workflows/review-router.yml@main
+    secrets: inherit

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,6 +1,15 @@
 ---
 name: Review Router
 
+# SECURITY: This workflow intentionally uses pull_request_target (not
+# pull_request) because review-router never checks out or executes PR code.
+# Do NOT add actions/checkout or shell run: blocks here.
+#
+# If you need to build or test PR code, use a separate workflow with the
+# pull_request trigger instead.
+#
+# See: https://github.com/datarobot-oss/review-router/blob/main/docs/security/pull-request-target.md
+
 on:
   pull_request_target:
     types: [labeled]


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions and CODEOWNERS metadata; no runtime application or security-sensitive product code changes.
> 
> **Overview**
> Adds **default code ownership** so every path is owned by `@datarobot-community/dsx`, which drives GitHub’s automatic review requests.
> 
> Adds a **Review Router** workflow that runs on PR label changes, submitted reviews, and issue comments (only when the comment contains `/review`). The job **reuses** the shared `datarobot-community/.github` `review-router` workflow on `main` and passes through repository secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f3ae7678d80da13f61fe5f7876abd083b51045. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->