### PR TITLE
[RAPTOR-18437] - surfacing logs for failed deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `datarobot_artifact` data source for looking up an existing Workload API artifact by ID
 - `datarobot_artifacts` data source for listing Workload API artifacts with optional `status` and `limit` filters
+- `datarobot_deployment` now surfaces deployment logs in the error message when a deployment fails to create
 
 ### Fixed
 

--- a/internal/client/deployment_service.go
+++ b/internal/client/deployment_service.go
@@ -22,6 +22,15 @@ type Deployment struct {
 	Importance            string                `json:"importance"`
 }
 
+type OtelLogEntry struct {
+	Level      string  `json:"level"`
+	Message    string  `json:"message"`
+	Timestamp  string  `json:"timestamp"`
+	SpanID     *string `json:"spanId,omitempty"`
+	TraceID    *string `json:"traceId,omitempty"`
+	StackTrace string  `json:"stacktrace,omitempty"`
+}
+
 type Model struct {
 	ID         string `json:"id"`
 	Type       string `json:"type"`

--- a/internal/client/deployment_service_test.go
+++ b/internal/client/deployment_service_test.go
@@ -17,30 +17,22 @@ func otelLogEntryJSON(level, message string) map[string]any {
 	}
 }
 
-func TestGetDeploymentLogsPaginatesAndFormats(t *testing.T) {
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestGetDeploymentLogsRequestsLimitAndFormats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/otel/deployment/dep-1/logs/" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Query().Get("offset") == "2" {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": []map[string]any{
-					otelLogEntryJSON("error", "container exited"),
-				},
-				"next": "",
-			})
-			return
+		if got := r.URL.Query().Get("limit"); got != "30" {
+			t.Fatalf("expected limit=30 query param, got %q", got)
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": []map[string]any{
 				otelLogEntryJSON("info", "starting up"),
 				otelLogEntryJSON("error", "failed to load model"),
 			},
-			"next": server.URL + "/otel/deployment/dep-1/logs/?offset=2",
+			"next": "",
 		})
 	}))
 	defer server.Close()
