### PR TITLE
[RAPTOR 18376] Fix bug in TestAccBatchPredictionJobDefinitionResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `datarobot_artifact` data source for looking up an existing Workload API artifact by ID
 - `datarobot_artifacts` data source for listing Workload API artifacts with optional `status` and `limit` filters
 
+### Fixed
+
+- `datarobot_deployment` no longer sends an empty deployment-settings PATCH on create or update when no settings are configured, and retries transient 5xx errors when updating deployment settings
+
 ## [0.10.42] - 2026-06-30
 
 ### Added

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -1102,10 +1102,15 @@ func (r *DeploymentResource) updateDeploymentSettings(
 		}
 	}
 
-	traceAPICall("UpdateDeploymentSettings")
-	_, err = r.provider.service.UpdateDeploymentSettings(ctx, id, req)
-	if err != nil {
-		return
+	if deploymentSettingsRequestHasUpdates(req) {
+		err = retryOnTransientServerError(func() error {
+			traceAPICall("UpdateDeploymentSettings")
+			_, updateErr := r.provider.service.UpdateDeploymentSettings(ctx, id, req)
+			return updateErr
+		})
+		if err != nil {
+			return
+		}
 	}
 
 	if data.ChallengerReplaySettings != nil {
@@ -1113,8 +1118,11 @@ func (r *DeploymentResource) updateDeploymentSettings(
 			Enabled: data.ChallengerReplaySettings.Enabled.ValueBool(),
 		}
 
-		traceAPICall("UpdateDeploymentChallengerReplaySettings")
-		_, err = r.provider.service.UpdateDeploymentChallengerReplaySettings(ctx, id, req)
+		err = retryOnTransientServerError(func() error {
+			traceAPICall("UpdateDeploymentChallengerReplaySettings")
+			_, updateErr := r.provider.service.UpdateDeploymentChallengerReplaySettings(ctx, id, req)
+			return updateErr
+		})
 		if err != nil {
 			return
 		}
@@ -1182,8 +1190,11 @@ func (r *DeploymentResource) updateDeploymentSettings(
 			}
 		}
 
-		traceAPICall("UpdateDeploymentHealthSettings")
-		_, err = r.provider.service.UpdateDeploymentHealthSettings(ctx, id, req)
+		err = retryOnTransientServerError(func() error {
+			traceAPICall("UpdateDeploymentHealthSettings")
+			_, updateErr := r.provider.service.UpdateDeploymentHealthSettings(ctx, id, req)
+			return updateErr
+		})
 		if err != nil {
 			return
 		}
@@ -1203,13 +1214,59 @@ func (r *DeploymentResource) updateDeploymentSettings(
 			req.Schedule = &schedule
 		}
 
-		traceAPICall("UpdateDeploymentFeatureCacheSettings")
-		_, err = r.provider.service.UpdateDeploymentFeatureCacheSettings(ctx, id, req)
+		err = retryOnTransientServerError(func() error {
+			traceAPICall("UpdateDeploymentFeatureCacheSettings")
+			_, updateErr := r.provider.service.UpdateDeploymentFeatureCacheSettings(ctx, id, req)
+			return updateErr
+		})
 		if err != nil {
 			return
 		}
 	}
 	return
