### PR TITLE
Update pipeline terraform-provider-datarobot-pr

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -47,9 +47,11 @@ pipeline:
                       go install github.com/jstemmer/go-junit-report/v2@latest
                       go mod download
                       go build -v .
-                      BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
-
+                      NEEDS_FULL_SUITE_FILE=/tmp/needs_full_suite BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
+                      TEST_EXIT_CODE=$?
+                      export NEEDS_FULL_SUITE="$(cat /tmp/needs_full_suite 2>/dev/null || echo false)"
                       echo $NEEDS_FULL_SUITE
+                      exit "$TEST_EXIT_CODE"
                     reports:
                       type: JUnit
                       spec:

--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -1,17 +1,3 @@
-# PR acceptance test pipeline — two-phase: selective first, full suite only if needed.
-#
-# Phase 1 (always runs): scripts/run-changed-tests.sh maps changed source → test
-# files → TestAcc*/TestIntegration* functions and runs only those. Fast signal
-# on the direct change. Expected wall-clock: 5-20 min per PR.
-#
-# Phase 2 (conditional): if run-changed-tests.sh detects a shared helper or
-# internal/client/ change (NEEDS_FULL_SUITE=true, exported as a step output
-# variable), the four parallel group stages run afterward — same
-# testacc-group-* targets used by full_suite_pipeline.yml — to catch anything
-# the selective run couldn't see. PRs that don't touch shared code skip phase 2
-# entirely and stay fast.
-#
-# For the unconditional post-merge full-suite pipeline, see full_suite_pipeline.yml.
 pipeline:
   name: terraform-provider-datarobot-pr
   identifier: terraformproviderdatarobotpr
@@ -62,6 +48,8 @@ pipeline:
                       go mod download
                       go build -v .
                       BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
+
+                      echo $NEEDS_FULL_SUITE
                     reports:
                       type: JUnit
                       spec:
@@ -74,6 +62,8 @@ pipeline:
                       DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
                     outputVariables:
                       - name: NEEDS_FULL_SUITE
+                        type: String
+                        value: NEEDS_FULL_SUITE
                     resources:
                       limits:
                         memory: 4Gi
@@ -101,7 +91,6 @@ pipeline:
             paths: []
           buildIntelligence:
             enabled: false
-
     - parallel:
         - stage:
             name: Tests Fast - Full Suite
@@ -176,7 +165,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Models - Full Suite
             identifier: TestsModelsPR
@@ -250,7 +238,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Deployments - Full Suite
             identifier: TestsDeploymentsPR
@@ -324,7 +311,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Apps - Full Suite
             identifier: TestsAppsPR
@@ -398,7 +384,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
   variables:
     - name: endpoint
       type: String

--- a/scripts/run-changed-tests.sh
+++ b/scripts/run-changed-tests.sh
@@ -30,6 +30,9 @@ BASE_REF="${BASE_REF:-main}"
 REPORT_FILE="${REPORT_FILE:-/harness/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-60m}"
 TEST_PARALLEL="${TEST_PARALLEL:-6}"
+# Where the NEEDS_FULL_SUITE result is written so the caller (a separate
+# shell process — see export_needs_full_suite() below) can pick it up.
+NEEDS_FULL_SUITE_FILE="${NEEDS_FULL_SUITE_FILE:-/tmp/needs_full_suite}"
 
 # Shared helper files in pkg/provider/ that are used across all resources.
 # Any change to these triggers the full test suite.
@@ -87,10 +90,19 @@ source_to_test_file() {
   echo "pkg/provider/${base}_test.go"
 }
 
-# Export NEEDS_FULL_SUITE so the Harness step's outputVariables capture it,
+# Record NEEDS_FULL_SUITE for the Harness step's outputVariables capture,
 # signalling whether the follow-up parallel full-suite stages should run.
+#
+# NOTE: this script runs as `bash scripts/run-changed-tests.sh`, a child
+# process of the Harness step's own shell. A plain `export` here only sets
+# the variable in this child's environment — it can never propagate back to
+# the parent shell, since child process environment changes never flow
+# upstream. So we also write the value to a file; the pipeline step reads
+# that file and exports the variable itself, in the shell Harness inspects
+# for outputVariables. See .harness/acceptnce_pipeline.yml.
 export_needs_full_suite() {
   export NEEDS_FULL_SUITE="$1"
+  echo "$1" > "$NEEDS_FULL_SUITE_FILE"
   echo "==> NEEDS_FULL_SUITE=${1}"
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI orchestration only; no provider or test logic changes, though a miswired flag could skip or over-run full suites.
> 
> **Overview**
> Fixes PR CI so conditional **full acceptance suite** stages actually run when shared/client code changes.
> 
> `run-changed-tests.sh` runs as a **child** `bash` process, so `export NEEDS_FULL_SUITE` never reached the Harness step that reads `outputVariables`. The script now writes the flag to **`NEEDS_FULL_SUITE_FILE`** (default `/tmp/needs_full_suite`); the **Run Selective Tests** step reads that file, exports `NEEDS_FULL_SUITE` in the parent shell, and declares it as a typed step output. The step also **preserves the script’s test exit code** while still surfacing the flag for downstream `when` conditions on the parallel full-suite stages.
> 
> Long-form pipeline comments at the top of `acceptnce_pipeline.yml` were removed; behavior of the two-phase selective → optional full suite flow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1191e62ef47f5a7372418aab04359d085c9815. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->