### PR TITLE
[RAPTOR-18378] - fix for deployment creation hanging on failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - `datarobot_artifact` data source for looking up an existing Workload API artifact by ID
 - `datarobot_artifacts` data source for listing Workload API artifacts with optional `status` and `limit` filters
 
+### Fixed
+
+- `datarobot_deployment` creation no longer hangs for the full timeout when the creation task reports a definitive `ERROR` status (e.g. custom model failed to start). The provider now fails fast with the task's error message instead of blind-polling deployment status, which never resolves in that case.
+
 ## [0.10.42] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - `datarobot_deployment` creation no longer hangs for the full timeout when the creation task reports a definitive `ERROR` status (e.g. custom model failed to start). The provider now fails fast with the task's error message instead of blind-polling deployment status, which never resolves in that case.
+- `datarobot_deployment` activation and deactivation (e.g. around runtime parameter updates) now track the async status-change task and fail fast with the task's error message when it reports `ERROR`, instead of blind-polling deployment status until the timeout.
 
 ## [0.10.42] - 2026-06-30
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot-community/terraform-provider-datarobot
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -145,8 +145,8 @@ type Service interface {
 	ValidateDeploymentModelReplacement(ctx context.Context, id string, req *ValidateDeployemntModelReplacementRequest) (*ValidateDeployemntModelReplacementResponse, error)
 	UpdateDeploymentRuntimeParameters(ctx context.Context, id string, req *UpdateDeploymentRuntimeParametersRequest) (*Deployment, error)
 	ListDeploymentRuntimeParameters(ctx context.Context, id string) ([]RuntimeParameter, error)
-	DeactivateDeployment(ctx context.Context, id string) (*Deployment, error)
-	ActivateDeployment(ctx context.Context, id string) (*Deployment, error)
+	DeactivateDeployment(ctx context.Context, id string) (*Deployment, string, error)
+	ActivateDeployment(ctx context.Context, id string) (*Deployment, string, error)
 	GetDeploymentSettings(ctx context.Context, id string) (*DeploymentSettings, error)
 	UpdateDeploymentModel(ctx context.Context, id string, req *UpdateDeploymentModelRequest) (*Deployment, string, error)
 	// Deployment: Settings
@@ -879,12 +879,12 @@ func (s *ServiceImpl) ListDeploymentRuntimeParameters(ctx context.Context, id st
 	return GetAllPages[RuntimeParameter](s.client, ctx, "/deployments/"+id+"/runtimeParameters/", nil)
 }
 
-func (s *ServiceImpl) DeactivateDeployment(ctx context.Context, id string) (*Deployment, error) {
-	return Patch[Deployment](s.client, ctx, "/deployments/"+id+"/status/", &UpdateDeploymentStatusRequest{Status: "inactive"})
+func (s *ServiceImpl) DeactivateDeployment(ctx context.Context, id string) (*Deployment, string, error) {
+	return ExecuteAndExpectStatus[Deployment](s.client, ctx, http.MethodPatch, "/deployments/"+id+"/status/", &UpdateDeploymentStatusRequest{Status: "inactive"})
 }
 
-func (s *ServiceImpl) ActivateDeployment(ctx context.Context, id string) (*Deployment, error) {
-	return Patch[Deployment](s.client, ctx, "/deployments/"+id+"/status/", &UpdateDeploymentStatusRequest{Status: "active"})
+func (s *ServiceImpl) ActivateDeployment(ctx context.Context, id string) (*Deployment, string, error) {
+	return ExecuteAndExpectStatus[Deployment](s.client, ctx, http.MethodPatch, "/deployments/"+id+"/status/", &UpdateDeploymentStatusRequest{Status: "active"})
 }
 
 func (s *ServiceImpl) UpdateDeploymentModel(ctx context.Context, id string, req *UpdateDeploymentModelRequest) (*Deployment, string, error) {

--- a/mock/service.go
+++ b/mock/service.go
@@ -36,12 +36,13 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 }
 
 // ActivateDeployment mocks base method.
-func (m *MockService) ActivateDeployment(ctx context.Context, id string) (*client.Deployment, error) {
+func (m *MockService) ActivateDeployment(ctx context.Context, id string) (*client.Deployment, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActivateDeployment", ctx, id)
 	ret0, _ := ret[0].(*client.Deployment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ActivateDeployment indicates an expected call of ActivateDeployment.
@@ -818,12 +819,13 @@ func (mr *MockServiceMockRecorder) CreateWorkload(ctx, req interface{}) *gomock.
 }
 
 // DeactivateDeployment mocks base method.
-func (m *MockService) DeactivateDeployment(ctx context.Context, id string) (*client.Deployment, error) {
+func (m *MockService) DeactivateDeployment(ctx context.Context, id string) (*client.Deployment, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeactivateDeployment", ctx, id)
 	ret0, _ := ret[0].(*client.Deployment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // DeactivateDeployment indicates an expected call of DeactivateDeployment.
@@ -2032,6 +2034,21 @@ func (mr *MockServiceMockRecorder) IsVectorDatabaseReady(ctx, id interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVectorDatabaseReady", reflect.TypeOf((*MockService)(nil).IsVectorDatabaseReady), ctx, id)
 }
 
+// ListArtifacts mocks base method.
+func (m *MockService) ListArtifacts(ctx context.Context, req *client.ListArtifactsRequest) ([]client.Artifact, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListArtifacts", ctx, req)
+	ret0, _ := ret[0].([]client.Artifact)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListArtifacts indicates an expected call of ListArtifacts.
+func (mr *MockServiceMockRecorder) ListArtifacts(ctx, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListArtifacts", reflect.TypeOf((*MockService)(nil).ListArtifacts), ctx, req)
+}
+
 // ListCredentials mocks base method.
 func (m *MockService) ListCredentials(ctx context.Context) ([]client.Credential, error) {
 	m.ctrl.T.Helper()
@@ -2105,21 +2122,6 @@ func (m *MockService) ListCustomModels(ctx context.Context) ([]client.CustomMode
 func (mr *MockServiceMockRecorder) ListCustomModels(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCustomModels", reflect.TypeOf((*MockService)(nil).ListCustomModels), ctx)
-}
-
-// ListArtifacts mocks base method.
-func (m *MockService) ListArtifacts(ctx context.Context, req *client.ListArtifactsRequest) ([]client.Artifact, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListArtifacts", ctx, req)
-	ret0, _ := ret[0].([]client.Artifact)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListArtifacts indicates an expected call of ListArtifacts.
-func (mr *MockServiceMockRecorder) ListArtifacts(ctx, req interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListArtifacts", reflect.TypeOf((*MockService)(nil).ListArtifacts), ctx, req)
 }
 
 // ListDatasources mocks base method.

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -1369,17 +1369,17 @@ func (r *DeploymentResource) deactivateDeployment(ctx context.Context, id string
 	traceAPICall("DeactivateDeployment")
 	_, statusId, err := r.provider.service.DeactivateDeployment(ctx, id)
 	if err != nil {
-		err = fmt.Errorf("Error deactivating deployment: %w", err)
+		err = fmt.Errorf("error deactivating deployment: %w", err)
 		return
 	}
 
 	if statusErr := r.waitForDeploymentStatusChangeTask(ctx, statusId); statusErr != nil {
-		err = fmt.Errorf("Deployment failed to deactivate: %s", statusErr.Error())
+		err = fmt.Errorf("deployment failed to deactivate: %s", statusErr.Error())
 		return
 	}
 
 	if _, err = r.waitForDeploymentStatus(ctx, id, "inactive"); err != nil {
-		err = fmt.Errorf("Error waiting for deployment to be inactive: %w", err)
+		err = fmt.Errorf("error waiting for deployment to be inactive: %w", err)
 		return
 	}
 
@@ -1390,17 +1390,17 @@ func (r *DeploymentResource) activateDeployment(ctx context.Context, id string) 
 	traceAPICall("ActivateDeployment")
 	_, statusId, err := r.provider.service.ActivateDeployment(ctx, id)
 	if err != nil {
-		err = fmt.Errorf("Error activating deployment: %w", err)
+		err = fmt.Errorf("error activating deployment: %w", err)
 		return
 	}
 
 	if statusErr := r.waitForDeploymentStatusChangeTask(ctx, statusId); statusErr != nil {
-		err = fmt.Errorf("Deployment failed to activate: %s", statusErr.Error())
+		err = fmt.Errorf("deployment failed to activate: %s", statusErr.Error())
 		return
 	}
 
 	if _, err = r.waitForDeploymentToBeReady(ctx, id); err != nil {
-		err = fmt.Errorf("Error waiting for deployment to be ready: %w", err)
+		err = fmt.Errorf("error waiting for deployment to be ready: %w", err)
 		return
 	}
 

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -1373,17 +1373,9 @@ func (r *DeploymentResource) deactivateDeployment(ctx context.Context, id string
 		return
 	}
 
-	if statusErr := waitForTaskStatusToComplete(ctx, r.provider.service, statusId); statusErr != nil {
-		var taskFailedErr *TaskFailedError
-		if errors.As(statusErr, &taskFailedErr) {
-			err = fmt.Errorf("Deployment failed to deactivate: %s", taskFailedErr.Message)
-			return
-		}
-
-		tflog.Warn(ctx, "Task status polling failed, checking deployment status directly", map[string]interface{}{
-			"status_id": statusId,
-			"error":     statusErr.Error(),
-		})
+	if statusErr := r.waitForDeploymentStatusChangeTask(ctx, statusId); statusErr != nil {
+		err = fmt.Errorf("Deployment failed to deactivate: %s", statusErr.Error())
+		return
 	}
 
 	if _, err = r.waitForDeploymentStatus(ctx, id, "inactive"); err != nil {
@@ -1402,17 +1394,9 @@ func (r *DeploymentResource) activateDeployment(ctx context.Context, id string) 
 		return
 	}
 
-	if statusErr := waitForTaskStatusToComplete(ctx, r.provider.service, statusId); statusErr != nil {
-		var taskFailedErr *TaskFailedError
-		if errors.As(statusErr, &taskFailedErr) {
-			err = fmt.Errorf("Deployment failed to activate: %s", taskFailedErr.Message)
-			return
-		}
-
-		tflog.Warn(ctx, "Task status polling failed, checking deployment status directly", map[string]interface{}{
-			"status_id": statusId,
-			"error":     statusErr.Error(),
-		})
+	if statusErr := r.waitForDeploymentStatusChangeTask(ctx, statusId); statusErr != nil {
+		err = fmt.Errorf("Deployment failed to activate: %s", statusErr.Error())
+		return
 	}
 
 	if _, err = r.waitForDeploymentToBeReady(ctx, id); err != nil {
@@ -1421,6 +1405,30 @@ func (r *DeploymentResource) activateDeployment(ctx context.Context, id string) 
 	}
 
 	return
+}
+
+// waitForDeploymentStatusChangeTask waits for the async status-change task
+// spawned by activate/deactivate. A task ERROR is definitive and returned
+// immediately; any other polling failure is ignored so the caller can fall
+// back to polling the deployment status directly.
+func (r *DeploymentResource) waitForDeploymentStatusChangeTask(ctx context.Context, statusId string) error {
+	if statusId == "" {
+		return nil
+	}
+
+	err := waitForTaskStatusToComplete(ctx, r.provider.service, statusId)
+	var taskFailedErr *TaskFailedError
+	if errors.As(err, &taskFailedErr) {
+		return taskFailedErr
+	}
+	if err != nil {
+		tflog.Warn(ctx, "Task status polling failed, checking deployment status directly", map[string]interface{}{
+			"status_id": statusId,
+			"error":     err.Error(),
+		})
+	}
+
+	return nil
 }
 
 // ensureDeploymentActive checks if the deployment is active and activates it if not.

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -1367,10 +1367,25 @@ func (r *DeploymentResource) updateDeploymentRuntimeParameters(
 
 func (r *DeploymentResource) deactivateDeployment(ctx context.Context, id string) (err error) {
 	traceAPICall("DeactivateDeployment")
-	if _, err = r.provider.service.DeactivateDeployment(ctx, id); err != nil {
+	_, statusId, err := r.provider.service.DeactivateDeployment(ctx, id)
+	if err != nil {
 		err = fmt.Errorf("Error deactivating deployment: %w", err)
 		return
 	}
+
+	if statusErr := waitForTaskStatusToComplete(ctx, r.provider.service, statusId); statusErr != nil {
+		var taskFailedErr *TaskFailedError
+		if errors.As(statusErr, &taskFailedErr) {
+			err = fmt.Errorf("Deployment failed to deactivate: %s", taskFailedErr.Message)
+			return
+		}
+
+		tflog.Warn(ctx, "Task status polling failed, checking deployment status directly", map[string]interface{}{
+			"status_id": statusId,
+			"error":     statusErr.Error(),
+		})
+	}
+
 	if _, err = r.waitForDeploymentStatus(ctx, id, "inactive"); err != nil {
 		err = fmt.Errorf("Error waiting for deployment to be inactive: %w", err)
 		return
@@ -1381,10 +1396,25 @@ func (r *DeploymentResource) deactivateDeployment(ctx context.Context, id string
 
 func (r *DeploymentResource) activateDeployment(ctx context.Context, id string) (err error) {
 	traceAPICall("ActivateDeployment")
-	if _, err = r.provider.service.ActivateDeployment(ctx, id); err != nil {
+	_, statusId, err := r.provider.service.ActivateDeployment(ctx, id)
+	if err != nil {
 		err = fmt.Errorf("Error activating deployment: %w", err)
 		return
 	}
+
+	if statusErr := waitForTaskStatusToComplete(ctx, r.provider.service, statusId); statusErr != nil {
+		var taskFailedErr *TaskFailedError
+		if errors.As(statusErr, &taskFailedErr) {
+			err = fmt.Errorf("Deployment failed to activate: %s", taskFailedErr.Message)
+			return
+		}
+
+		tflog.Warn(ctx, "Task status polling failed, checking deployment status directly", map[string]interface{}{
+			"status_id": statusId,
+			"error":     statusErr.Error(),
+		})
+	}
+
 	if _, err = r.waitForDeploymentToBeReady(ctx, id); err != nil {
 		err = fmt.Errorf("Error waiting for deployment to be ready: %w", err)
 		return

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -610,7 +610,13 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	err = waitForTaskStatusToComplete(ctx, r.provider.service, statusID)
+	var taskFailedErr *TaskFailedError
 	if err != nil {
+		if errors.As(err, &taskFailedErr) {
+			resp.Diagnostics.AddError("Deployment failed to create", taskFailedErr.Message)
+			return
+		}
+
 		tflog.Warn(ctx, "Task status polling failed, checking if deployment is ready anyway", map[string]interface{}{
 			"status_id": statusID,
 			"error":     err.Error(),

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -146,6 +146,14 @@ func getExponentialBackoff() backoff.BackOff {
 	return expBackoff
 }
 
+type TaskFailedError struct {
+	Message string
+}
+
+func (e *TaskFailedError) Error() string {
+	return e.Message
+}
+
 func waitForGenAITaskStatusToComplete(ctx context.Context, s client.Service, id string) error {
 	return waitForTaskStatusToCompleteGeneric(ctx, s, id, true)
 }
@@ -178,7 +186,7 @@ func waitForTaskStatusToCompleteGeneric(ctx context.Context, s client.Service, i
 		}
 
 		if task.Status == "ERROR" {
-			return backoff.Permanent(errors.New(task.Message))
+			return backoff.Permanent(&TaskFailedError{Message: task.Message})
 		}
 
 		if task.Status == "COMPLETED" {


### PR DESCRIPTION
## RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

`datarobot_deployment` creation blind-polls deployment status after the creation task completes, regardless of the task's outcome. When the creation task reports a definitive `ERROR` status (e.g. the custom model failed to start), deployment status never resolves, so the resource hangs until the full timeout instead of failing fast with the actual error.

## CHANGES

- Add `TaskFailedError` type in `pkg/provider/utils.go` to carry the task's error message distinctly from other polling errors.
- `waitForTaskStatusToCompleteGeneric` now returns `TaskFailedError` on task `ERROR` status instead of a generic error.
- `DeploymentResource.Create` checks for `TaskFailedError` via `errors.As` and immediately surfaces the task's error message instead of falling through to deployment-status polling.
- Update `CHANGELOG.md` with a Fixed entry.

<!-- rr:slack:start -->
<!-- rr:slack:C053QK4M33R:1783517317.171859 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to deployment create error handling and task polling error typing; improves failure behavior without altering successful create paths.
> 
> **Overview**
> **`datarobot_deployment` create** no longer sits on the full provider timeout when the async creation task returns **`ERROR`** (for example a custom model that fails to start). After creation-task polling finishes, a definitive task failure now stops create immediately with the API’s error message instead of continuing into deployment readiness polling, which often never succeeds in that scenario.
> 
> Shared task polling now returns a typed **`TaskFailedError`** (with the task message) when status is **`ERROR`**, so **`DeploymentResource.Create`** can distinguish a failed task from transient polling issues—the latter still log a warning and fall through to the readiness check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25020f9cc9f6e950c28ffef63b79d22227d9372. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->