+}
+
+func deploymentSettingsRequestHasUpdates(req *client.DeploymentSettings) bool {
+	if req == nil {
+		return false
+	}
+	return req.AssociationID != nil ||
+		req.BatchMonitoring != nil ||
+		req.BiasAndFairness != nil ||
+		req.ChallengerModels != nil ||
+		req.FeatureDrift != nil ||
+		req.Humility != nil ||
+		req.PredictionsSettings != nil ||
+		req.PredictionsByForecastDate != nil ||
+		req.PredictionsDataCollection != nil ||
+		req.PredictionIntervals != nil ||
+		req.PredictionWarning != nil ||
+		req.SegmentAnalysis != nil ||
+		req.TargetDrift != nil
+}
+
+func isTransientServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "502") ||
+		strings.Contains(msg, "503") ||
+		strings.Contains(msg, "504")
+}
+
+func retryOnTransientServerError(operation func() error) error {
+	expBackoff := getExponentialBackoff()
+	return backoff.Retry(func() error {
+		err := operation()
+		if err == nil {
+			return nil
+		}
+		if isTransientServerError(err) {
+			return err
+		}
+		return backoff.Permanent(err)
+	}, expBackoff)
 }
 
 func (r *DeploymentResource) updateDeploymentSettingsInNotActiveState(
@@ -1226,8 +1283,11 @@ func (r *DeploymentResource) updateDeploymentSettingsInNotActiveState(
 			ResourceBundleID: StringValuePointerOptional(data.PredictionsSettings.ResourceBundleID),
 		}
 
-		traceAPICall("UpdateDeploymentSettings")
-		_, err = r.provider.service.UpdateDeploymentSettings(ctx, id, req)
+		err = retryOnTransientServerError(func() error {
+			traceAPICall("UpdateDeploymentSettings")
+			_, updateErr := r.provider.service.UpdateDeploymentSettings(ctx, id, req)
+			return updateErr
+		})
 		if err != nil {
 			return
 		}

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -1247,7 +1247,7 @@ func deploymentSettingsRequestHasUpdates(req *client.DeploymentSettings) bool {
 }
 
 // transientServerErrorPattern matches the HTTP status in client error messages:
-// "<METHOD> request <url> : response <status> <body>"
+// "<METHOD> request <url> : response <status> <body>".
 var transientServerErrorPattern = regexp.MustCompile(`: response (502|503|504) `)
 
 func isTransientServerError(err error) bool {

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1245,14 +1246,15 @@ func deploymentSettingsRequestHasUpdates(req *client.DeploymentSettings) bool {
 		req.TargetDrift != nil
 }
 
+// transientServerErrorPattern matches the HTTP status in client error messages:
+// "<METHOD> request <url> : response <status> <body>"
+var transientServerErrorPattern = regexp.MustCompile(`: response (502|503|504) `)
+
 func isTransientServerError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "502") ||
-		strings.Contains(msg, "503") ||
-		strings.Contains(msg, "504")
+	return transientServerErrorPattern.MatchString(err.Error())
 }
 
 func retryOnTransientServerError(operation func() error) error {

--- a/pkg/provider/deployment_resource_test.go
+++ b/pkg/provider/deployment_resource_test.go
@@ -318,16 +318,20 @@ func TestIsTransientServerError(t *testing.T) {
 		t.Fatal("expected 502 error to be transient")
 	}
 
-	if !isTransientServerError(fmt.Errorf("response 503 Service Unavailable")) {
+	if !isTransientServerError(fmt.Errorf("PATCH request https://example.com : response 503 Service Unavailable")) {
 		t.Fatal("expected 503 error to be transient")
 	}
 
-	if !isTransientServerError(fmt.Errorf("response 504 Gateway Timeout")) {
+	if !isTransientServerError(fmt.Errorf("PATCH request https://example.com : response 504 Gateway Timeout")) {
 		t.Fatal("expected 504 error to be transient")
 	}
 
-	if isTransientServerError(fmt.Errorf("response 409 Conflict")) {
+	if isTransientServerError(fmt.Errorf("PATCH request https://example.com : response 409 Conflict")) {
 		t.Fatal("expected 409 error to not be transient")
+	}
+
+	if isTransientServerError(fmt.Errorf("PATCH request https://example.com : response 409 Conflict {\"detail\":\"upstream returned 502\"}")) {
+		t.Fatal("expected 409 error with 502 in body to not be transient")
 	}
 }
 

--- a/pkg/provider/deployment_resource_test.go
+++ b/pkg/provider/deployment_resource_test.go
@@ -289,6 +289,48 @@ func TestDeploymentResourceSchema(t *testing.T) {
 	}
 }
 
+func TestDeploymentSettingsRequestHasUpdates(t *testing.T) {
+	t.Parallel()
+
+	if deploymentSettingsRequestHasUpdates(&client.DeploymentSettings{}) {
+		t.Fatal("expected empty deployment settings request to have no updates")
+	}
+
+	if deploymentSettingsRequestHasUpdates(nil) {
+		t.Fatal("expected nil deployment settings request to have no updates")
+	}
+
+	if !deploymentSettingsRequestHasUpdates(&client.DeploymentSettings{
+		BatchMonitoring: &client.BasicSetting{Enabled: true},
+	}) {
+		t.Fatal("expected populated deployment settings request to have updates")
+	}
+}
+
+func TestIsTransientServerError(t *testing.T) {
+	t.Parallel()
+
+	if isTransientServerError(nil) {
+		t.Fatal("expected nil error to not be transient")
+	}
+
+	if !isTransientServerError(fmt.Errorf("PATCH request https://example.com : response 502 Bad Gateway")) {
+		t.Fatal("expected 502 error to be transient")
+	}
+
+	if !isTransientServerError(fmt.Errorf("response 503 Service Unavailable")) {
+		t.Fatal("expected 503 error to be transient")
+	}
+
+	if !isTransientServerError(fmt.Errorf("response 504 Gateway Timeout")) {
+		t.Fatal("expected 504 error to be transient")
+	}
+
+	if isTransientServerError(fmt.Errorf("response 409 Conflict")) {
+		t.Fatal("expected 409 error to not be transient")
+	}
+}
+
 func deploymentResourceConfig(
 	label,
 	importance string,


### PR DESCRIPTION
## Summary

Fixes a CI failure in `TestAccBatchPredictionJobDefinitionResource` (`testacc-group-fast`) caused by `datarobot_deployment` issuing an unnecessary `PATCH /deployments/{id}/settings/` on create when no deployment settings are configured. The empty PATCH hit a **502 Bad Gateway** on staging and left the test stuck in teardown until the 30-minute timeout.

**Changes:**
- Skip `UpdateDeploymentSettings` when the built request has no settings fields.
- Retry deployment settings PATCH calls (settings, challenger replay, health, feature cache) on transient **502 / 503 / 504** errors using existing exponential backoff.

**Why:** Minimal deployments (e.g. batch prediction job definition tests) should not call the settings API at all. When settings are configured, transient staging/nginx failures should be retried at the resource layer (non-GET HTTP is not auto-retried in the transport client).

## Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [x] test
- [ ] ci

## Details / User Impact

### Provider behavior (`datarobot_deployment`)

| Scenario | Before | After |
|----------|--------|-------|
| Create/update with **no** optional settings blocks | Always `PATCH /deployments/{id}/settings/` (empty body) | **No settings PATCH** |
| Create/update **with** settings configured | Single attempt; fails on transient 5xx | **Retries** on 502/503/504 via `getExponentialBackoff()` |
| `predictions_settings` (inactive state path) | Single attempt | Same retry behavior |

No schema changes. No breaking changes.

### Root cause

`updateDeploymentSettings` always called `UpdateDeploymentSettings` even when `req` was empty, unlike `updateDeploymentSettingsInNotActiveState`, which only PATCHes when `predictions_settings` is set. The batch prediction acceptance test creates a minimal deployment (label, importance, PE, registered model only), so it triggered a fragile no-op API call.

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)

Suggested entry (if included):
> Fixed `datarobot_deployment` to skip empty deployment-settings PATCH on create/update and to retry transient 5xx errors when updating deployment settings.

## Testing

### Unit tests

| Test | Coverage |
|------|----------|
| `TestDeploymentSettingsRequestHasUpdates` | Empty / nil / populated `DeploymentSettings` request detection |
| `TestIsTransientServerError` | 502/503/504 vs non-transient errors |

### Run

```bash
cd terraform-provider-datarobot
go test ./pkg/provider -run 'TestDeployment(ResourceSchema|SettingsRequestHasUpdates|IsTransientServerError)' -count=1 -v
```

### Acceptance (staging creds required)

```bash
make testacc-group-fast
# or targeted:
go test ./pkg/provider -run TestAccBatchPredictionJobDefinitionResource -count=1 -timeout 30m
```

Expected: `TestAccBatchPredictionJobDefinitionResource` no longer fails on empty settings PATCH during deployment create.

## Release Preparation Checklist
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major) — **patch** (bug fix)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes

- **Base branch:** `brunoromano-dr/RAPTOR-18109-create-draft-or-locked-artifact` (RAPTOR-18109 artifact `status`). This fix is **unrelated** to artifact work; it only touches deployment resource logic. Target PR against 18109 or rebase onto `main` if 18109 is already merged.
- **CI context:** Failure observed in `tests.log` — `testacc-group-fast`, 17 passed / 1 failed (`TestAccBatchPredictionJobDefinitionResource`), 1 skipped. Secondary 30m timeout was collateral from failed apply + slow deployment destroy cleanup.
- **502 source:** nginx reverse proxy on staging for `/api/v2/deployments/{id}/settings/` (deployments API, not workload-api).

### Files changed (RAPTOR-18376 only)

| File | Change |
|------|--------|
| `pkg/provider/deployment_resource.go` | Skip empty settings PATCH; `deploymentSettingsRequestHasUpdates`, `isTransientServerError`, `retryOnTransientServerError`; retry on settings-related PATCH endpoints |
| `pkg/provider/deployment_resource_test.go` | Unit tests for helpers above |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment create/update API behavior for all `datarobot_deployment` resources; skipping empty PATCH is a bug fix, but retries on 5xx could mask prolonged outages or extend apply time.
> 
> **Overview**
> Fixes `datarobot_deployment` create/update so it no longer always calls `PATCH /deployments/{id}/settings/` when no optional settings blocks are configured. **`updateDeploymentSettings`** now PATCHes only when `deploymentSettingsRequestHasUpdates` finds at least one populated field on the built request, avoiding no-op calls that were failing acceptance tests (e.g. minimal deployments in batch prediction job definition tests).
> 
> When settings **are** sent, deployment-related PATCH operations—main settings, challenger replay, health, feature cache, and the inactive-state `predictions_settings` path—run inside **`retryOnTransientServerError`**, which retries **502 / 503 / 504** using the provider’s existing exponential backoff and treats other errors as permanent.
> 
> Unit tests cover empty/nil vs populated settings detection and transient vs non-transient error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c65cf9d1e99cc568b64c2f11f67af4b861ca1949. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->