### PR TITLE
fix: run full suite as parallel follow-up stages instead of inline on shared-code PRs

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -1,8 +1,17 @@
-# PR acceptance test pipeline — selective, runs only tests for changed files.
-# Uses scripts/run-changed-tests.sh to map changed source → test files → TestAcc*/TestIntegration* functions.
-# Expected wall-clock: 5-20 min per PR (vs. 60-80 min for the full suite).
+# PR acceptance test pipeline — two-phase: selective first, full suite only if needed.
 #
-# For the full-suite pipeline (main merges / release), see full_suite_pipeline.yml.
+# Phase 1 (always runs): scripts/run-changed-tests.sh maps changed source → test
+# files → TestAcc*/TestIntegration* functions and runs only those. Fast signal
+# on the direct change. Expected wall-clock: 5-20 min per PR.
+#
+# Phase 2 (conditional): if run-changed-tests.sh detects a shared helper or
+# internal/client/ change (NEEDS_FULL_SUITE=true, exported as a step output
+# variable), the four parallel group stages run afterward — same
+# testacc-group-* targets used by full_suite_pipeline.yml — to catch anything
+# the selective run couldn't see. PRs that don't touch shared code skip phase 2
+# entirely and stay fast.
+#
+# For the unconditional post-merge full-suite pipeline, see full_suite_pipeline.yml.
 pipeline:
   name: terraform-provider-datarobot-pr
   identifier: terraformproviderdatarobotpr
@@ -59,10 +68,12 @@ pipeline:
                         paths:
                           - /harness/report.xml
                     envVariables:
-                      DATAROBOT_ENDPOINT: <+stage.variables.endpoint>
-                      DATAROBOT_API_TOKEN: <+stage.variables.apiKey>
+                      DATAROBOT_ENDPOINT: <+pipeline.variables.endpoint>
+                      DATAROBOT_API_TOKEN: <+pipeline.variables.apiKey>
                       DATAROBOT_USERNAME: declarative_user_admin@datarobot.com
                       DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
+                    outputVariables:
+                      - name: NEEDS_FULL_SUITE
                     resources:
                       limits:
                         memory: 4Gi
@@ -90,15 +101,313 @@ pipeline:
             paths: []
           buildIntelligence:
             enabled: false
