### PR TITLE
Create inputset Full_run_inputset

### DIFF
--- a/.harness/orgs/DSX/projects/Declarative_API/pipelines/terraformproviderdatarobotfull/input_sets/Full_run_inputset.yaml
+++ b/.harness/orgs/DSX/projects/Declarative_API/pipelines/terraformproviderdatarobotfull/input_sets/Full_run_inputset.yaml
@@ -1,0 +1,104 @@
+inputSet:
+  name: Full_run_inputset
+  identifier: Full_run_inputset
+  orgIdentifier: DSX
+  projectIdentifier: Declarative_API
+  pipeline:
+    identifier: terraformproviderdatarobotfull
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: main
+    stages:
+      - parallel:
+          - stage:
+              identifier: TestsFast
+              type: CI
+              spec:
+                execution:
+                  steps:
+                    - step:
+                        identifier: RunFast
+                        type: Run
+                        spec:
+                          image: datarobotdev/platform-base-golang-devel
+                    - step:
+                        identifier: Notify_dsxalerts_fast
+                        template:
+                          templateInputs:
+                            type: Run
+                            spec:
+                              envVariables:
+                                SLACK_URL: ""
+                                MESSAGE_DETAILS_FILENAME: ./SLACK_MESSAGE.md
+          - stage:
+              identifier: TestsModels
+              type: CI
+              spec:
+                execution:
+                  steps:
+                    - step:
+                        identifier: RunModels
+                        type: Run
+                        spec:
+                          image: datarobotdev/platform-base-golang-devel
+                    - step:
+                        identifier: Notify_dsxalerts_models
+                        template:
+                          templateInputs:
+                            type: Run
+                            spec:
+                              envVariables:
+                                SLACK_URL: ""
+                                MESSAGE_DETAILS_FILENAME: ./SLACK_MESSAGE.md
+          - stage:
+              identifier: TestsDeployments
+              type: CI
+              spec:
+                execution:
+                  steps:
+                    - step:
+                        identifier: RunDeployments
+                        type: Run
+                        spec:
+                          image: datarobotdev/platform-base-golang-devel
+                    - step:
+                        identifier: Notify_dsxalerts_deployments
+                        template:
+                          templateInputs:
+                            type: Run
+                            spec:
+                              envVariables:
+                                SLACK_URL: ""
+                                MESSAGE_DETAILS_FILENAME: ./SLACK_MESSAGE.md
+          - stage:
+              identifier: TestsApps
+              type: CI
+              spec:
+                execution:
+                  steps:
+                    - step:
+                        identifier: RunApps
+                        type: Run
+                        spec:
+                          image: datarobotdev/platform-base-golang-devel
+                    - step:
+                        identifier: Notify_dsxalerts_apps
+                        template:
+                          templateInputs:
+                            type: Run
+                            spec:
+                              envVariables:
+                                SLACK_URL: ""
+                                MESSAGE_DETAILS_FILENAME: ./SLACK_MESSAGE.md
+    variables:
+      - name: endpoint
+        type: String
+        value: https://staging.datarobot.com/api/v2
+      - name: apiKey
+        type: Secret
+        default: dr_staging_api_key
+        value: dr_staging_api_key


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI configuration only; no application or provider runtime code changes.
> 
> **Overview**
> Adds a Harness **input set** (`Full_run_inputset`) for the `terraformproviderdatarobotfull` pipeline so a full acceptance run can be triggered with fixed defaults instead of manual inputs.
> 
> It pins the codebase build to **`main`**, sets pipeline variables to **staging** (`endpoint` + `dr_staging_api_key`), and overrides the four parallel CI stages (**TestsFast**, **TestsModels**, **TestsDeployments**, **TestsApps**) to use `datarobotdev/platform-base-golang-devel` and Slack notify steps with empty `SLACK_URL` and `./SLACK_MESSAGE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f0245a308751978779f9c7e4fd22ebf3ef66c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->