### PR TITLE
[RAPTOR-18242] - fix to omit RT overwrites for blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Deployment model replacement updates now wait for backend `modelPackageId` propagation after the deployment returns to `active`, reducing false positives from short consistency delays. The update now fails only after a bounded wait if the deployment still serves the previous model package, and reports a clear mismatch error instead of writing incorrect planned state.
 - Added integration-style mock tests for deployment model replacement success and mismatch scenarios to validate backend `modelPackageId` verification behavior.
 - Bumped the Go toolchain target from `1.26.4` to `1.26.5` to pick up the standard-library `crypto/tls` fix for `GO-2026-5856` detected by `govulncheck`.
+- when custom model is created with `source_llm_blueprint_id` and user defines `runtime_parameter_values` on the resource, default LLM blueprint runtime parameters are not removed overwritten anymore
 
 ## [0.10.42] - 2026-06-30
 

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -1529,6 +1529,8 @@ func (r *CustomModelResource) createNewCustomModelVersion(
 	}
 	if IsKnown(plan.BaseEnvironmentVersionID) {
 		updateRequest.BaseEnvironmentVersionID = plan.BaseEnvironmentVersionID.ValueString()
+	} else if updateRequest.BaseEnvironmentID != customModel.LatestVersion.BaseEnvironmentID {
+		updateRequest.BaseEnvironmentVersionID = ""
 	}
 
 	traceAPICall("CreateCustomModelVersionCreateFromLatest")

--- a/pkg/provider/custom_model_resource.go
+++ b/pkg/provider/custom_model_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -562,15 +563,6 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 	state.IsProxy = types.BoolValue(customModel.IsProxyModel)
 	state.DeploymentsCount = types.Int64Value(customModel.DeploymentsCount)
 
