### PR TITLE
feat: add example resources for custom models, prediction environment…

### DIFF
--- a/docs/resources/batch_prediction_job_definition.md
+++ b/docs/resources/batch_prediction_job_definition.md
@@ -13,6 +13,36 @@ Batch Prediction Job Definition
 ## Example Usage
 
 ```terraform
+resource "datarobot_custom_model" "batch_prediction_job_definition" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "batch_prediction_job_definition" {
+  custom_model_version_id = datarobot_custom_model.batch_prediction_job_definition.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "batch_prediction_job_definition" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "batch_prediction_job_definition" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.batch_prediction_job_definition.id
+  registered_model_version_id = datarobot_registered_model.batch_prediction_job_definition.version_id
+}
+
+resource "datarobot_basic_credential" "batch_prediction_job_definition" {
+  name     = "Example Basic Credential"
+  user     = "example_user"
+  password = "example_password"
+}
+
 resource "datarobot_batch_prediction_job_definition" "example" {
   name          = "Example Batch Prediction Job Definition"
   deployment_id = datarobot_deployment.batch_prediction_job_definition.id

--- a/docs/resources/custom_application_from_environment.md
+++ b/docs/resources/custom_application_from_environment.md
@@ -13,6 +13,13 @@ Custom Application created from an Execution Environment.
 ## Example Usage
 
 ```terraform
