### PR TITLE
Create inputset Base

### DIFF
--- a/.harness/orgs/DSX/projects/Declarative_API/pipelines/terraformproviderdatarobotpr/input_sets/Base.yaml
+++ b/.harness/orgs/DSX/projects/Declarative_API/pipelines/terraformproviderdatarobotpr/input_sets/Base.yaml
@@ -1,0 +1,43 @@
+inputSet:
+  name: Base
+  identifier: Base
+  orgIdentifier: DSX
+  projectIdentifier: Declarative_API
+  pipeline:
+    identifier: terraformproviderdatarobotpr
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    stages:
+      - stage:
+          identifier: Tests
+          type: CI
+          spec:
+            execution:
+              steps:
+                - step:
+                    identifier: Run_1
+                    type: Run
+                    spec:
+                      image: datarobotdev/platform-base-golang-devel
+                - step:
+                    identifier: Notify_dsxalerts
+                    template:
+                      templateInputs:
+                        type: Run
+                        spec:
+                          envVariables:
+                            SLACK_URL: ""
+                            MESSAGE_DETAILS_FILENAME: ./SLACK_MESSAGE.md
+          variables:
+            - name: endpoint
+              type: String
+              value: https://staging.datarobot.com/api/v2
+            - name: apiKey
+              type: Secret
+              default: dr_staging_api_key
+              value: dr_staging_api_key


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI configuration only; no application or provider runtime code changes.
> 
> **Overview**
> Adds a Harness **Base** input set for the `terraformproviderdatarobotpr` pipeline so PR builds can run without manual input.
> 
> The input set sets the codebase build to **PR** with `number: <+trigger.prNumber>`, runs the **Tests** CI stage on `datarobotdev/platform-base-golang-devel`, includes the **Notify_dsxalerts** step template (Slack message from `./SLACK_MESSAGE.md`), and pins **endpoint** to staging (`https://staging.datarobot.com/api/v2`) with **apiKey** defaulting to `dr_staging_api_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c26cdcadf0798033b8fa105d09e2df060e225f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->