-	if IsKnown(plan.RuntimeParameterValues) && len(plan.RuntimeParameterValues.Elements()) > 0 {
-		customModel, err = r.applyRuntimeParameterValues(ctx, customModelID, baseEnvironmentID, baseEnvironmentVersionID, plan)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating Custom Model version with runtime parameters", err.Error())
-			return
-		}
-		state.VersionID = types.StringValue(customModel.LatestVersion.ID)
-	}
-
 	if len(plan.GuardConfigurations) > 0 {
 		if err = r.createCustomModelVersionFromGuards(ctx, plan, customModelID, customModel.LatestVersion.ID, plan.GuardConfigurations, []GuardConfiguration{}); err != nil {
 			resp.Diagnostics.AddError("Error creating Custom Model version from Guards", err.Error())
@@ -605,7 +597,7 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 	state.Replicas = plan.Replicas
 	state.NetworkAccess = plan.NetworkAccess
 
-	if err = r.addResourceBundle(ctx, customModel, &state, plan); err != nil {
+	if _, err = r.addResourceBundle(ctx, customModel, &state, plan); err != nil {
 		resp.Diagnostics.AddError("Error adding resource bundle", err.Error())
 		return
 	}
@@ -615,6 +607,41 @@ func (r *CustomModelResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 	state.VersionID = types.StringValue(customModel.LatestVersion.ID)
+
+	// Applied last: unlike the guard/resource-settings/bundle version-creates
+	// above, this one sends runtimeParameters, which the API treats as a full
+	// replacement. Doing it earlier would let a later step revert it. For
+	// blueprint models, also merge in params the user didn't declare so they
+	// survive that replacement.
+	planHasRuntimeParams := IsKnown(plan.RuntimeParameterValues) && len(plan.RuntimeParameterValues.Elements()) > 0
+	if planHasRuntimeParams {
+		runtimeParamsToApply := plan.RuntimeParameterValues
+		if IsKnown(plan.SourceLLMBlueprintID) && len(customModel.LatestVersion.RuntimeParameters) > 0 {
+			merged, mDiags := mergeBlueprintRuntimeParameters(
+				ctx,
+				customModel.LatestVersion.RuntimeParameters,
+				types.ListNull(runtimeParameterListElemType()),
+				plan.RuntimeParameterValues,
+			)
+			resp.Diagnostics.Append(mDiags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			runtimeParamsToApply = merged
+		}
+		customModel, err = r.applyRuntimeParameterValues(
+			ctx,
+			customModelID,
+			customModel.LatestVersion.BaseEnvironmentID,
+			customModel.LatestVersion.BaseEnvironmentVersionID,
+			runtimeParamsToApply,
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("Error creating Custom Model version with runtime parameters", err.Error())
+			return
+		}
+		state.VersionID = types.StringValue(customModel.LatestVersion.ID)
+	}
 
 	if len(customModel.LatestVersion.Dependencies) > 0 {
 		traceAPICall("CreateDependencyBuild")
@@ -778,12 +805,15 @@ func (r *CustomModelResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	initialRuntimeParams := customModel.LatestVersion.RuntimeParameters
+
 	if err := r.updateCustomModel(ctx, customModel, &state, plan); err != nil {
 		resp.Diagnostics.AddError("Error updating Custom Model", err.Error())
 		return
 	}
 
-	if err = r.createNewCustomModelVersion(ctx, plan, customModel); err != nil {
+	newVersionCreated, err := r.createNewCustomModelVersion(ctx, plan, customModel)
+	if err != nil {
 		resp.Diagnostics.AddError("Error creating Custom Model version", err.Error())
 		return
 	}
@@ -795,7 +825,8 @@ func (r *CustomModelResource) Update(ctx context.Context, req resource.UpdateReq
 	state.BaseEnvironmentID = types.StringValue(customModel.LatestVersion.BaseEnvironmentID)
 	state.BaseEnvironmentVersionID = types.StringValue(customModel.LatestVersion.BaseEnvironmentVersionID)
 
-	if err = r.updateRemoteRepositories(ctx, customModel, &state, plan); err != nil {
+	remoteReposVersionCreated, err := r.updateRemoteRepositories(ctx, customModel, &state, plan)
+	if err != nil {
 		resp.Diagnostics.AddError("Error updating remote repositories", err.Error())
 		return
 	}
@@ -806,22 +837,27 @@ func (r *CustomModelResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if err = r.updateGuardConfigurations(ctx, &state, plan); err != nil {
+	guardsVersionCreated, err := r.updateGuardConfigurations(ctx, &state, plan)
+	if err != nil {
 		resp.Diagnostics.AddError("Error updating guard configurations", err.Error())
 		return
 	}
 
-	if err = r.updateResourceSettings(ctx, customModel, &state, plan); err != nil {
+	resourceSettingsVersionCreated, err := r.updateResourceSettings(ctx, customModel, &state, plan)
+	if err != nil {
 		resp.Diagnostics.AddError("Error updating resource settings", err.Error())
 		return
 	}
 
-	if err = r.addResourceBundle(ctx, customModel, &state, plan); err != nil {
+	resourceBundleVersionCreated, err := r.addResourceBundle(ctx, customModel, &state, plan)
+	if err != nil {
 		resp.Diagnostics.AddError("Error adding resource bundle", err.Error())
 		return
 	}
 
-	if err = r.updateRuntimeParameterValuesUnified(ctx, customModel, state, plan, localFilesUpdated); err != nil {
+	versionModifiedInApply := newVersionCreated || remoteReposVersionCreated || localFilesUpdated || guardsVersionCreated || resourceSettingsVersionCreated || resourceBundleVersionCreated
+
+	if err = r.updateRuntimeParameterValuesUnified(ctx, customModel, state, plan, initialRuntimeParams, versionModifiedInApply); err != nil {
 		resp.Diagnostics.AddError("Error updating runtime parameter values", err.Error())
 		return
 	}
@@ -1464,6 +1500,7 @@ func (r *CustomModelResource) createNewCustomModelVersion(
 	plan CustomModelResourceModel,
 	customModel *client.CustomModel,
 ) (
+	versionCreated bool,
 	err error,
 ) {
 	// check for major version update
@@ -1479,10 +1516,13 @@ func (r *CustomModelResource) createNewCustomModelVersion(
 		if err != nil {
 			return
 		}
+		versionCreated = true
 	}
 
 	updateRequest := &client.CreateCustomModelVersionFromLatestRequest{
-		IsMajorUpdate: "false",
+		IsMajorUpdate:            "false",
+		BaseEnvironmentID:        customModel.LatestVersion.BaseEnvironmentID,
+		BaseEnvironmentVersionID: customModel.LatestVersion.BaseEnvironmentVersionID,
 	}
 	if IsKnown(plan.BaseEnvironmentID) {
 		updateRequest.BaseEnvironmentID = plan.BaseEnvironmentID.ValueString()
@@ -1495,6 +1535,7 @@ func (r *CustomModelResource) createNewCustomModelVersion(
 	if _, err = r.provider.service.CreateCustomModelVersionCreateFromLatest(ctx, customModel.ID, updateRequest); err != nil {
 		return
 	}
+	versionCreated = true
 
 	return
 }
@@ -1598,35 +1639,54 @@ func (r *CustomModelResource) updateRuntimeParameterValuesUnified(
 	ctx context.Context,
 	customModel *client.CustomModel,
 	state, plan CustomModelResourceModel,
-	localFilesUpdated bool,
+	initialRuntimeParams []client.RuntimeParameter,
+	versionModifiedInApply bool,
 ) error {
+	isBlueprint := IsKnown(state.SourceLLMBlueprintID) || IsKnown(plan.SourceLLMBlueprintID)
 	runtimeParamsChanged := !plan.RuntimeParameterValues.Equal(state.RuntimeParameterValues)
-	reapplyAfterLocalFiles := localFilesUpdated &&
-		IsKnown(plan.RuntimeParameterValues) &&
-		len(plan.RuntimeParameterValues.Elements()) > 0
-	if !runtimeParamsChanged && !reapplyAfterLocalFiles {
+	planHasRuntimeParams := IsKnown(plan.RuntimeParameterValues) && len(plan.RuntimeParameterValues.Elements()) > 0
+
+	needsReapplyAfterVersionCreate := versionModifiedInApply && planHasRuntimeParams
+	needsBlueprintRestore := isBlueprint && versionModifiedInApply
+
+	if !runtimeParamsChanged && !needsReapplyAfterVersionCreate && !needsBlueprintRestore {
 		return nil
 	}
+
+	runtimeParamsToApply := plan.RuntimeParameterValues
+	if isBlueprint && len(initialRuntimeParams) > 0 {
+		merged, mDiags := mergeBlueprintRuntimeParameters(
+			ctx,
+			initialRuntimeParams,
+			state.RuntimeParameterValues,
+			plan.RuntimeParameterValues,
+		)
+		if mDiags.HasError() {
+			return fmt.Errorf("merging blueprint runtime parameters: %s", mDiags.Errors()[0].Detail())
+		}
+		runtimeParamsToApply = merged
+	}
+
 	return r.createVersionWithRuntimeParams(
 		ctx,
 		customModel.ID,
 		customModel.LatestVersion.BaseEnvironmentID,
 		customModel.LatestVersion.BaseEnvironmentVersionID,
 		state.RuntimeParameterValues,
-		plan.RuntimeParameterValues,
+		runtimeParamsToApply,
 	)
 }
 
 func (r *CustomModelResource) applyRuntimeParameterValues(
 	ctx context.Context,
 	customModelID, baseEnvironmentID, baseEnvironmentVersionID string,
-	plan CustomModelResourceModel,
+	planRuntimeParams basetypes.ListValue,
 ) (*client.CustomModel, error) {
 	if err := r.createVersionWithRuntimeParams(
 		ctx,
 		customModelID, baseEnvironmentID, baseEnvironmentVersionID,
 		types.ListNull(runtimeParameterListElemType()),
-		plan.RuntimeParameterValues,
+		planRuntimeParams,
 	); err != nil {
 		return nil, err
 	}
@@ -1640,6 +1700,7 @@ func (r *CustomModelResource) updateRemoteRepositories(
 	state *CustomModelResourceModel,
 	plan CustomModelResourceModel,
 ) (
+	versionCreated bool,
 	err error,
 ) {
 	if !reflect.DeepEqual(plan.SourceRemoteRepositories, state.SourceRemoteRepositories) {
@@ -1687,6 +1748,7 @@ func (r *CustomModelResource) updateRemoteRepositories(
 			if err != nil {
 				return
 			}
+			versionCreated = true
 		}
 
 		for _, newSourceRemoteRepository := range plan.SourceRemoteRepositories {
@@ -1717,6 +1779,7 @@ func (r *CustomModelResource) updateRemoteRepositories(
 				); err != nil {
 					return
 				}
+				versionCreated = true
 			}
 		}
 		state.SourceRemoteRepositories = plan.SourceRemoteRepositories
@@ -1784,6 +1847,7 @@ func (r *CustomModelResource) updateGuardConfigurations(
 	state *CustomModelResourceModel,
 	plan CustomModelResourceModel,
 ) (
+	versionCreated bool,
 	err error,
 ) {
 	if reflect.DeepEqual(plan.GuardConfigurations, state.GuardConfigurations) &&
@@ -1835,6 +1899,7 @@ func (r *CustomModelResource) updateGuardConfigurations(
 	); err != nil {
 		return
 	}
+	versionCreated = true
 	state.GuardConfigurations = plan.GuardConfigurations
 	state.OverallModerationConfiguration = plan.OverallModerationConfiguration
 
@@ -1847,6 +1912,7 @@ func (r *CustomModelResource) updateResourceSettings(
 	state *CustomModelResourceModel,
 	plan CustomModelResourceModel,
 ) (
+	versionCreated bool,
 	err error,
 ) {
 	payload := &client.CreateCustomModelVersionFromLatestRequest{
@@ -1866,6 +1932,7 @@ func (r *CustomModelResource) updateResourceSettings(
 	if _, err = r.provider.service.CreateCustomModelVersionCreateFromLatest(ctx, customModel.ID, payload); err != nil {
 		return
 	}
+	versionCreated = true
 	state.Replicas = plan.Replicas
 	state.NetworkAccess = plan.NetworkAccess
 
@@ -1916,6 +1983,7 @@ func (r *CustomModelResource) addResourceBundle(
 	state *CustomModelResourceModel,
 	plan CustomModelResourceModel,
 ) (
+	versionCreated bool,
 	err error,
 ) {
 	if IsKnown(plan.ResourceBundleID) {
@@ -1928,6 +1996,7 @@ func (r *CustomModelResource) addResourceBundle(
 		}); err != nil {
 			return
 		}
+		versionCreated = true
 	}
 
 	state.ResourceBundleID = plan.ResourceBundleID

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -1983,25 +1983,26 @@ func TestIntegrationCustomModelResourceRuntimeParameters(t *testing.T) {
 	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
 	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
 
-	// Create: applyRuntimeParameterValues — v2 path (RuntimeParameters set)
-	runtimeParamsCall := mockService.EXPECT().
-		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, hasRuntimeParamsMatcher{}).
-		Return(&client.CustomModelVersion{}, nil).
-		After(baseEnvCall)
-
-	// Create: wait after runtime params
-	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
-	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
-
-	// Create: replicas/network version
-	mockService.EXPECT().
+	// Create: replicas/network version (runtime parameters are applied last, see custom_model_resource.go)
+	replicasCall := mockService.EXPECT().
 		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, gomock.Any()).
 		Return(&client.CustomModelVersion{}, nil).
-		After(runtimeParamsCall)
+		After(baseEnvCall)
 
 	// Create: wait after replicas
 	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
 	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
+
+	// Create: applyRuntimeParameterValues — v2 path (RuntimeParameters set), applied last
+	runtimeParamsCall := mockService.EXPECT().
+		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, hasRuntimeParamsMatcher{}).
+		Return(&client.CustomModelVersion{}, nil).
+		After(replicasCall)
+
+	// Create: wait after runtime params
+	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
+	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil).
+		After(runtimeParamsCall)
 
 	// Create: final GetCustomModel
 	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
@@ -2085,11 +2086,21 @@ func TestIntegrationCustomModelResourceRuntimeParametersOldAPI(t *testing.T) {
 	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
 	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
 
+	// Create: replicas/network version (runtime parameters are applied last, see custom_model_resource.go)
+	replicasCall := mockService.EXPECT().
+		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, gomock.Any()).
+		Return(&client.CustomModelVersion{}, nil).
+		After(baseEnvCall)
+
+	// Create: wait after replicas
+	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
+	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
+
 	// Create: applyRuntimeParameterValues — v2 attempt fails, triggering v1 fallback
 	v2FailCall := mockService.EXPECT().
 		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, hasRuntimeParamsMatcher{}).
 		Return(nil, fmt.Errorf("runtimeParameters is not allowed key")).
-		After(baseEnvCall)
+		After(replicasCall)
 
 	// Create: v1 fallback succeeds
 	v1Call := mockService.EXPECT().
@@ -2099,17 +2110,8 @@ func TestIntegrationCustomModelResourceRuntimeParametersOldAPI(t *testing.T) {
 
 	// Create: wait after v1 runtime params
 	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
-	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
-
-	// Create: replicas/network version
-	mockService.EXPECT().
-		CreateCustomModelVersionCreateFromLatest(gomock.Any(), modelID, gomock.Any()).
-		Return(&client.CustomModelVersion{}, nil).
+	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil).
 		After(v1Call)
-
-	// Create: wait after replicas
-	mockService.EXPECT().IsCustomModelReady(gomock.Any(), modelID).Return(true, nil)
-	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)
 
 	// Create: final GetCustomModel
 	mockService.EXPECT().GetCustomModel(gomock.Any(), modelID).Return(customModel, nil)

--- a/pkg/provider/custom_model_resource_test.go
+++ b/pkg/provider/custom_model_resource_test.go
@@ -47,6 +47,8 @@ func TestAccCustomModelFromLlmBlueprintResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "example_description"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
+					checkBlueprintInjectedRuntimeParametersPresent(resourceName,
+						"LLM_BLUEPRINT_ID", "PLAYGROUND_ID", "LLM_ID", "CUSTOM_MODEL_WORKERS"),
 				),
 			},
 			// Update name, description
@@ -58,6 +60,8 @@ func TestAccCustomModelFromLlmBlueprintResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "new_example_description"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
+					checkBlueprintInjectedRuntimeParametersPresent(resourceName,
+						"LLM_BLUEPRINT_ID", "PLAYGROUND_ID", "LLM_ID", "CUSTOM_MODEL_WORKERS"),
 				),
 			},
 			// Delete is tested automatically
@@ -1842,6 +1846,51 @@ func checkCustomModelResourceExists(resourceName string) resource.TestCheckFunc 
 		}
 
 		return fmt.Errorf("Custom Model not found")
+	}
+}
+
+// checkBlueprintInjectedRuntimeParametersPresent asserts that blueprint-populated
+// runtime parameters (never declared in config) survive on the custom model version.
+func checkBlueprintInjectedRuntimeParametersPresent(resourceName string, expectedFieldNames ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		p, ok := testAccProvider.(*Provider)
+		if !ok {
+			return fmt.Errorf("Provider not found")
+		}
+		p.service = client.NewService(cl)
+
+		traceAPICall("GetCustomModel")
+		customModel, err := p.service.GetCustomModel(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		present := make(map[string]bool, len(customModel.LatestVersion.RuntimeParameters))
+		for _, runtimeParam := range customModel.LatestVersion.RuntimeParameters {
+			present[runtimeParam.FieldName] = true
+		}
+
+		var missing []string
+		for _, fieldName := range expectedFieldNames {
+			if !present[fieldName] {
+				missing = append(missing, fieldName)
+			}
+		}
+
+		if len(missing) > 0 {
+			return fmt.Errorf("blueprint-injected runtime parameters missing from custom model %s: %v", rs.Primary.ID, missing)
+		}
+
+		return nil
 	}
 }
 

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -509,6 +509,63 @@ func formatRuntimeParameterValuesByManagedKeys(
 	return listValueFromRuntimParameters(ctx, result)
 }
 
+// mergeBlueprintRuntimeParameters restores blueprint-set runtime params the
+// plan doesn't declare. Plan values win on conflict; keys dropped from state
+// to plan stay dropped.
+func mergeBlueprintRuntimeParameters(
+	ctx context.Context,
+	apiParams []client.RuntimeParameter,
+	stateVals, planVals basetypes.ListValue,
+) (basetypes.ListValue, diag.Diagnostics) {
+	declared := make([]RuntimeParameterValue, 0)
+	if IsKnown(planVals) {
+		if diags := planVals.ElementsAs(ctx, &declared, false); diags.HasError() {
+			return basetypes.ListValue{}, diags
+		}
+	}
+	declaredKeys := make(map[string]bool, len(declared))
+	for _, d := range declared {
+		declaredKeys[d.Key.ValueString()] = true
+	}
+
+	stateEntries := make([]RuntimeParameterValue, 0)
+	if IsKnown(stateVals) {
+		if diags := stateVals.ElementsAs(ctx, &stateEntries, false); diags.HasError() {
+			return basetypes.ListValue{}, diags
+		}
+	}
+	stateKeys := make(map[string]bool, len(stateEntries))
+	for _, s := range stateEntries {
+		stateKeys[s.Key.ValueString()] = true
+	}
+
+	carryover := make([]RuntimeParameterValue, 0, len(apiParams))
+	for _, param := range apiParams {
+		key := param.FieldName
+		if declaredKeys[key] {
+			continue
+		}
+		if stateKeys[key] {
+			continue
+		}
+
+		if param.OverrideValue == nil {
+			continue
+		}
+
+		carryover = append(carryover, RuntimeParameterValue{
+			Key:   types.StringValue(key),
+			Type:  types.StringValue(param.Type),
+			Value: types.StringValue(fmt.Sprintf("%v", param.CurrentValue)),
+		})
+	}
+
+	merged := make([]RuntimeParameterValue, 0, len(carryover)+len(declared))
+	merged = append(merged, carryover...)
+	merged = append(merged, declared...)
+	return listValueFromRuntimParameters(ctx, merged)
+}
+
 func isManagedByGuards(param client.RuntimeParameter) bool {
 	return param.FieldName == faithfulnessOpenAiRuntimeParam ||
 		param.FieldName == faithfulnessAzureOpenAiRuntimeParam ||

--- a/pkg/provider/utils_test.go
+++ b/pkg/provider/utils_test.go
@@ -480,3 +480,200 @@ func TestFormatRuntimeParameterValuesByManagedKeys(t *testing.T) {
 		}
 	})
 }
+
+func TestMergeBlueprintRuntimeParameters(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	nullList := basetypes.NewListNull(runtimeParameterListElemType())
+
+	t.Run("no apiParams returns plan unchanged", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{
+			{Key: types.StringValue("A"), Type: types.StringValue("string"), Value: types.StringValue("v")},
+		})
+		got, diags := mergeBlueprintRuntimeParameters(ctx, nil, nullList, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		if len(result) != 1 || result[0].Key.ValueString() != "A" {
+			t.Errorf("expected only [A], got %v", result)
+		}
+	})
+
+	t.Run("blueprint override carried over when user does not declare it", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{
+			{Key: types.StringValue("system_prompt"), Type: types.StringValue("string"), Value: types.StringValue("hi")},
+		})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "system_prompt", Type: "string", DefaultValue: "", OverrideValue: "blueprint prompt", CurrentValue: "blueprint prompt"},
+			{FieldName: "temperature", Type: "numeric", DefaultValue: 0.7, OverrideValue: 0.7, CurrentValue: 0.7},
+		}
+		got, diags := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 params, got %d: %v", len(result), result)
+		}
+		byKey := map[string]RuntimeParameterValue{}
+		for _, p := range result {
+			byKey[p.Key.ValueString()] = p
+		}
+		if v := byKey["system_prompt"].Value.ValueString(); v != "hi" {
+			t.Errorf("system_prompt: expected user value 'hi', got %q", v)
+		}
+		if v := byKey["temperature"].Value.ValueString(); v != "0.7" {
+			t.Errorf("temperature: expected blueprint carryover '0.7', got %q", v)
+		}
+	})
+
+	t.Run("user declares same key wins on conflict", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{
+			{Key: types.StringValue("system_prompt"), Type: types.StringValue("string"), Value: types.StringValue("user prompt")},
+		})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "system_prompt", Type: "string", DefaultValue: "", OverrideValue: "blueprint prompt", CurrentValue: "blueprint prompt"},
+		}
+		got, diags := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 param, got %d: %v", len(result), result)
+		}
+		if result[0].Value.ValueString() != "user prompt" {
+			t.Errorf("expected user value, got %q", result[0].Value.ValueString())
+		}
+	})
+
+	t.Run("key in state but removed from plan is NOT carried over", func(t *testing.T) {
+		t.Parallel()
+		state := makeParamList(t, []RuntimeParameterValue{
+			{Key: types.StringValue("system_prompt"), Type: types.StringValue("string"), Value: types.StringValue("previous")},
+		})
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "system_prompt", Type: "string", DefaultValue: "", OverrideValue: "still-on-api", CurrentValue: "still-on-api"},
+			{FieldName: "temperature", Type: "numeric", DefaultValue: 0.7, OverrideValue: 0.7, CurrentValue: 0.7},
+		}
+		got, diags := mergeBlueprintRuntimeParameters(ctx, apiParams, state, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		keys := make(map[string]bool)
+		for _, p := range result {
+			keys[p.Key.ValueString()] = true
+		}
+		if keys["system_prompt"] {
+			t.Errorf("system_prompt should not be carried over after user removal, got %v", result)
+		}
+		if !keys["temperature"] {
+			t.Errorf("temperature should be carried over, got %v", result)
+		}
+	})
+
+	t.Run("guard-managed key with blueprint override IS carried over", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: faithfulnessOpenAiRuntimeParam, Type: "string", DefaultValue: "", OverrideValue: "blueprint-guard-key", CurrentValue: "blueprint-guard-key"},
+		}
+		got, diags := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		if len(result) != 1 {
+			t.Fatalf("expected guard key carryover, got %v", result)
+		}
+	})
+
+	t.Run("credential-typed param is carried over", func(t *testing.T) {
+		t.Parallel()
+		credType := "api_token"
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "OPENAI_API_KEY", Type: "credential", CredentialType: &credType, OverrideValue: "credential-id-abc", CurrentValue: "credential-id-abc"},
+		}
+		got, diags := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		result := extractParams(t, got)
+		if len(result) != 1 {
+			t.Fatalf("expected credential carryover, got %v", result)
+		}
+		if result[0].Value.ValueString() != "credential-id-abc" {
+			t.Errorf("expected credential id 'credential-id-abc', got %q", result[0].Value.ValueString())
+		}
+	})
+
+	t.Run("OverrideValue nil is skipped even when CurrentValue is set", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "PROMPT", Type: "string", DefaultValue: "default", CurrentValue: "default"},
+		}
+		got, _ := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		if len(got.Elements()) != 0 {
+			t.Errorf("expected empty, got %v", extractParams(t, got))
+		}
+	})
+
+	t.Run("OverrideValue equal to DefaultValue is still carried over", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "S", Type: "string", DefaultValue: "same", OverrideValue: "same", CurrentValue: "same"},
+			{FieldName: "N", Type: "numeric", DefaultValue: 3.14, OverrideValue: 3.14, CurrentValue: 3.14},
+			{FieldName: "B", Type: "boolean", DefaultValue: true, OverrideValue: true, CurrentValue: true},
+		}
+		got, _ := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		result := extractParams(t, got)
+		if len(result) != 3 {
+			t.Errorf("expected all 3 carried over, got %v", result)
+		}
+	})
+
+	t.Run("falsy OverrideValue (zero, false, empty string) is still carried over", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "N_ZERO", Type: "numeric", DefaultValue: nil, OverrideValue: 0.0, CurrentValue: 0.0},
+			{FieldName: "B_FALSE", Type: "boolean", DefaultValue: nil, OverrideValue: false, CurrentValue: false},
+			{FieldName: "N_NONZERO", Type: "numeric", DefaultValue: nil, OverrideValue: 1.5, CurrentValue: 1.5},
+		}
+		got, _ := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		result := extractParams(t, got)
+		if len(result) != 3 {
+			t.Errorf("expected all 3 carried over regardless of falsy value, got %v", result)
+		}
+	})
+
+	t.Run("blueprint entries appear before user entries", func(t *testing.T) {
+		t.Parallel()
+		plan := makeParamList(t, []RuntimeParameterValue{
+			{Key: types.StringValue("system_prompt"), Type: types.StringValue("string"), Value: types.StringValue("user")},
+		})
+		apiParams := []client.RuntimeParameter{
+			{FieldName: "temperature", Type: "numeric", DefaultValue: 0.7, OverrideValue: 0.7, CurrentValue: 0.7},
+		}
+		got, _ := mergeBlueprintRuntimeParameters(ctx, apiParams, nullList, plan)
+		result := extractParams(t, got)
+		if len(result) != 2 {
+			t.Fatalf("expected 2, got %v", result)
+		}
+		if result[0].Key.ValueString() != "temperature" {
+			t.Errorf("expected carryover first, got %v", result)
+		}
+		if result[1].Key.ValueString() != "system_prompt" {
+			t.Errorf("expected user entry second, got %v", result)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes blueprint-derived `datarobot_custom_model` resources losing their blueprint-populated runtime parameters (`LLM_BLUEPRINT_ID`, `PLAYGROUND_ID`, `LLM_ID`, `CUSTOM_MODEL_WORKERS`, etc.) whenever the user declares any `runtime_parameter_values` in config. The DataRobot API replaces the full runtime parameter set on each version create, so a partial user-declared list wiped out the blueprint's own values.

## Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
- Runtime parameters are now applied last during version create (after guards, replicas/network, resource bundle) so intermediate version creates can't wipe them.
- For `source_llm_blueprint_id` models, undeclared blueprint-populated keys are merged into the plan via `mergeBlueprintRuntimeParameters` before apply. User-declared values still win on conflict; explicit removals are still respected.
- Update path tracks whether any step created a new version and re-applies merged params when needed, so blueprint-only keys survive replacement across unrelated updates (replicas, guards, remote repos, etc.).
- Non-blueprint models are unaffected — merge logic only engages when `source_llm_blueprint_id` is set.

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)

## Testing
- Unit tests (`utils_test.go`): `TestMergeBlueprintRuntimeParameters`, `TestFormatRuntimeParameterValuesByManagedKeys` — conflict resolution, explicit removal, guard/credential key carryover.
- Extended `TestAccCustomModelFromLlmBlueprintResource` with `checkBlueprintInjectedRuntimeParametersPresent`, asserting blueprint-injected keys survive on create and on update.
- Manually verified against staging across 9 scenarios (bug repro, unrelated-update reapply, conflict override, explicit removal, idempotency/no spurious version, non-blueprint regression, guards+params combo, credential round-trip, plan-drift) — all passed.

## Release Preparation Checklist
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

<!-- rr:slack:start -->
<!-- rr:slack:C053QK4M33R:1783522240.495589 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes custom model create/update ordering and runtime-parameter merging for blueprint-backed models; incorrect merge logic could drop or resurrect params, but scope is limited to `source_llm_blueprint_id` and existing non-blueprint paths are largely unchanged.
> 
> **Overview**
> Fixes **`datarobot_custom_model`** resources created from **`source_llm_blueprint_id`** losing blueprint-injected runtime parameters (e.g. `LLM_BLUEPRINT_ID`, `PLAYGROUND_ID`) when users set **`runtime_parameter_values`**, because the API **fully replaces** runtime params on each version create.
> 
> **Create:** Runtime parameters are applied **after** guards, replicas/network, and resource bundle so later version steps cannot wipe them. For blueprint models, **`mergeBlueprintRuntimeParameters`** adds API blueprint overrides the user did not declare; declared keys still win.
> 
> **Update:** Helpers now report whether they created a new version; **`updateRuntimeParameterValuesUnified`** re-applies merged params when the plan changed, when a version was created and the plan has params, or when a blueprint model had any version-modifying step—using runtime params captured at the start of apply.
> 
> Adds unit tests for merge behavior and acceptance checks that blueprint-injected keys survive create/update on LLM blueprint models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fed07eda35fda9f5fbe4fa92cc7f22153aeb730. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->