### PR TITLE
Update pipeline terraform-provider-datarobot-pr

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -47,12 +47,13 @@ pipeline:
                       go install github.com/jstemmer/go-junit-report/v2@latest
                       go mod download
                       go build -v .
+                      set +e
                       NEEDS_FULL_SUITE_FILE=/tmp/needs_full_suite BASE_REF=main TEST_PARALLEL=6 bash scripts/run-changed-tests.sh
                       TEST_EXIT_CODE=$?
                       cat /tmp/needs_full_suite
                       export NEEDS_FULL_SUITE="$(cat /tmp/needs_full_suite 2>/dev/null || echo false)"
-                      echo $NEEDS_FULL_SUITE
-                      exit "$TEST_EXIT_CODE"
+                      echo "NEEDS_FULL_SUITE=$NEEDS_FULL_SUITE"
+                      trap 'exit $TEST_EXIT_CODE' EXIT
                     reports:
                       type: JUnit
                       spec:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI shell-script behavior only; no application or runtime code changes.
> 
> **Overview**
> Updates the **Run Selective Tests** step in `.harness/acceptnce_pipeline.yml` so a failing `run-changed-tests.sh` run no longer short-circuits before Harness can publish step outputs.
> 
> The step now runs selective tests with **`set +e`**, still records **`TEST_EXIT_CODE`**, exports **`NEEDS_FULL_SUITE`** from `/tmp/needs_full_suite`, and uses **`trap 'exit $TEST_EXIT_CODE' EXIT`** instead of an immediate **`exit "$TEST_EXIT_CODE"`**. Logging is clarified with **`NEEDS_FULL_SUITE=$NEEDS_FULL_SUITE`**.
> 
> **Net effect:** downstream parallel full-suite stages can still gate on **`NEEDS_FULL_SUITE == "true"`** while the overall step still fails when tests fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7184da233b28f13f341008968ad46d470d566a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->