### PR TITLE
fix: NEEDS_FULL_SUITE not propagating, causing manual dispatch to always run full suite

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -47,9 +47,11 @@ pipeline:
                       go install github.com/jstemmer/go-junit-report/v2@latest
                       go mod download
                       go build -v .
-                      BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
-
+                      NEEDS_FULL_SUITE_FILE=/tmp/needs_full_suite BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
+                      TEST_EXIT_CODE=$?
+                      export NEEDS_FULL_SUITE="$(cat /tmp/needs_full_suite 2>/dev/null || echo false)"
                       echo $NEEDS_FULL_SUITE
+                      exit "$TEST_EXIT_CODE"
                     reports:
                       type: JUnit
                       spec:

--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -1,17 +1,3 @@
-# PR acceptance test pipeline — two-phase: selective first, full suite only if needed.
-#
-# Phase 1 (always runs): scripts/run-changed-tests.sh maps changed source → test
-# files → TestAcc*/TestIntegration* functions and runs only those. Fast signal
-# on the direct change. Expected wall-clock: 5-20 min per PR.
-#
-# Phase 2 (conditional): if run-changed-tests.sh detects a shared helper or
-# internal/client/ change (NEEDS_FULL_SUITE=true, exported as a step output
-# variable), the four parallel group stages run afterward — same
-# testacc-group-* targets used by full_suite_pipeline.yml — to catch anything
-# the selective run couldn't see. PRs that don't touch shared code skip phase 2
-# entirely and stay fast.
-#
-# For the unconditional post-merge full-suite pipeline, see full_suite_pipeline.yml.
 pipeline:
   name: terraform-provider-datarobot-pr
   identifier: terraformproviderdatarobotpr
@@ -62,6 +48,8 @@ pipeline:
                       go mod download
                       go build -v .
                       BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
+
+                      echo $NEEDS_FULL_SUITE
                     reports:
                       type: JUnit
                       spec:
@@ -74,6 +62,8 @@ pipeline:
                       DATAROBOT_USER_ID: 69987d0c27ee4c2c40d1b924
                     outputVariables:
                       - name: NEEDS_FULL_SUITE
+                        type: String
+                        value: NEEDS_FULL_SUITE
                     resources:
                       limits:
                         memory: 4Gi
@@ -101,7 +91,6 @@ pipeline:
             paths: []
           buildIntelligence:
             enabled: false
-
     - parallel:
         - stage:
             name: Tests Fast - Full Suite
@@ -176,7 +165,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Models - Full Suite
             identifier: TestsModelsPR
@@ -250,7 +238,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Deployments - Full Suite
             identifier: TestsDeploymentsPR
@@ -324,7 +311,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
         - stage:
             name: Tests Apps - Full Suite
             identifier: TestsAppsPR
@@ -398,7 +384,6 @@ pipeline:
                 enabled: false
               buildIntelligence:
                 enabled: false
-
   variables:
     - name: endpoint
       type: String

--- a/scripts/run-changed-tests.sh
+++ b/scripts/run-changed-tests.sh
@@ -30,6 +30,9 @@ BASE_REF="${BASE_REF:-main}"
 REPORT_FILE="${REPORT_FILE:-/harness/report.xml}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-60m}"
 TEST_PARALLEL="${TEST_PARALLEL:-6}"
+# Where the NEEDS_FULL_SUITE result is written so the caller (a separate
+# shell process — see export_needs_full_suite() below) can pick it up.
+NEEDS_FULL_SUITE_FILE="${NEEDS_FULL_SUITE_FILE:-/tmp/needs_full_suite}"
 
 # Shared helper files in pkg/provider/ that are used across all resources.
 # Any change to these triggers the full test suite.
@@ -87,10 +90,19 @@ source_to_test_file() {
   echo "pkg/provider/${base}_test.go"
 }
 
-# Export NEEDS_FULL_SUITE so the Harness step's outputVariables capture it,
+# Record NEEDS_FULL_SUITE for the Harness step's outputVariables capture,
 # signalling whether the follow-up parallel full-suite stages should run.
+#
+# NOTE: this script runs as `bash scripts/run-changed-tests.sh`, a child
+# process of the Harness step's own shell. A plain `export` here only sets
+# the variable in this child's environment — it can never propagate back to
+# the parent shell, since child process environment changes never flow
+# upstream. So we also write the value to a file; the pipeline step reads
+# that file and exports the variable itself, in the shell Harness inspects
+# for outputVariables. See .harness/acceptnce_pipeline.yml.
 export_needs_full_suite() {
   export NEEDS_FULL_SUITE="$1"
+  echo "$1" > "$NEEDS_FULL_SUITE_FILE"
   echo "==> NEEDS_FULL_SUITE=${1}"
 }
 