-        variables:
-          - name: endpoint
-            type: String
-            description: ""
-            required: false
-            value: <+input>.default(https://staging.datarobot.com/api/v2).allowedValues(https://staging.datarobot.com/api/v2,https://app.datarobot.com/api/v2,https://dr-app-charts-r10p2-daily-eks.rd.int.datarobot.com/api/v2,https://private-ca-testing.rd.int.datarobot.com/api/v2)
-          - name: apiKey
-            type: Secret
-            default: dr_staging_api_key
-            description: ""
-            required: false
-            value: <+input>.default(dr_staging_api_key).allowedValues(dr_staging_api_key,dr_app_charts_r10p2_api_key,dr_private_ca_api_key)
+
+    - parallel:
+        - stage:
+            name: Tests Fast (full suite)
+            identifier: TestsFastPR
+            type: CI
+            when:
+              pipelineStatus: Success
+              condition: <+pipeline.stages.Tests.spec.execution.steps.Run_1.output.outputVariables.NEEDS_FULL_SUITE> == "true"
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Fast Group
+                      identifier: RunFast
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: <+input>.default(datarobotdev/platform-base-golang-devel)
+                        shell: Sh
+                        command: |-
+                          microdnf install unzip
+                          TERRAFORM_VERSION="1.14.5"
+                          curl -o terraform.zip -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+                          unzip terraform.zip && mv terraform /usr/local/bin
+                          export PATH=$(go env GOPATH)/bin:$PATH
+                          go install github.com/jstemmer/go-junit-report/v2@latest
+                          go mod download
+                          make testacc-group-fast
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/report-fast.xml
+                        envVariables:
+                          DATAROBOT_ENDPOINT: <+pipeline.variables.endpoint>
+                          DATAROBOT_API_TOKEN: <+pipeline.variables.apiKey>
+                          DATAROBOT_USERNAME: declarative_user_admin@datarobot.com
+                          DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
+                          REPORT_FILE: /harness/report-fast.xml
+                        resources:
+                          limits:
+                            memory: 4Gi
+                            cpu: "4"
+                  - step:
+                      name: Notify dsx-alerts
+                      identifier: Notify_dsxalerts_fast
+                      template:
+                        templateRef: org.Send_Slack_notification
+                        versionLabel: v1
+                        templateInputs:
+                          type: Run
+                          spec:
+                            envVariables:
+                              SLACK_CHANNEL: dsx-alerts
+                              SLACK_URL: <+input>.default("")
+                              MESSAGE_TYPE: Error
+                              MESSAGE_TITLE: Declarative API Terraform Tests Failed (fast)
+                              MESSAGE_TEXT: "@here Check the pipeline logs to see more details..."
+                              MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
+                      when:
+                        stageStatus: Failure
+              caching:
+                enabled: false
+              buildIntelligence:
+                enabled: false
+
+        - stage:
+            name: Tests Models (full suite)
+            identifier: TestsModelsPR
+            type: CI
+            when:
+              pipelineStatus: Success
+              condition: <+pipeline.stages.Tests.spec.execution.steps.Run_1.output.outputVariables.NEEDS_FULL_SUITE> == "true"
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Models Group
+                      identifier: RunModels
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: <+input>.default(datarobotdev/platform-base-golang-devel)
+                        shell: Sh
+                        command: |-
+                          microdnf install unzip
+                          TERRAFORM_VERSION="1.14.5"
+                          curl -o terraform.zip -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+                          unzip terraform.zip && mv terraform /usr/local/bin
+                          export PATH=$(go env GOPATH)/bin:$PATH
+                          go install github.com/jstemmer/go-junit-report/v2@latest
+                          go mod download
+                          make testacc-group-models
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/report-models.xml
+                        envVariables:
+                          DATAROBOT_ENDPOINT: <+pipeline.variables.endpoint>
+                          DATAROBOT_API_TOKEN: <+pipeline.variables.apiKey>
+                          DATAROBOT_USERNAME: declarative_user_admin@datarobot.com
+                          DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
+                          REPORT_FILE: /harness/report-models.xml
+                        resources:
+                          limits:
+                            memory: 4Gi
+                            cpu: "6"
+                  - step:
+                      name: Notify dsx-alerts
+                      identifier: Notify_dsxalerts_models
+                      template:
+                        templateRef: org.Send_Slack_notification
+                        versionLabel: v1
+                        templateInputs:
+                          type: Run
+                          spec:
+                            envVariables:
+                              SLACK_CHANNEL: dsx-alerts
+                              SLACK_URL: <+input>.default("")
+                              MESSAGE_TYPE: Error
+                              MESSAGE_TITLE: Declarative API Terraform Tests Failed (models)
+                              MESSAGE_TEXT: "@here Check the pipeline logs to see more details..."
+                              MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
+                      when:
+                        stageStatus: Failure
+              caching:
+                enabled: false
+              buildIntelligence:
+                enabled: false
+
+        - stage:
+            name: Tests Deployments (full suite)
+            identifier: TestsDeploymentsPR
+            type: CI
+            when:
+              pipelineStatus: Success
+              condition: <+pipeline.stages.Tests.spec.execution.steps.Run_1.output.outputVariables.NEEDS_FULL_SUITE> == "true"
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Deployments Group
+                      identifier: RunDeployments
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: <+input>.default(datarobotdev/platform-base-golang-devel)
+                        shell: Sh
+                        command: |-
+                          microdnf install unzip
+                          TERRAFORM_VERSION="1.14.5"
+                          curl -o terraform.zip -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+                          unzip terraform.zip && mv terraform /usr/local/bin
+                          export PATH=$(go env GOPATH)/bin:$PATH
+                          go install github.com/jstemmer/go-junit-report/v2@latest
+                          go mod download
+                          make testacc-group-deployments
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/report-deployments.xml
+                        envVariables:
+                          DATAROBOT_ENDPOINT: <+pipeline.variables.endpoint>
+                          DATAROBOT_API_TOKEN: <+pipeline.variables.apiKey>
+                          DATAROBOT_USERNAME: declarative_user_admin@datarobot.com
+                          DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
+                          REPORT_FILE: /harness/report-deployments.xml
+                        resources:
+                          limits:
+                            memory: 4Gi
+                            cpu: "6"
+                  - step:
+                      name: Notify dsx-alerts
+                      identifier: Notify_dsxalerts_deployments
+                      template:
+                        templateRef: org.Send_Slack_notification
+                        versionLabel: v1
+                        templateInputs:
+                          type: Run
+                          spec:
+                            envVariables:
+                              SLACK_CHANNEL: dsx-alerts
+                              SLACK_URL: <+input>.default("")
+                              MESSAGE_TYPE: Error
+                              MESSAGE_TITLE: Declarative API Terraform Tests Failed (deployments)
+                              MESSAGE_TEXT: "@here Check the pipeline logs to see more details..."
+                              MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
+                      when:
+                        stageStatus: Failure
+              caching:
+                enabled: false
+              buildIntelligence:
+                enabled: false
+
+        - stage:
+            name: Tests Apps (full suite)
+            identifier: TestsAppsPR
+            type: CI
+            when:
+              pipelineStatus: Success
+              condition: <+pipeline.stages.Tests.spec.execution.steps.Run_1.output.outputVariables.NEEDS_FULL_SUITE> == "true"
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Apps Group
+                      identifier: RunApps
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: <+input>.default(datarobotdev/platform-base-golang-devel)
+                        shell: Sh
+                        command: |-
+                          microdnf install unzip
+                          TERRAFORM_VERSION="1.14.5"
+                          curl -o terraform.zip -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+                          unzip terraform.zip && mv terraform /usr/local/bin
+                          export PATH=$(go env GOPATH)/bin:$PATH
+                          go install github.com/jstemmer/go-junit-report/v2@latest
+                          go mod download
+                          make testacc-group-apps
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/report-apps.xml
+                        envVariables:
+                          DATAROBOT_ENDPOINT: <+pipeline.variables.endpoint>
+                          DATAROBOT_API_TOKEN: <+pipeline.variables.apiKey>
+                          DATAROBOT_USERNAME: declarative_user_admin@datarobot.com
+                          DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
+                          REPORT_FILE: /harness/report-apps.xml
+                        resources:
+                          limits:
+                            memory: 4Gi
+                            cpu: "4"
+                  - step:
+                      name: Notify dsx-alerts
+                      identifier: Notify_dsxalerts_apps
+                      template:
+                        templateRef: org.Send_Slack_notification
+                        versionLabel: v1
+                        templateInputs:
+                          type: Run
+                          spec:
+                            envVariables:
+                              SLACK_CHANNEL: dsx-alerts
+                              SLACK_URL: <+input>.default("")
+                              MESSAGE_TYPE: Error
+                              MESSAGE_TITLE: Declarative API Terraform Tests Failed (apps)
+                              MESSAGE_TEXT: "@here Check the pipeline logs to see more details..."
+                              MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
+                      when:
+                        stageStatus: Failure
+              caching:
+                enabled: false
+              buildIntelligence:
+                enabled: false
+
+  variables:
+    - name: endpoint
+      type: String
+      description: ""
+      required: false
+      value: <+input>.default(https://staging.datarobot.com/api/v2).allowedValues(https://staging.datarobot.com/api/v2,https://app.datarobot.com/api/v2,https://dr-app-charts-r10p2-daily-eks.rd.int.datarobot.com/api/v2,https://private-ca-testing.rd.int.datarobot.com/api/v2)
+    - name: apiKey
+      type: Secret
+      default: dr_staging_api_key
+      description: ""
+      required: false
+      value: <+input>.default(dr_staging_api_key).allowedValues(dr_staging_api_key,dr_app_charts_r10p2_api_key,dr_private_ca_api_key)

--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -104,7 +104,7 @@ pipeline:
 
     - parallel:
         - stage:
-            name: Tests Fast (full suite)
+            name: Tests Fast - Full Suite
             identifier: TestsFastPR
             type: CI
             when:
@@ -178,7 +178,7 @@ pipeline:
                 enabled: false
 
         - stage:
-            name: Tests Models (full suite)
+            name: Tests Models - Full Suite
             identifier: TestsModelsPR
             type: CI
             when:
@@ -252,7 +252,7 @@ pipeline:
                 enabled: false
 
         - stage:
-            name: Tests Deployments (full suite)
+            name: Tests Deployments - Full Suite
             identifier: TestsDeploymentsPR
             type: CI
             when:
@@ -326,7 +326,7 @@ pipeline:
                 enabled: false
 
         - stage:
-            name: Tests Apps (full suite)
+            name: Tests Apps - Full Suite
             identifier: TestsAppsPR
             type: CI
             when:

--- a/scripts/run-changed-tests.sh
+++ b/scripts/run-changed-tests.sh
@@ -6,6 +6,12 @@
 # pkg/provider/ and internal/client/, and runs only the relevant TestAcc*
 # acceptance tests. Produces a JUnit XML report compatible with Harness.
 #
+# If a shared helper or internal/client/ file changed, this script does NOT
+# run the full suite inline — it still runs selective tests for any directly
+# changed resource/test files (if any), and exports NEEDS_FULL_SUITE=true so
+# the caller (Harness pipeline) can trigger the parallel group-based full
+# suite as a follow-up stage. See .harness/acceptnce_pipeline.yml.
+#
 # Environment variables:
 #   BASE_REF        — target branch to diff against (required, e.g. "main")
 #   REPORT_FILE     — JUnit XML output path    (default: /harness/report.xml)
@@ -81,6 +87,13 @@ source_to_test_file() {
   echo "pkg/provider/${base}_test.go"
 }
 
+# Export NEEDS_FULL_SUITE so the Harness step's outputVariables capture it,
+# signalling whether the follow-up parallel full-suite stages should run.
+export_needs_full_suite() {
+  export NEEDS_FULL_SUITE="$1"
+  echo "==> NEEDS_FULL_SUITE=${1}"
+}
+
 ###############################################################################
 # 1. Fetch target branch & compute diff
 ###############################################################################
@@ -94,6 +107,7 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD"
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "No changed files detected."
   write_empty_report
+  export_needs_full_suite false
   exit 0
 fi
 
@@ -154,44 +168,57 @@ done <<< "$CHANGED_FILES"
 
 ###############################################################################
 # 3. Build test regex
+#
+# NOTE: even when RUN_ALL is true (shared helper or internal/client/ change),
+# we do NOT run the full suite here — that's too slow for a single serial
+# step. We only run tests for any directly-changed resource/test files, and
+# export NEEDS_FULL_SUITE=true so the Harness pipeline runs the full suite
+# afterward via the parallel testacc-group-* stages.
 ###############################################################################
 if $RUN_ALL; then
   echo ""
-  echo "==> Running ALL acceptance tests (shared code changed)"
-  TEST_RUN_ARG=""
-elif [[ ${#TEST_FILES_TO_SCAN[@]} -eq 0 ]]; then
-  echo ""
-  echo "==> No relevant changes detected in pkg/provider/ or internal/client/. Skipping tests."
-  write_empty_report
-  exit 0
-else
-  # Collect unique TestAcc* function names from all identified test files
-  declare -A SEEN_TESTS
-  TEST_NAMES=()
-
-  for tf in "${TEST_FILES_TO_SCAN[@]}"; do
-    while IFS= read -r name; do
-      [[ -z "$name" ]] && continue
-      if [[ -z "${SEEN_TESTS[$name]+x}" ]]; then
-        SEEN_TESTS[$name]=1
-        TEST_NAMES+=("$name")
-      fi
-    done < <(extract_test_names "$tf")
-  done
-
-  if [[ ${#TEST_NAMES[@]} -eq 0 ]]; then
-    echo ""
-    echo "==> Changed test files contain no TestAcc* functions. Skipping tests."
-    write_empty_report
-    exit 0
-  fi
-
-  # Build regex: TestAccFoo|TestAccBar|...
-  REGEX=$(IFS='|'; echo "${TEST_NAMES[*]}")
-  TEST_RUN_ARG="-run ${REGEX}"
-  echo ""
-  echo "==> Running selective tests: ${REGEX}"
+  echo "==> Shared/client code changed — full suite will run separately in parallel group stages"
 fi
+
+if [[ ${#TEST_FILES_TO_SCAN[@]} -eq 0 ]]; then
+  echo ""
+  if $RUN_ALL; then
+    echo "==> No directly-changed resource/test files to run selectively."
+  else
+    echo "==> No relevant changes detected in pkg/provider/ or internal/client/. Skipping tests."
+  fi
+  write_empty_report
+  export_needs_full_suite "$RUN_ALL"
+  exit 0
+fi
+
+# Collect unique TestAcc* function names from all identified test files
+declare -A SEEN_TESTS
+TEST_NAMES=()
+
+for tf in "${TEST_FILES_TO_SCAN[@]}"; do
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if [[ -z "${SEEN_TESTS[$name]+x}" ]]; then
+      SEEN_TESTS[$name]=1
+      TEST_NAMES+=("$name")
+    fi
+  done < <(extract_test_names "$tf")
+done
+
+if [[ ${#TEST_NAMES[@]} -eq 0 ]]; then
+  echo ""
+  echo "==> Changed test files contain no TestAcc* functions. Skipping tests."
+  write_empty_report
+  export_needs_full_suite "$RUN_ALL"
+  exit 0
+fi
+
+# Build regex: TestAccFoo|TestAccBar|...
+REGEX=$(IFS='|'; echo "${TEST_NAMES[*]}")
+TEST_RUN_ARG="-run ${REGEX}"
+echo ""
+echo "==> Running selective tests: ${REGEX}"
 
 ###############################################################################
 # 4. Run tests
@@ -204,6 +231,8 @@ set +e
 TF_ACC=1 go test -v -cover ${TEST_RUN_ARG} -timeout "${TEST_TIMEOUT}" -parallel "${TEST_PARALLEL}" ./pkg/provider/ 2>&1 | tee report.out
 TEST_EXIT_CODE=${PIPESTATUS[0]}
 set -e
+
+export_needs_full_suite "$RUN_ALL"
 
 ###############################################################################
 # 5. Generate JUnit report


### PR DESCRIPTION
## Summary
- `scripts/run-changed-tests.sh` no longer falls back to an unfiltered `go test ./pkg/provider/` when a shared helper (e.g. `provider.go`, `utils.go`) or `internal/client/*` file changes — that ran the entire ~92-test suite serially inside a single PR step, negating the parallel group split `full_suite_pipeline.yml` already provides.
- It now always runs selective tests for any directly-changed resource/test files first (fast signal), and exports `NEEDS_FULL_SUITE=true|false` as a Harness step output variable.
- `.harness/acceptnce_pipeline.yml` gets four new parallel stages (`TestsFastPR`/`TestsModelsPR`/`TestsDeploymentsPR`/`TestsAppsPR`, mirroring `full_suite_pipeline.yml`'s groups) gated by `when.condition` on that flag — they only run when shared/client code was touched, so unrelated PRs stay fast.

## Test plan
- [x] `bash -n scripts/run-changed-tests.sh` — syntax check
- [x] Verified locally (temp commits, reset after) that a shared-helper-only change sets `NEEDS_FULL_SUITE=true` without running an inline full suite
- [x] Verified a resource-file-only change sets `NEEDS_FULL_SUITE=false` and runs the existing selective `-run` regex
- [x] Verified a combined shared+resource change runs the selective test AND sets `NEEDS_FULL_SUITE=true`
- [x] `make testacc-check-groups` still passes (94 tests, all covered)
- [ ] Confirm the new conditional stages fire correctly in an actual Harness PR run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes when shared/client code is touched: full coverage now depends on Harness correctly reading `NEEDS_FULL_SUITE` and firing the new conditional stages; mis-gating could skip or over-run tests.
> 
> **Overview**
> PR CI for acceptance tests is now **two-phase**: phase 1 still runs `run-changed-tests.sh` for a fast, change-scoped signal; phase 2 runs only when shared helpers or `internal/client/` change.
> 
> **`scripts/run-changed-tests.sh`** no longer runs an unfiltered full `go test ./pkg/provider/` when `RUN_ALL` is set. It keeps selective `-run` tests for directly touched resource/test files when present, and **exports `NEEDS_FULL_SUITE`** (`true`/`false`) on every exit path so Harness can decide follow-up work.
> 
> **`.harness/acceptnce_pipeline.yml`** captures that flag as a step output on the selective run, moves **endpoint/apiKey** to **pipeline-level** variables (referenced as `<+pipeline.variables.*>`), and adds **four parallel stages** (fast/models/deployments/apps) that mirror `full_suite_pipeline.yml` via `make testacc-group-*`. Those stages run only when `NEEDS_FULL_SUITE == "true"` after a successful first stage, so most PRs stay on the short selective path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a1d7bdc15b9486ae9ef5c4b025560e0ca24697. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->