@@ -57,7 +49,6 @@ func TestGetDeploymentLogsPaginatesAndFormats(t *testing.T) {
 	for _, want := range []string{
 		"[2026-07-09T16:14:50Z] INFO: starting up",
 		"[2026-07-09T16:14:50Z] ERROR: failed to load model",
-		"[2026-07-09T16:14:50Z] ERROR: container exited",
 	} {
 		if !strings.Contains(logs, want) {
 			t.Errorf("expected logs to contain %q, got:\n%s", want, logs)
@@ -67,10 +58,14 @@ func TestGetDeploymentLogsPaginatesAndFormats(t *testing.T) {
 
 func TestGetDeploymentLogsTailLinesEnvVar(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("expected limit=2 query param, got %q", got)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		entries := make([]map[string]any, 0, 5)
-		for i := 0; i < 5; i++ {
-			entries = append(entries, otelLogEntryJSON("info", "line"))
+		entries := []map[string]any{
+			otelLogEntryJSON("info", "line1"),
+			otelLogEntryJSON("info", "line2"),
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": entries, "next": ""})
 	}))
@@ -94,9 +89,13 @@ func TestGetDeploymentLogsTailLinesEnvVar(t *testing.T) {
 
 func TestGetDeploymentLogsDefaultTailLines(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("limit"); got != "30" {
+			t.Fatalf("expected default limit=30 query param, got %q", got)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		entries := make([]map[string]any, 0, 40)
-		for i := 0; i < 40; i++ {
+		entries := make([]map[string]any, 0, defaultDeploymentLogsTailLines)
+		for i := 0; i < defaultDeploymentLogsTailLines; i++ {
 			entries = append(entries, otelLogEntryJSON("info", "line"))
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": entries, "next": ""})
@@ -115,4 +114,33 @@ func TestGetDeploymentLogsDefaultTailLines(t *testing.T) {
 	if got := strings.Count(logs, "\n") + 1; got != defaultDeploymentLogsTailLines {
 		t.Errorf("expected %d log lines by default, got %d", defaultDeploymentLogsTailLines, got)
 	}
+}
+
+func TestDeploymentLogsTailLines(t *testing.T) {
+	t.Run("uses env var override", func(t *testing.T) {
+		t.Setenv(DeploymentLogsTailLinesEnvVar, "7")
+		if got := deploymentLogsTailLines(); got != 7 {
+			t.Errorf("expected 7, got %d", got)
+		}
+	})
+
+	t.Run("falls back to default on invalid value", func(t *testing.T) {
+		t.Setenv(DeploymentLogsTailLinesEnvVar, "not-a-number")
+		if got := deploymentLogsTailLines(); got != defaultDeploymentLogsTailLines {
+			t.Errorf("expected default %d, got %d", defaultDeploymentLogsTailLines, got)
+		}
+	})
+
+	t.Run("falls back to default on non-positive value", func(t *testing.T) {
+		t.Setenv(DeploymentLogsTailLinesEnvVar, "0")
+		if got := deploymentLogsTailLines(); got != defaultDeploymentLogsTailLines {
+			t.Errorf("expected default %d, got %d", defaultDeploymentLogsTailLines, got)
+		}
+	})
+
+	t.Run("falls back to default when unset", func(t *testing.T) {
+		if got := deploymentLogsTailLines(); got != defaultDeploymentLogsTailLines {
+			t.Errorf("expected default %d, got %d", defaultDeploymentLogsTailLines, got)
+		}
+	})
 }

--- a/internal/client/deployment_service_test.go
+++ b/internal/client/deployment_service_test.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func otelLogEntryJSON(level, message string) map[string]any {
+	return map[string]any{
+		"level":     level,
+		"message":   message,
+		"timestamp": "2026-07-09T16:14:50Z",
+	}
+}
+
+func TestGetDeploymentLogsPaginatesAndFormats(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/otel/deployment/dep-1/logs/" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("offset") == "2" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					otelLogEntryJSON("error", "container exited"),
+				},
+				"next": "",
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				otelLogEntryJSON("info", "starting up"),
+				otelLogEntryJSON("error", "failed to load model"),
+			},
+			"next": server.URL + "/otel/deployment/dep-1/logs/?offset=2",
+		})
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration("fake-token")
+	cfg.Endpoint = server.URL
+	svc := NewService(NewClient(cfg))
+
+	logs, err := svc.GetDeploymentLogs(context.Background(), "dep-1")
+	if err != nil {
+		t.Fatalf("GetDeploymentLogs returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"[2026-07-09T16:14:50Z] INFO: starting up",
+		"[2026-07-09T16:14:50Z] ERROR: failed to load model",
+		"[2026-07-09T16:14:50Z] ERROR: container exited",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("expected logs to contain %q, got:\n%s", want, logs)
+		}
+	}
+}
+
+func TestGetDeploymentLogsTailLinesEnvVar(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		entries := make([]map[string]any, 0, 5)
+		for i := 0; i < 5; i++ {
+			entries = append(entries, otelLogEntryJSON("info", "line"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": entries, "next": ""})
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration("fake-token")
+	cfg.Endpoint = server.URL
+	svc := NewService(NewClient(cfg))
+
+	t.Setenv(DeploymentLogsTailLinesEnvVar, "2")
+
+	logs, err := svc.GetDeploymentLogs(context.Background(), "dep-1")
+	if err != nil {
+		t.Fatalf("GetDeploymentLogs returned error: %v", err)
+	}
+
+	if got := strings.Count(logs, "\n") + 1; got != 2 {
+		t.Errorf("expected 2 log lines with tail=2, got %d:\n%s", got, logs)
+	}
+}
+
+func TestGetDeploymentLogsDefaultTailLines(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		entries := make([]map[string]any, 0, 40)
+		for i := 0; i < 40; i++ {
+			entries = append(entries, otelLogEntryJSON("info", "line"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": entries, "next": ""})
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration("fake-token")
+	cfg.Endpoint = server.URL
+	svc := NewService(NewClient(cfg))
+
+	logs, err := svc.GetDeploymentLogs(context.Background(), "dep-1")
+	if err != nil {
+		t.Fatalf("GetDeploymentLogs returned error: %v", err)
+	}
+
+	if got := strings.Count(logs, "\n") + 1; got != defaultDeploymentLogsTailLines {
+		t.Errorf("expected %d log lines by default, got %d", defaultDeploymentLogsTailLines, got)
+	}
+}

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -5,6 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	DeploymentLogsTailLinesEnvVar  = "DATAROBOT_DEPLOYMENT_LOGS_TAIL_LINES"
+	defaultDeploymentLogsTailLines = 30
 )
 
 type Service interface {
@@ -140,6 +148,7 @@ type Service interface {
 	// Deployment
 	CreateDeploymentFromModelPackage(ctx context.Context, req *CreateDeploymentFromModelPackageRequest) (*DeploymentCreateResponse, string, error)
 	GetDeployment(ctx context.Context, id string) (*Deployment, error)
+	GetDeploymentLogs(ctx context.Context, id string) (string, error)
 	UpdateDeployment(ctx context.Context, id string, req *UpdateDeploymentRequest) (*Deployment, error)
 	DeleteDeployment(ctx context.Context, id string) error
 	ValidateDeploymentModelReplacement(ctx context.Context, id string, req *ValidateDeployemntModelReplacementRequest) (*ValidateDeployemntModelReplacementResponse, error)
@@ -749,6 +758,32 @@ func (s *ServiceImpl) CreateDeploymentFromModelPackage(ctx context.Context, req 
 
 func (s *ServiceImpl) GetDeployment(ctx context.Context, id string) (*Deployment, error) {
 	return Get[Deployment](s.client, ctx, "/deployments/"+id+"/")
+}
+
+func (s *ServiceImpl) GetDeploymentLogs(ctx context.Context, id string) (string, error) {
+	entries, err := GetAllPages[OtelLogEntry](s.client, ctx, "/otel/deployment/"+id+"/logs/", nil)
+	if err != nil {
+		return "", err
+	}
+
+	tailLines, err := strconv.Atoi(os.Getenv(DeploymentLogsTailLinesEnvVar))
+	if err != nil || tailLines <= 0 {
+		tailLines = defaultDeploymentLogsTailLines
+	}
+	if len(entries) > tailLines {
+		entries = entries[len(entries)-tailLines:]
+	}
+
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		line := fmt.Sprintf("[%s] %s: %s", entry.Timestamp, strings.ToUpper(entry.Level), entry.Message)
+		if entry.StackTrace != "" {
+			line += "\n" + entry.StackTrace
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n"), nil
 }
 
 func (s *ServiceImpl) UpdateDeployment(ctx context.Context, id string, req *UpdateDeploymentRequest) (*Deployment, error) {

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 const (
@@ -760,22 +762,29 @@ func (s *ServiceImpl) GetDeployment(ctx context.Context, id string) (*Deployment
 	return Get[Deployment](s.client, ctx, "/deployments/"+id+"/")
 }
 
+func deploymentLogsTailLines() int {
+	tailLines, err := strconv.Atoi(os.Getenv(DeploymentLogsTailLinesEnvVar))
+	if err != nil || tailLines <= 0 {
+		return defaultDeploymentLogsTailLines
+	}
+	return tailLines
+}
+
+type getDeploymentLogsRequest struct {
+	Limit int `url:"limit,omitempty"`
+}
+
 func (s *ServiceImpl) GetDeploymentLogs(ctx context.Context, id string) (string, error) {
-	entries, err := GetAllPages[OtelLogEntry](s.client, ctx, "/otel/deployment/"+id+"/logs/", nil)
+	queryReq := &getDeploymentLogsRequest{Limit: deploymentLogsTailLines()}
+	pathValues, _ := query.Values(queryReq)
+
+	resp, err := Get[PaginatedResponse[OtelLogEntry]](s.client, ctx, "/otel/deployment/"+id+"/logs/?"+pathValues.Encode())
 	if err != nil {
 		return "", err
 	}
 
-	tailLines, err := strconv.Atoi(os.Getenv(DeploymentLogsTailLinesEnvVar))
-	if err != nil || tailLines <= 0 {
-		tailLines = defaultDeploymentLogsTailLines
-	}
-	if len(entries) > tailLines {
-		entries = entries[len(entries)-tailLines:]
-	}
-
-	lines := make([]string, 0, len(entries))
-	for _, entry := range entries {
+	lines := make([]string, 0, len(resp.Data))
+	for _, entry := range resp.Data {
 		line := fmt.Sprintf("[%s] %s: %s", entry.Timestamp, strings.ToUpper(entry.Level), entry.Message)
 		if entry.StackTrace != "" {
 			line += "\n" + entry.StackTrace

--- a/mock/service.go
+++ b/mock/service.go
@@ -1524,6 +1524,21 @@ func (mr *MockServiceMockRecorder) GetDeployment(ctx, id interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockService)(nil).GetDeployment), ctx, id)
 }
 
+// GetDeploymentLogs mocks base method.
+func (m *MockService) GetDeploymentLogs(ctx context.Context, id string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeploymentLogs", ctx, id)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeploymentLogs indicates an expected call of GetDeploymentLogs.
+func (mr *MockServiceMockRecorder) GetDeploymentLogs(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentLogs", reflect.TypeOf((*MockService)(nil).GetDeploymentLogs), ctx, id)
+}
+
 // GetDeploymentChallengerReplaySettings mocks base method.
 func (m *MockService) GetDeploymentChallengerReplaySettings(ctx context.Context, id string) (*client.DeploymentChallengerReplaySettings, error) {
 	m.ctrl.T.Helper()

--- a/pkg/provider/deployment_logs_test.go
+++ b/pkg/provider/deployment_logs_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client"
+	mock_client "github.com/datarobot-community/terraform-provider-datarobot/mock"
+	"github.com/golang/mock/gomock"
+)
+
+func TestDeploymentErrorMessageWithLogs(t *testing.T) {
+	t.Run("includes logs and UI link on success", func(t *testing.T) {
+		msg := deploymentErrorMessageWithLogs("deployment has errored", "line1\nline2", nil, "https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs")
+
+		for _, want := range []string{
+			"deployment has errored",
+			deploymentLogsSeparator,
+			"line1\nline2",
+			"See full logs at: https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs",
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected message to contain %q, got:\n%s", want, msg)
+			}
+		}
+	})
+
+	t.Run("falls back to UI link when log retrieval fails", func(t *testing.T) {
+		msg := deploymentErrorMessageWithLogs("deployment has errored", "", errors.New("boom"), "https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs")
+
+		for _, want := range []string{
+			"deployment has errored",
+			"failed to retrieve deployment logs: boom",
+			"See full logs at: https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs",
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected message to contain %q, got:\n%s", want, msg)
+			}
+		}
+	})
+}
+
+func TestWaitForDeploymentStatusErroredIncludesLogsAndUIURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	r := &DeploymentResource{provider: &Provider{service: mockService}}
+
+	mockService.EXPECT().GetDeployment(gomock.Any(), "dep-1").Return(&client.Deployment{Status: "error"}, nil)
+	mockService.EXPECT().GetDeploymentLogs(gomock.Any(), "dep-1").Return("[2026-07-09T16:14:50Z] ERROR: failed to load model", nil)
+	mockService.EXPECT().BaseURL().Return("https://app.datarobot.com")
+
+	_, err := r.waitForDeploymentToBeReady(context.Background(), "dep-1")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	for _, want := range []string{
+		"deployment has errored",
+		deploymentLogsSeparator,
+		"failed to load model",
+		"See full logs at: https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got:\n%s", want, err.Error())
+		}
+	}
+}
+
+func TestWaitForDeploymentStatusErroredLogRetrievalFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_client.NewMockService(ctrl)
+	r := &DeploymentResource{provider: &Provider{service: mockService}}
+
+	mockService.EXPECT().GetDeployment(gomock.Any(), "dep-1").Return(&client.Deployment{Status: "error"}, nil)
+	mockService.EXPECT().GetDeploymentLogs(gomock.Any(), "dep-1").Return("", errors.New("logs unavailable"))
+	mockService.EXPECT().BaseURL().Return("https://app.datarobot.com")
+
+	_, err := r.waitForDeploymentToBeReady(context.Background(), "dep-1")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	for _, want := range []string{
+		"deployment has errored",
+		"failed to retrieve deployment logs: logs unavailable",
+		"See full logs at: https://app.datarobot.com/console-nextgen/deployments/dep-1/activity-log/otel-logs",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got:\n%s", want, err.Error())
+		}
+	}
+}

--- a/pkg/provider/deployment_resource.go
+++ b/pkg/provider/deployment_resource.go
@@ -27,6 +27,24 @@ import (
 var _ resource.Resource = &DeploymentResource{}
 var _ resource.ResourceWithImportState = &DeploymentResource{}
 
+const deploymentLogsSeparator = "----------------------------------------"
+
+// deploymentErrorMessageWithLogs builds a diagnostic message for a failed
+// deployment, appending retrieved logs (or the log retrieval error) and a
+// link to the full logs in the DataRobot UI.
+func deploymentErrorMessageWithLogs(baseMessage, logs string, logErr error, logsURL string) string {
+	if logErr != nil {
+		return fmt.Sprintf(
+			"%s (failed to retrieve deployment logs: %s)\n%s\nSee full logs at: %s",
+			baseMessage, logErr, deploymentLogsSeparator, logsURL,
+		)
+	}
+	return fmt.Sprintf(
+		"%s\n%s\nCustom Model Deployment logs:\n%s\n%s\nSee full logs at: %s",
+		baseMessage, deploymentLogsSeparator, logs, deploymentLogsSeparator, logsURL,
+	)
+}
+
 func NewDeploymentResource() resource.Resource {
 	return &DeploymentResource{}
 }
@@ -613,7 +631,11 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	var taskFailedErr *TaskFailedError
 	if err != nil {
 		if errors.As(err, &taskFailedErr) {
-			resp.Diagnostics.AddError("Deployment failed to create", taskFailedErr.Message)
+			logsURL := r.provider.service.BaseURL() + "/console-nextgen/deployments/" + createResp.ID + "/activity-log/otel-logs"
+
+			traceAPICall("GetDeploymentLogs")
+			logs, logErr := r.provider.service.GetDeploymentLogs(ctx, createResp.ID)
+			resp.Diagnostics.AddError("Deployment failed to create", deploymentErrorMessageWithLogs(taskFailedErr.Message, logs, logErr, logsURL))
 			return
 		}
 
@@ -1103,11 +1125,18 @@ func (r *DeploymentResource) waitForDeploymentStatus(ctx context.Context, id str
 		}
 
 		if deployment.Status == status {
+			tflog.Info(ctx, "Deployment is ready", map[string]interface{}{"deployment_id": id})
 			return nil
 		} else if strings.Contains(deployment.Status, "error") {
-			return backoff.Permanent(errors.New("deployment has errored"))
+			logsURL := r.provider.service.BaseURL() + "/console-nextgen/deployments/" + id + "/activity-log/otel-logs"
+
+			traceAPICall("GetDeploymentLogs")
+			tflog.Error(ctx, "Deployment has errored", map[string]interface{}{"deployment_id": id})
+			logs, logErr := r.provider.service.GetDeploymentLogs(ctx, id)
+			return backoff.Permanent(errors.New(deploymentErrorMessageWithLogs("deployment has errored", logs, logErr, logsURL)))
 		}
 
+		tflog.Info(ctx, "Deployment is not ready", map[string]interface{}{"deployment_id": id, "status": deployment.Status})
 		lastStatus = deployment.Status
 
 		return errors.New("deployment is not ready")


### PR DESCRIPTION
## Summary
Adds log surfacing when a custom model deployment fails to start. It displays last 30 log messages from instrumented oTel logging. If oTel is not instrumented then most likely logs won't be visible. Default amount of lines could be changed by changing `DATAROBOT_DEPLOYMENT_LOGS_TAIL_LINES` env var. Also, a link to the deployment UI with logs is added to the output.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Whenever custom model deployment will fail, logs from that deployment will be displayed in the CLI output.

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- rr:slack:start -->
<!-- rr:slack:C053QK4M33R:1783683409.313069 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core deployment create and activate/deactivate wait logic and client method signatures (activate/deactivate now return a status task ID), which could alter timing and error surfaces for existing Terraform workflows.
> 
> **Overview**
> Improves **`datarobot_deployment`** failure handling so Terraform stops waiting on the full timeout when the backend already knows the operation failed, and gives operators actionable detail in diagnostics.
> 
> **Deployment logs in errors:** The client adds **`GetDeploymentLogs`**, which paginates `/otel/deployment/{id}/logs/`, formats entries, and tails the last N lines (default 30, overridable via **`DATAROBOT_DEPLOYMENT_LOGS_TAIL_LINES`**). When create fails on a task **`ERROR`**, or readiness polling sees an errored deployment status, the provider builds a richer message (task/base error, tailed logs, link to OTEL logs in the UI).
> 
> **Fail-fast on async tasks:** Creation now treats **`TaskFailedError`** from task polling as terminal and returns immediately with logs instead of falling through to deployment status polling. **Activate** and **deactivate** switch from blind PATCH polling to **`ExecuteAndExpectStatus`**, returning an async **status task ID**; the provider waits on that task and fails fast on task **`ERROR`** before continuing to poll deployment status (e.g. around runtime parameter updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29133ea06a0f84810854fc92e11dcc6acd4ad5ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->