--- a/scripts/run-changed-tests.sh
+++ b/scripts/run-changed-tests.sh
@@ -112,9 +112,35 @@ export_needs_full_suite() {
 echo "==> Fetching origin/${BASE_REF}..."
 git fetch origin "$BASE_REF" --depth=1 2>/dev/null || git fetch origin "$BASE_REF" || true
 
+# A shallow fetch of BASE_REF's tip has no shared history with a shallow
+# checkout of HEAD, so `git merge-base` (needed by the triple-dot diff below)
+# fails with "no merge base". On PR builds this stays hidden because Harness
+# checks out a merge commit whose direct parent IS the target branch tip, so
+# the merge-base resolves trivially even shallow. On manual/branch dispatch
+# there's no such merge commit, so it always fails here. Unshallow so the
+# real merge-base can be found either way.
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]; then
+  echo "==> Shallow clone detected — unshallowing for an accurate diff..."
+  git fetch --unshallow origin 2>/dev/null || git fetch --depth=1000 origin "$BASE_REF" HEAD 2>/dev/null || true
+fi
+
 echo "==> Computing diff against origin/${BASE_REF}..."
-CHANGED_FILES=$(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" 2>/dev/null || \
-                git diff --name-only --diff-filter=d "origin/${BASE_REF}" 2>/dev/null || true)
+MERGE_BASE=$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null || true)
+
+if [[ -z "$MERGE_BASE" ]]; then
+  # No safe way to scope the diff to just this branch's changes — a naive
+  # two-ref diff here would pick up every file that changed on BASE_REF
+  # since divergence (including unrelated shared-helper/internal/client
+  # changes from other merged PRs), falsely tripping RUN_ALL/NEEDS_FULL_SUITE
+  # on nearly every run. Bail out to the real full-suite signal instead.
+  echo "==> Could not determine a merge base with origin/${BASE_REF} even after unshallowing."
+  echo "==> Falling back to the full suite for safety instead of guessing from an inaccurate diff."
+  write_empty_report
+  export_needs_full_suite true
+  exit 0
+fi
+
+CHANGED_FILES=$(git diff --name-only --diff-filter=d "${MERGE_BASE}" HEAD 2>/dev/null || true)
 
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "No changed files detected."


### PR DESCRIPTION
## Summary
- Fix `NEEDS_FULL_SUITE` never reaching Harness's `outputVariables` capture: the value was exported inside `bash scripts/run-changed-tests.sh`, a child process of the step's own shell, so it could never propagate back to the parent shell Harness inspects. The script now writes the value to a file and the pipeline step reads it back and exports it itself.
- Fix manual/branch dispatch always tripping the full suite: `git fetch origin "$BASE_REF" --depth=1` left `origin/main` as a disconnected commit, breaking `git merge-base` for the triple-dot diff. The failure was silently swallowed and fell back to a naive two-ref diff that overcounts changed files (picking up unrelated shared-helper/`internal/client` changes from other merged PRs), tripping `RUN_ALL`/`NEEDS_FULL_SUITE=true` almost every time. PR-triggered builds hid this because Harness's merge-commit checkout makes merge-base resolve trivially even when shallow; manual dispatch has no such merge commit. Fixed by unshallowing before diffing, with an explicit conservative full-suite fallback if a merge-base still can't be found.

## Test plan
- [ ] Reproduced both bugs locally (`git merge-base` failing after a `--depth=1` fetch; confirmed `git fetch --unshallow` resolves it)
- [ ] Verify `scripts/run-changed-tests.sh` still runs selectively for a normal PR build
- [ ] Verify a manual/branch dispatch of the pipeline now runs selective tests first and only triggers the full suite when shared/client code actually changed
- [ ] Confirm `NEEDS_FULL_SUITE` output variable is populated correctly in the Harness step logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Harness pipeline wiring and `scripts/run-changed-tests.sh` git/diff logic; no provider runtime or API behavior is touched.
> 
> **Overview**
> Fixes PR acceptance CI so **conditional full-suite stages** actually follow selective test results, and so **manual/branch runs** don’t almost always force the full suite.
> 
> **`NEEDS_FULL_SUITE` propagation:** `run-changed-tests.sh` runs as a child shell, so exports there never reached Harness `outputVariables`. The script now writes the flag to `NEEDS_FULL_SUITE_FILE` (default `/tmp/needs_full_suite`), and the Harness **Run Selective Tests** step reads that file, exports `NEEDS_FULL_SUITE` in the parent shell, preserves the test exit code, and declares the output variable explicitly (`type: String`, `value: NEEDS_FULL_SUITE`).
> 
> **Accurate changed-files diff:** Shallow `git fetch --depth=1` plus a broken `merge-base` used to fall back to a broad two-ref diff that over-counted changes (especially on manual dispatch). The script **unshallows** when needed, diffs `merge-base..HEAD`, and if merge-base still can’t be found it **safely defaults** to full suite (`NEEDS_FULL_SUITE=true`, empty JUnit report) instead of guessing.
> 
> Pipeline YAML also drops the long two-phase comment block and minor blank-line cleanup between parallel full-suite stages; behavior of those stages is unchanged (still gated on `NEEDS_FULL_SUITE == "true"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede2543144dc9a9ca3417565377048c310d1dfe5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->