### PR TITLE
Update pipeline terraform-provider-datarobot-pr

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -115,7 +115,7 @@ pipeline:
                   build:
                     type: branch
                     spec:
-                      branch: <+trigger.targetBranch>
+                      branch: <+trigger.sourceBranch>
             stages:
               - parallel:
                   - stage:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Harness CI configuration only; no application or provider runtime behavior changes.
> 
> **Overview**
> When the PR acceptance pipeline escalates to **`terraformproviderdatarobotfull`** (`NEEDS_FULL_SUITE=true`), the nested pipeline’s codebase build branch is switched from **`<+trigger.targetBranch>`** to **`<+trigger.sourceBranch>`**.
> 
> That makes the full suite run against the **PR branch/commit** that triggered the pipeline, matching the **Full suite** stage description instead of building the merge/target branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0518ea2be74e46e1e04b4070b1299c041e87902. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->