+resource "datarobot_execution_environment" "example" {
+  name                 = "Example Execution Environment"
+  programming_language = "python"
+  docker_image         = "docker_image.tar"
+  use_cases            = ["customApplication"]
+}
+
 resource "datarobot_custom_application_from_environment" "example" {
   name           = "example-custom-app-from-environment"
   environment_id = datarobot_execution_environment.example.id

--- a/docs/resources/custom_metric.md
+++ b/docs/resources/custom_metric.md
@@ -13,6 +13,30 @@ Custom Metric
 ## Example Usage
 
 ```terraform
+resource "datarobot_custom_model" "example" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "example" {
+  custom_model_version_id = datarobot_custom_model.example.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "example" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "example" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.example.id
+  registered_model_version_id = datarobot_registered_model.example.version_id
+}
+
 resource "datarobot_custom_metric" "example" {
   deployment_id     = datarobot_deployment.example.id
   name              = "example custom metric"

--- a/docs/resources/datasource.md
+++ b/docs/resources/datasource.md
@@ -13,6 +13,32 @@ Data source
 ## Example Usage
 
 ```terraform
+resource "datarobot_datastore" "example_database" {
+  canonical_name  = "Example Database Datastore"
+  data_store_type = "dr-database-v1"
+  driver_id       = "64a288a50636598d75df7f82"
+  fields = [
+    {
+      "id" : "bq.project_id",
+      "name" : "Project Id",
+      "value" : "project-id"
+    },
+  ]
+}
+
+resource "datarobot_datastore" "example_connector" {
+  canonical_name  = "Example Connector Datastore"
+  data_store_type = "dr-connector-v1"
+  connector_id    = "65538041dde6a1d664d0b2ec"
+  fields = [
+    {
+      "id" : "fs.defaultFS",
+      "name" : "Bucket Name",
+      "value" : "my-bucket"
+    }
+  ]
+}
+
 resource "datarobot_datasource" "example_database_table" {
   canonical_name   = "Example Database Table Data Source"
   data_source_type = "dr-database-v1"

--- a/docs/resources/deployment_retraining_policy.md
+++ b/docs/resources/deployment_retraining_policy.md
@@ -13,6 +13,44 @@ Deployment Retraining Policy
 ## Example Usage
 
 ```terraform
+resource "datarobot_use_case" "example" {
+  name = "Example use case"
+}
+
+resource "datarobot_custom_model" "example" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "example" {
+  custom_model_version_id = datarobot_custom_model.example.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "example" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "example" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.example.id
+  registered_model_version_id = datarobot_registered_model.example.version_id
+}
+
+resource "datarobot_custom_job" "example" {
+  name           = "Example Custom Job"
+  job_type       = "retraining"
+  environment_id = "65f9b27eab986d30d4c64268"
+  files = [
+    "file1.py",
+    "file2.py",
+  ]
+}
+
 resource "datarobot_deployment_retraining_policy" "example" {
   deployment_id = datarobot_deployment.example.id
   name          = "Example Deployment Retraining Policy"

--- a/examples/resources/datarobot_batch_prediction_job_definition/resource.tf
+++ b/examples/resources/datarobot_batch_prediction_job_definition/resource.tf
@@ -1,3 +1,33 @@
+resource "datarobot_custom_model" "batch_prediction_job_definition" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "batch_prediction_job_definition" {
+  custom_model_version_id = datarobot_custom_model.batch_prediction_job_definition.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "batch_prediction_job_definition" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "batch_prediction_job_definition" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.batch_prediction_job_definition.id
+  registered_model_version_id = datarobot_registered_model.batch_prediction_job_definition.version_id
+}
+
+resource "datarobot_basic_credential" "batch_prediction_job_definition" {
+  name     = "Example Basic Credential"
+  user     = "example_user"
+  password = "example_password"
+}
+
 resource "datarobot_batch_prediction_job_definition" "example" {
   name          = "Example Batch Prediction Job Definition"
   deployment_id = datarobot_deployment.batch_prediction_job_definition.id

--- a/examples/resources/datarobot_custom_application_from_environment/resource.tf
+++ b/examples/resources/datarobot_custom_application_from_environment/resource.tf
@@ -1,3 +1,10 @@
+resource "datarobot_execution_environment" "example" {
+  name                 = "Example Execution Environment"
+  programming_language = "python"
+  docker_image         = "docker_image.tar"
+  use_cases            = ["customApplication"]
+}
+
 resource "datarobot_custom_application_from_environment" "example" {
   name           = "example-custom-app-from-environment"
   environment_id = datarobot_execution_environment.example.id

--- a/examples/resources/datarobot_custom_metric/resource.tf
+++ b/examples/resources/datarobot_custom_metric/resource.tf
@@ -1,3 +1,27 @@
+resource "datarobot_custom_model" "example" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "example" {
+  custom_model_version_id = datarobot_custom_model.example.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "example" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "example" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.example.id
+  registered_model_version_id = datarobot_registered_model.example.version_id
+}
+
 resource "datarobot_custom_metric" "example" {
   deployment_id     = datarobot_deployment.example.id
   name              = "example custom metric"

--- a/examples/resources/datarobot_datasource/resource.tf
+++ b/examples/resources/datarobot_datasource/resource.tf
@@ -1,3 +1,29 @@
+resource "datarobot_datastore" "example_database" {
+  canonical_name  = "Example Database Datastore"
+  data_store_type = "dr-database-v1"
+  driver_id       = "64a288a50636598d75df7f82"
+  fields = [
+    {
+      "id" : "bq.project_id",
+      "name" : "Project Id",
+      "value" : "project-id"
+    },
+  ]
+}
+
+resource "datarobot_datastore" "example_connector" {
+  canonical_name  = "Example Connector Datastore"
+  data_store_type = "dr-connector-v1"
+  connector_id    = "65538041dde6a1d664d0b2ec"
+  fields = [
+    {
+      "id" : "fs.defaultFS",
+      "name" : "Bucket Name",
+      "value" : "my-bucket"
+    }
+  ]
+}
+
 resource "datarobot_datasource" "example_database_table" {
   canonical_name   = "Example Database Table Data Source"
   data_source_type = "dr-database-v1"

--- a/examples/resources/datarobot_deployment_retraining_policy/resource.tf
+++ b/examples/resources/datarobot_deployment_retraining_policy/resource.tf
@@ -1,3 +1,41 @@
+resource "datarobot_use_case" "example" {
+  name = "Example use case"
+}
+
+resource "datarobot_custom_model" "example" {
+  name                = "Example Custom Model"
+  target_type         = "Binary"
+  target_name         = "my_label"
+  base_environment_id = "65f9b27eab986d30d4c64268"
+  files               = ["example.py"]
+}
+
+resource "datarobot_registered_model" "example" {
+  custom_model_version_id = datarobot_custom_model.example.version_id
+  name                    = "Example Registered Model"
+}
+
+resource "datarobot_prediction_environment" "example" {
+  name     = "Example Prediction Environment"
+  platform = "datarobotServerless"
+}
+
+resource "datarobot_deployment" "example" {
+  label                       = "An example deployment"
+  prediction_environment_id   = datarobot_prediction_environment.example.id
+  registered_model_version_id = datarobot_registered_model.example.version_id
+}
+
+resource "datarobot_custom_job" "example" {
+  name           = "Example Custom Job"
+  job_type       = "retraining"
+  environment_id = "65f9b27eab986d30d4c64268"
+  files = [
+    "file1.py",
+    "file2.py",
+  ]
+}
+
 resource "datarobot_deployment_retraining_policy" "example" {
   deployment_id = datarobot_deployment.example.id
   name          = "Example Deployment Retraining Policy"


### PR DESCRIPTION
…s, and deployment policies

<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no impact on provider behavior or APIs.
> 
> **Overview**
> Makes several resource **docs** and matching **`examples/resources`** snippets self-contained by adding the upstream Terraform resources they reference, instead of assuming readers already have deployments, datastores, or execution environments defined elsewhere.
> 
> For **batch prediction**, **custom metric**, and **deployment retraining policy**, examples now include the custom model → registered model → prediction environment → deployment chain (plus **basic credential** or **custom job** / **use case** where required). **Datasource** examples add **datastore** blocks for database and connector types. **Custom application from environment** adds an **execution environment** resource before the app resource.
> 
> No provider schema or runtime behavior changes—documentation and copy-paste examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538e6518a882a803e4ddf455324ee3a78dc31ea3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->