### PR TITLE
[RAPTOR 18360] Artifact source push directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `internal/client/filesapi` package: context-aware Files API client (catalog create, staged upload, zip upload, async status polling, manifest listing) ported from the DR CLI for upcoming `datarobot_artifact` `source { dir }` support
+- `internal/artifactsource` package: push-only directory upload orchestration (`PushDirectory`) over the Files API client (walk, hash, stage/zip routing, async poll) for upcoming `datarobot_artifact` `source { dir }` support
 - `image_build_config` block on `datarobot_artifact` containers: configure code-to-workload image builds with optional `code_ref` and a `dockerfile` (`provided` or `generated`). Use with `status = "draft"` for pre-build artifacts; locking requires a completed build so workload-api has populated `image_uri`.
 - `status` attribute on `datarobot_artifact`: `draft` (the current artifact version is mutable; spec changes are applied in-place and `artifact_id` stays the same) or `locked` (artifact versions are immutable; spec changes create a new version with a new `artifact_id` in the same `artifact_repository_id`). Defaults to `locked`. Locking a draft artifact is one-way. Changing `status` from `locked` to `draft` creates a new draft artifact (the Workload API cannot unlock in place).
 - `datarobot_artifact` data source for looking up an existing Workload API artifact by ID

--- a/internal/artifactsource/diff.go
+++ b/internal/artifactsource/diff.go
@@ -1,0 +1,42 @@
+package artifactsource
+
+import "sort"
+
+// PushPlan is the incremental upload blueprint: only paths that changed since
+// the last successful push (BaseFiles from Terraform state).
+type PushPlan struct {
+	Uploads []string // added or modified paths
+	Deletes []string // removed since last push
+	// no downloads here because we're intending a push-only behavior
+}
+
+func (p *PushPlan) IsEmpty() bool {
+	return len(p.Uploads) == 0 && len(p.Deletes) == 0
+}
+
+func (p *PushPlan) sort() {
+	sort.Strings(p.Uploads)
+	sort.Strings(p.Deletes)
+}
+
+// DiffPushOnly compares the previous manifest (Terraform state) to the current
+// local tree. Local is the source of truth; this is push-only (no downloads).
+func DiffPushOnly(base, local Manifest) *PushPlan {
+	plan := &PushPlan{}
+
+	for path, entry := range local {
+		prev, ok := base[path]
+		if !ok || prev.Hash != entry.Hash {
+			plan.Uploads = append(plan.Uploads, path)
+		}
+	}
+
+	for path := range base {
+		if _, ok := local[path]; !ok {
+			plan.Deletes = append(plan.Deletes, path)
+		}
+	}
+
+	plan.sort()
+	return plan
+}

--- a/internal/artifactsource/diff_test.go
+++ b/internal/artifactsource/diff_test.go
@@ -52,7 +52,7 @@ func TestDiffPushOnly_BaseOnlyFileSchedulesDeleteNotUpload(t *testing.T) {
 	// For that path the upload list stays empty: there is nothing local to push,
 	// and we never pull remote-only files into the plan.
 	base := Manifest{
-		"keep.txt":       {Hash: "same", Size: 4},
+		"keep.txt":        {Hash: "same", Size: 4},
 		"remote-only.txt": {Hash: "remote", Size: 6},
 	}
 	local := Manifest{

--- a/internal/artifactsource/diff_test.go
+++ b/internal/artifactsource/diff_test.go
@@ -1,0 +1,66 @@
+package artifactsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffPushOnly_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	base := Manifest{
+		"a.txt": {Hash: "aaa", Size: 3},
+		"b.txt": {Hash: "bbb", Size: 3},
+	}
+	local := Manifest{
+		"a.txt": {Hash: "aaa", Size: 3},
+		"b.txt": {Hash: "bbb", Size: 3},
+	}
+
+	plan := DiffPushOnly(base, local)
+	assert.True(t, plan.IsEmpty())
+}
+
+func TestDiffPushOnly_AddedModifiedDeleted(t *testing.T) {
+	t.Parallel()
+
+	base := Manifest{
+		"keep.txt":    {Hash: "same", Size: 4},
+		"changed.txt": {Hash: "old", Size: 3},
+		"removed.txt": {Hash: "gone", Size: 4},
+	}
+	local := Manifest{
+		"keep.txt":    {Hash: "same", Size: 4},
+		"changed.txt": {Hash: "new", Size: 3},
+		"added.txt":   {Hash: "add", Size: 3},
+	}
+
+	plan := DiffPushOnly(base, local)
+	assert.Equal(t, []string{"added.txt", "changed.txt"}, plan.Uploads)
+	assert.Equal(t, []string{"removed.txt"}, plan.Deletes)
+}
+
+func TestDiffPushOnly_BaseOnlyFileSchedulesDeleteNotUpload(t *testing.T) {
+	t.Parallel()
+
+	// Push-only / delete-only diff: local is the source of truth. When a path
+	// exists in base (last successful push, i.e. Terraform state) but is absent
+	// locally, we do not download it back — PushPlan has no Downloads bucket at
+	// all (unlike the CLI three-way sync). The only action is a remote delete.
+	//
+	// For that path the upload list stays empty: there is nothing local to push,
+	// and we never pull remote-only files into the plan.
+	base := Manifest{
+		"keep.txt":       {Hash: "same", Size: 4},
+		"remote-only.txt": {Hash: "remote", Size: 6},
+	}
+	local := Manifest{
+		"keep.txt": {Hash: "same", Size: 4},
+	}
+
+	plan := DiffPushOnly(base, local)
+
+	assert.Empty(t, plan.Uploads)
+	assert.Equal(t, []string{"remote-only.txt"}, plan.Deletes)
+}

--- a/internal/artifactsource/doc.go
+++ b/internal/artifactsource/doc.go
@@ -1,0 +1,8 @@
+// Package artifactsource provides local directory upload orchestration over the
+// DataRobot Files API client (internal/client/filesapi).
+//
+// PushDirectory walks a local directory, hashes files, and uploads via either
+// the stage path (small change sets) or zip/fromFile path (large change sets).
+// When CatalogID and BaseFiles (per-path hashes from Terraform state) are set,
+// only added, modified, and deleted files are synced incrementally.
+package artifactsource

--- a/internal/artifactsource/fingerprint.go
+++ b/internal/artifactsource/fingerprint.go
@@ -1,0 +1,20 @@
+package artifactsource
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// directoryFingerprint returns a deterministic SHA-256 hex digest of the tree.
+// Files must already be sorted by RelPath. Each entry contributes relPath + NUL + fileHash.
+func directoryFingerprint(files []LocalFile) string {
+	h := sha256.New()
+
+	for _, f := range files {
+		_, _ = h.Write([]byte(f.RelPath))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(f.Hash))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/artifactsource/fingerprint_test.go
+++ b/internal/artifactsource/fingerprint_test.go
@@ -1,0 +1,52 @@
+package artifactsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirectoryFingerprint_OrderStable(t *testing.T) {
+	t.Parallel()
+
+	files := []LocalFile{
+		{RelPath: "a.txt", Hash: "aaa"},
+		{RelPath: "b.txt", Hash: "bbb"},
+	}
+
+	h1 := directoryFingerprint(files)
+	h2 := directoryFingerprint(files)
+	assert.Equal(t, h1, h2)
+	assert.NotEmpty(t, h1)
+}
+
+func TestDirectoryFingerprint_DifferentPaths(t *testing.T) {
+	t.Parallel()
+
+	filesA := []LocalFile{{RelPath: "a.txt", Hash: "same"}}
+	filesB := []LocalFile{{RelPath: "b.txt", Hash: "same"}}
+
+	assert.NotEqual(t, directoryFingerprint(filesA), directoryFingerprint(filesB))
+}
+
+func TestDirectoryFingerprint_DifferentHashes(t *testing.T) {
+	t.Parallel()
+
+	filesA := []LocalFile{{RelPath: "a.txt", Hash: "one"}}
+	filesB := []LocalFile{{RelPath: "a.txt", Hash: "two"}}
+
+	assert.NotEqual(t, directoryFingerprint(filesA), directoryFingerprint(filesB))
+}
+
+func TestDirectoryFingerprint_NULSeparatorPreventsAmbiguousConcatenation(t *testing.T) {
+	t.Parallel()
+
+	// Each entry is hashed as relPath + NUL + fileHash. Without the NUL byte,
+	// ("ab", "cdef") and ("a", "bcdef") would serialize to the same byte
+	// sequence "abcdef" and collide. The separator keeps distinct trees distinct
+	// even when path/hash boundaries could otherwise align.
+	filesA := []LocalFile{{RelPath: "ab", Hash: "cdef"}}
+	filesB := []LocalFile{{RelPath: "a", Hash: "bcdef"}}
+
+	assert.NotEqual(t, directoryFingerprint(filesA), directoryFingerprint(filesB))
+}

--- a/internal/artifactsource/hash.go
+++ b/internal/artifactsource/hash.go
@@ -1,0 +1,45 @@
+package artifactsource
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	maxFileSizeBytes   int64 = 5 * 1024 * 1024 * 1024 // 5 GiB
+	hashChunkSizeBytes       = 64 * 1024
+)
+
+// ErrFileTooLarge is returned when a file exceeds maxFileSizeBytes.
+var ErrFileTooLarge = errors.New("file exceeds max size")
+
+// hashFile returns the SHA-256 hex digest and size of a regular file.
+func hashFile(path string) (string, int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	if info.Size() > maxFileSizeBytes {
+		return "", info.Size(), fmt.Errorf("%w: %s (%d bytes)", ErrFileTooLarge, path, info.Size())
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", info.Size(), fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	buf := make([]byte, hashChunkSizeBytes)
+
+	if _, err := io.CopyBuffer(h, f, buf); err != nil {
+		return "", info.Size(), fmt.Errorf("hash %s: %w", path, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), info.Size(), nil
+}

--- a/internal/artifactsource/hash_test.go
+++ b/internal/artifactsource/hash_test.go
@@ -1,0 +1,41 @@
+package artifactsource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashFile_KnownVector(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "hello.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	hash, size, err := hashFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), size)
+	// SHA-256 of "hello"
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash)
+}
+
+func TestHashFile_TooLarge(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "big.bin")
+
+	// Create a file just over the limit without allocating 5GiB in memory.
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(maxFileSizeBytes+1))
+	require.NoError(t, f.Close())
+
+	_, _, err = hashFile(path)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFileTooLarge)
+}

--- a/internal/artifactsource/limits.go
+++ b/internal/artifactsource/limits.go
@@ -1,0 +1,10 @@
+package artifactsource
+
+// Upload orchestration tunables ported from cli/internal/workload/sync/limits.go.
+const (
+	UploadConcurrency = 4
+
+	// Stage path is used when file count and total bytes are both at or below these thresholds.
+	StageVsZipFileThreshold  = 20
+	StageVsZipBytesThreshold = 50 * 1024 * 1024
+)

--- a/internal/artifactsource/manifest.go
+++ b/internal/artifactsource/manifest.go
@@ -1,0 +1,37 @@
+package artifactsource
+
+// FileMeta is the per-file manifest entry stored in Terraform state.
+// Hash is SHA-256 hex (64 chars) as produced by hashFile.
+type FileMeta struct {
+	Hash string
+	Size int64
+}
+
+// Manifest maps normalized relative paths to per-file metadata.
+type Manifest map[string]FileMeta
+
+func manifestFromFiles(files []LocalFile) Manifest {
+	out := make(Manifest, len(files))
+	for _, f := range files {
+		out[f.RelPath] = FileMeta{Hash: f.Hash, Size: f.Size}
+	}
+	return out
+}
+
+func localFilesByPath(files []LocalFile) map[string]LocalFile {
+	out := make(map[string]LocalFile, len(files))
+	for _, f := range files {
+		out[f.RelPath] = f
+	}
+	return out
+}
+
+func localFilesForPaths(byPath map[string]LocalFile, paths []string) []LocalFile {
+	out := make([]LocalFile, 0, len(paths))
+	for _, path := range paths {
+		if f, ok := byPath[path]; ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/internal/artifactsource/manifest_test.go
+++ b/internal/artifactsource/manifest_test.go
@@ -1,0 +1,20 @@
+package artifactsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestFromFiles(t *testing.T) {
+	t.Parallel()
+
+	files := []LocalFile{
+		{RelPath: "a.txt", Hash: "aaa", Size: 3},
+		{RelPath: "b.txt", Hash: "bbb", Size: 3},
+	}
+
+	m := manifestFromFiles(files)
+	assert.Equal(t, FileMeta{Hash: "aaa", Size: 3}, m["a.txt"])
+	assert.Equal(t, FileMeta{Hash: "bbb", Size: 3}, m["b.txt"])
+}

--- a/internal/artifactsource/push.go
+++ b/internal/artifactsource/push.go
@@ -1,0 +1,110 @@
+package artifactsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+// PushDirectory walks a local directory and uploads files to the DataRobot
+// Files API catalog. On first push (no CatalogID or BaseFiles) the full tree
+// is uploaded. On subsequent pushes only added, modified, and deleted files
+// are synced incrementally on top of the previous catalog version.
+func PushDirectory(ctx context.Context, client filesapi.Client, opts Options) (*Result, error) {
+	if client == nil {
+		return nil, errors.New("files API client is required")
+	}
+	if opts.Dir == "" {
+		return nil, errors.New("directory path is required")
+	}
+
+	overwrite := opts.Overwrite
+	if overwrite == "" {
+		overwrite = filesapi.OverwriteReplace
+	}
+
+	files, totalBytes, err := scanLocalFiles(opts.Dir, opts.Ignore)
+	if err != nil {
+		return nil, err
+	}
+
+	fileHashes := manifestFromFiles(files)
+	sourceHash := directoryFingerprint(files)
+	byPath := localFilesByPath(files)
+
+	result := &Result{
+		SourceHash: sourceHash,
+		FileHashes: fileHashes,
+		FileCount:  len(files),
+		TotalBytes: totalBytes,
+	}
+
+	if canIncrementalPush(opts) {
+		plan := DiffPushOnly(opts.BaseFiles, fileHashes)
+		if plan.IsEmpty() {
+			result.CatalogID = opts.CatalogID
+			result.CatalogVersionID = opts.CatalogVersionID
+			return result, nil
+		}
+
+		catalogID, versionID, err := applyIncrementalPush(ctx, client, opts.CatalogID, overwrite, plan, byPath)
+		if err != nil {
+			return nil, err
+		}
+
+		result.CatalogID = catalogID
+		result.CatalogVersionID = versionID
+		result.Incremental = true
+		return result, nil
+	}
+
+	up := chooseUploader(files)
+	catalogID, versionID, err := up.upload(ctx, client, opts.CatalogID, overwrite, files)
+	if err != nil {
+		return nil, err
+	}
+
+	result.CatalogID = catalogID
+	result.CatalogVersionID = versionID
+	return result, nil
+}
+
+func canIncrementalPush(opts Options) bool {
+	return opts.CatalogID != "" && len(opts.BaseFiles) > 0
+}
+
+func scanLocalFiles(dir string, ignore IgnoreFunc) ([]LocalFile, int64, error) {
+	entries, err := walkDirectory(dir, ignore)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(entries) == 0 {
+		return nil, 0, fmt.Errorf("directory %s contains no uploadable files", dir)
+	}
+
+	files := make([]LocalFile, 0, len(entries))
+	var totalBytes int64
+
+	for _, e := range entries {
+		if err := filesapi.SafeRelPath(e.RelPath); err != nil {
+			return nil, 0, fmt.Errorf("invalid path %q: %w", e.RelPath, err)
+		}
+
+		hash, size, err := hashFile(e.AbsPath)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		files = append(files, LocalFile{
+			RelPath: e.RelPath,
+			AbsPath: e.AbsPath,
+			Size:    size,
+			Hash:    hash,
+		})
+		totalBytes += size
+	}
+
+	return files, totalBytes, nil
+}

--- a/internal/artifactsource/push_test.go
+++ b/internal/artifactsource/push_test.go
@@ -1,0 +1,296 @@
+package artifactsource_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFilesAPI struct {
+	createCatalogCalls      int
+	createStageCalls        int
+	uploadToStagePaths      []string
+	applyStageCalls         int
+	uploadFromZipNewCalls   int
+	uploadFromZipExistCalls int
+	pollStatusCalls         int
+	deletePaths             []string
+	deleteCalls             int
+
+	catalogID string
+	stageID   string
+	version   int
+}
+
+func (m *mockFilesAPI) CreateCatalog(_ context.Context) (*filesapi.CatalogResp, error) {
+	m.createCatalogCalls++
+	if m.catalogID == "" {
+		m.catalogID = "cat-new"
+	}
+	m.version++
+	return &filesapi.CatalogResp{CatalogID: m.catalogID, CatalogVersionID: versionID(m.version)}, nil
+}
+
+func (m *mockFilesAPI) CreateStage(_ context.Context, catalogID string) (*filesapi.StageResp, error) {
+	m.createStageCalls++
+	m.stageID = "stage-1"
+	return &filesapi.StageResp{CatalogID: catalogID, StageID: m.stageID}, nil
+}
+
+func (m *mockFilesAPI) UploadToStage(_ context.Context, _, _, name string, _ int64, _ io.Reader) error {
+	m.uploadToStagePaths = append(m.uploadToStagePaths, name)
+	return nil
+}
+
+func (m *mockFilesAPI) ApplyStage(_ context.Context, catalogID, _, _ string) (*filesapi.ApplyStageResp, error) {
+	m.applyStageCalls++
+	m.version++
+	return &filesapi.ApplyStageResp{CatalogID: catalogID, CatalogVersionID: versionID(m.version), NumFiles: len(m.uploadToStagePaths)}, nil
+}
+
+func (m *mockFilesAPI) UploadFromZipNew(_ context.Context, _ string, _ int64, _ io.Reader) (*filesapi.FromFileResp, error) {
+	m.uploadFromZipNewCalls++
+	if m.catalogID == "" {
+		m.catalogID = "cat-zip-new"
+	}
+	m.version++
+	return &filesapi.FromFileResp{CatalogID: m.catalogID, CatalogVersionID: versionID(m.version)}, nil
+}
+
+func (m *mockFilesAPI) UploadFromZipExisting(_ context.Context, catalogID, _, _ string, _ int64, _ io.Reader) (*filesapi.FromFileResp, error) {
+	m.uploadFromZipExistCalls++
+	m.version++
+	return &filesapi.FromFileResp{CatalogID: catalogID, CatalogVersionID: versionID(m.version), StatusID: "status-1"}, nil
+}
+
+func (m *mockFilesAPI) PollStatus(_ context.Context, _ string) (*filesapi.StatusResp, error) {
+	m.pollStatusCalls++
+	return &filesapi.StatusResp{Status: filesapi.StatusCompleted}, nil
+}
+
+func (m *mockFilesAPI) AllFiles(context.Context, string, string) (map[string]filesapi.FileMeta, error) {
+	panic("not used")
+}
+
+func (m *mockFilesAPI) DownloadFile(context.Context, string, string, string, io.Writer) (string, int64, error) {
+	panic("not used")
+}
+
+func (m *mockFilesAPI) DeleteFiles(_ context.Context, _ string, paths []string) (*filesapi.DeleteFilesResp, error) {
+	m.deleteCalls++
+	m.deletePaths = append(m.deletePaths, paths...)
+	m.version++
+	return &filesapi.DeleteFilesResp{CatalogVersionID: versionID(m.version)}, nil
+}
+
+func (m *mockFilesAPI) ListVersions(context.Context, string, int) ([]filesapi.CatalogVersion, error) {
+	panic("not used")
+}
+
+func versionID(n int) string {
+	return fmt.Sprintf("ver-%d", n)
+}
+
+func TestPushDirectory_StagePathSmallTree(t *testing.T) {
+	t.Parallel()
+
+	root := writeSmallTree(t)
+	mock := &mockFilesAPI{}
+
+	result, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-new", result.CatalogID)
+	assert.Equal(t, "ver-2", result.CatalogVersionID)
+	assert.Equal(t, 2, result.FileCount)
+	assert.NotEmpty(t, result.SourceHash)
+	assert.Len(t, result.FileHashes, 2)
+	assert.False(t, result.Incremental)
+
+	assert.Equal(t, 1, mock.createCatalogCalls)
+	assert.Equal(t, 1, mock.createStageCalls)
+	assert.Equal(t, 2, len(mock.uploadToStagePaths))
+	assert.Equal(t, 1, mock.applyStageCalls)
+	assert.Zero(t, mock.uploadFromZipNewCalls)
+}
+
+func TestPushDirectory_ExistingCatalogStagePath(t *testing.T) {
+	t.Parallel()
+
+	root := writeSmallTree(t)
+	mock := &mockFilesAPI{catalogID: "cat-existing"}
+
+	result, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{
+		Dir:       root,
+		CatalogID: "cat-existing",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-existing", result.CatalogID)
+	assert.Zero(t, mock.createCatalogCalls)
+	assert.Equal(t, 1, mock.createStageCalls)
+}
+
+func TestPushDirectory_ZipPathLargeTree(t *testing.T) {
+	t.Parallel()
+
+	root := writeLargeTree(t, artifactsource.StageVsZipFileThreshold+1)
+	mock := &mockFilesAPI{}
+
+	result, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-zip-new", result.CatalogID)
+	assert.Equal(t, artifactsource.StageVsZipFileThreshold+1, result.FileCount)
+	assert.Len(t, result.FileHashes, artifactsource.StageVsZipFileThreshold+1)
+	assert.Equal(t, 1, mock.uploadFromZipNewCalls)
+	assert.Zero(t, mock.createStageCalls)
+}
+
+func TestPushDirectory_ZipPathExistingCatalogPolls(t *testing.T) {
+	t.Parallel()
+
+	root := writeLargeTree(t, artifactsource.StageVsZipFileThreshold+1)
+	mock := &mockFilesAPI{catalogID: "cat-zip-existing"}
+
+	result, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{
+		Dir:       root,
+		CatalogID: "cat-zip-existing",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-zip-existing", result.CatalogID)
+	assert.Equal(t, 1, mock.uploadFromZipExistCalls)
+	assert.Equal(t, 1, mock.pollStatusCalls)
+}
+
+func TestPushDirectory_IncrementalNoChanges(t *testing.T) {
+	t.Parallel()
+
+	root := writeSmallTree(t)
+	mock := &mockFilesAPI{catalogID: "cat-existing", version: 5}
+
+	first, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.NoError(t, err)
+
+	mock2 := &mockFilesAPI{catalogID: "cat-existing", version: 5}
+	second, err := artifactsource.PushDirectory(context.Background(), mock2, artifactsource.Options{
+		Dir:              root,
+		CatalogID:        first.CatalogID,
+		CatalogVersionID: first.CatalogVersionID,
+		BaseFiles:        first.FileHashes,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.CatalogVersionID, second.CatalogVersionID)
+	assert.Equal(t, first.FileHashes, second.FileHashes)
+	assert.Zero(t, mock2.createStageCalls)
+	assert.Zero(t, mock2.deleteCalls)
+}
+
+func TestPushDirectory_IncrementalUploadsOnlyChangedFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("aaa"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("bbb"), 0o644))
+
+	mock := &mockFilesAPI{}
+	first, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("changed"), 0o644))
+
+	mock2 := &mockFilesAPI{catalogID: first.CatalogID, version: 2}
+	second, err := artifactsource.PushDirectory(context.Background(), mock2, artifactsource.Options{
+		Dir:              root,
+		CatalogID:        first.CatalogID,
+		CatalogVersionID: first.CatalogVersionID,
+		BaseFiles:        first.FileHashes,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, second.Incremental)
+	assert.Equal(t, []string{"b.txt"}, mock2.uploadToStagePaths)
+	assert.Equal(t, 1, mock2.createStageCalls)
+	assert.Zero(t, mock2.deleteCalls)
+	assert.NotEqual(t, first.SourceHash, second.SourceHash)
+	assert.NotEqual(t, first.FileHashes["b.txt"], second.FileHashes["b.txt"])
+}
+
+func TestPushDirectory_IncrementalDeletesRemovedFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("aaa"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("bbb"), 0o644))
+
+	mock := &mockFilesAPI{}
+	first, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(filepath.Join(root, "b.txt")))
+
+	mock2 := &mockFilesAPI{catalogID: first.CatalogID, version: 2}
+	second, err := artifactsource.PushDirectory(context.Background(), mock2, artifactsource.Options{
+		Dir:              root,
+		CatalogID:        first.CatalogID,
+		CatalogVersionID: first.CatalogVersionID,
+		BaseFiles:        first.FileHashes,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, second.Incremental)
+	assert.Equal(t, []string{"b.txt"}, mock2.deletePaths)
+	assert.Equal(t, 1, mock2.deleteCalls)
+	assert.Empty(t, mock2.uploadToStagePaths)
+	assert.Len(t, second.FileHashes, 1)
+}
+
+func TestPushDirectory_EmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mock := &mockFilesAPI{}
+
+	_, err := artifactsource.PushDirectory(context.Background(), mock, artifactsource.Options{Dir: root})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no uploadable files")
+}
+
+func TestPushDirectory_NilClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := artifactsource.PushDirectory(context.Background(), nil, artifactsource.Options{Dir: t.TempDir()})
+	require.Error(t, err)
+}
+
+func writeSmallTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("aaa"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("bbb"), 0o644))
+	return root
+}
+
+func writeLargeTree(t *testing.T, count int) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := 0; i < count; i++ {
+		name := filepath.Join(root, "file-"+padIndex(i)+".txt")
+		require.NoError(t, os.WriteFile(name, []byte("x"), 0o644))
+	}
+	return root
+}
+
+func padIndex(i int) string {
+	return fmt.Sprintf("%02d", i)
+}

--- a/internal/artifactsource/push_test.go
+++ b/internal/artifactsource/push_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource"
@@ -15,6 +16,8 @@ import (
 )
 
 type mockFilesAPI struct {
+	mu sync.Mutex
+
 	createCatalogCalls      int
 	createStageCalls        int
 	uploadToStagePaths      []string
@@ -46,11 +49,15 @@ func (m *mockFilesAPI) CreateStage(_ context.Context, catalogID string) (*filesa
 }
 
 func (m *mockFilesAPI) UploadToStage(_ context.Context, _, _, name string, _ int64, _ io.Reader) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.uploadToStagePaths = append(m.uploadToStagePaths, name)
 	return nil
 }
 
 func (m *mockFilesAPI) ApplyStage(_ context.Context, catalogID, _, _ string) (*filesapi.ApplyStageResp, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.applyStageCalls++
 	m.version++
 	return &filesapi.ApplyStageResp{CatalogID: catalogID, CatalogVersionID: versionID(m.version), NumFiles: len(m.uploadToStagePaths)}, nil

--- a/internal/artifactsource/stage.go
+++ b/internal/artifactsource/stage.go
@@ -1,0 +1,109 @@
+package artifactsource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+type stageUploader struct{}
+
+func (stageUploader) upload(ctx context.Context, client filesapi.Client, catalogID, overwrite string, files []LocalFile) (string, string, error) {
+	if catalogID == "" {
+		cat, err := client.CreateCatalog(ctx)
+		if err != nil {
+			return "", "", fmt.Errorf("create catalog: %w", err)
+		}
+		catalogID = cat.CatalogID
+	}
+
+	stage, err := client.CreateStage(ctx, catalogID)
+	if err != nil {
+		return "", "", fmt.Errorf("create stage: %w", err)
+	}
+
+	if err := uploadFilesParallel(ctx, client, catalogID, stage.StageID, files); err != nil {
+		return "", "", err
+	}
+
+	apply, err := client.ApplyStage(ctx, catalogID, stage.StageID, overwrite)
+	if err != nil {
+		return "", "", fmt.Errorf("apply stage: %w", err)
+	}
+
+	return catalogID, apply.CatalogVersionID, nil
+}
+
+func uploadFilesParallel(ctx context.Context, client filesapi.Client, catalogID, stageID string, files []LocalFile) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	done := make(chan struct{})
+	var cancelOnce sync.Once
+	cancel := func() { cancelOnce.Do(func() { close(done) }) }
+	defer cancel()
+
+	sem := make(chan struct{}, UploadConcurrency)
+	errCh := make(chan error, len(files))
+
+	var wg sync.WaitGroup
+
+	for _, f := range files {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+
+			if err := uploadOneToStage(ctx, client, catalogID, stageID, f); err != nil {
+				select {
+				case errCh <- err:
+					cancel()
+				default:
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return err
+		}
+	default:
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func uploadOneToStage(ctx context.Context, client filesapi.Client, catalogID, stageID string, f LocalFile) error {
+	file, err := os.Open(f.AbsPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", f.RelPath, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := client.UploadToStage(ctx, catalogID, stageID, f.RelPath, f.Size, file); err != nil {
+		return fmt.Errorf("upload %s: %w", f.RelPath, err)
+	}
+
+	return nil
+}

--- a/internal/artifactsource/stage_test.go
+++ b/internal/artifactsource/stage_test.go
@@ -69,11 +69,11 @@ func (m *stageClientMock) UploadToStage(_ context.Context, _, _, name string, _ 
 	defer m.activeUploads.Add(-1)
 
 	for {
-		max := m.maxConcurrent.Load()
-		if current <= max {
+		prevMax := m.maxConcurrent.Load()
+		if current <= prevMax {
 			break
 		}
-		if m.maxConcurrent.CompareAndSwap(max, current) {
+		if m.maxConcurrent.CompareAndSwap(prevMax, current) {
 			break
 		}
 	}
@@ -136,7 +136,7 @@ func stageVersionID(n int) string {
 	return fmt.Sprintf("ver-%d", n)
 }
 
-func writeStageTestFiles(t *testing.T, names ...string) ([]LocalFile, string) {
+func writeStageTestFiles(t *testing.T, names ...string) []LocalFile {
 	t.Helper()
 	root := t.TempDir()
 	files := make([]LocalFile, 0, len(names))
@@ -146,7 +146,7 @@ func writeStageTestFiles(t *testing.T, names ...string) ([]LocalFile, string) {
 		require.NoError(t, os.WriteFile(abs, []byte("x"), 0o644))
 		files = append(files, LocalFile{RelPath: name, AbsPath: abs, Size: 1})
 	}
-	return files, root
+	return files
 }
 
 func TestUploadFilesParallel_Empty(t *testing.T) {
@@ -161,7 +161,7 @@ func TestUploadFilesParallel_Empty(t *testing.T) {
 func TestUploadFilesParallel_AllSucceed(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "a.txt", "b.txt", "c.txt")
+	files := writeStageTestFiles(t, "a.txt", "b.txt", "c.txt")
 	mock := &stageClientMock{}
 
 	err := uploadFilesParallel(context.Background(), mock, "cat", "stage", files)
@@ -172,7 +172,7 @@ func TestUploadFilesParallel_AllSucceed(t *testing.T) {
 func TestUploadFilesParallel_OneUploadFails(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "ok.txt", "bad.txt", "also-ok.txt")
+	files := writeStageTestFiles(t, "ok.txt", "bad.txt", "also-ok.txt")
 	wantErr := errors.New("upload failed")
 	mock := &stageClientMock{
 		uploadErrForPath: map[string]error{"bad.txt": wantErr},
@@ -187,7 +187,7 @@ func TestUploadFilesParallel_OneUploadFails(t *testing.T) {
 func TestUploadFilesParallel_ContextCancelled(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "slow-1.txt", "slow-2.txt", "slow-3.txt", "slow-4.txt", "slow-5.txt")
+	files := writeStageTestFiles(t, "slow-1.txt", "slow-2.txt", "slow-3.txt", "slow-4.txt", "slow-5.txt")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -210,7 +210,7 @@ func TestUploadFilesParallel_RespectsConcurrencyLimit(t *testing.T) {
 	for i := range names {
 		names[i] = fmt.Sprintf("file-%02d.txt", i)
 	}
-	files, _ := writeStageTestFiles(t, names...)
+	files := writeStageTestFiles(t, names...)
 
 	started := make(chan struct{}, len(files))
 	release := make(chan struct{})
@@ -249,7 +249,7 @@ func TestUploadFilesParallel_RespectsConcurrencyLimit(t *testing.T) {
 func TestStageUploader_CreatesCatalogAndAppliesStage(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "only.txt")
+	files := writeStageTestFiles(t, "only.txt")
 	mock := &stageClientMock{}
 	up := stageUploader{}
 
@@ -267,7 +267,7 @@ func TestStageUploader_CreatesCatalogAndAppliesStage(t *testing.T) {
 func TestStageUploader_ExistingCatalogSkipsCreate(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "only.txt")
+	files := writeStageTestFiles(t, "only.txt")
 	mock := &stageClientMock{catalogID: "cat-existing"}
 	up := stageUploader{}
 
@@ -282,7 +282,7 @@ func TestStageUploader_ExistingCatalogSkipsCreate(t *testing.T) {
 func TestStageUploader_CreateCatalogFails(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "only.txt")
+	files := writeStageTestFiles(t, "only.txt")
 	mock := &stageClientMock{createCatalogErr: errors.New("create catalog failed")}
 	up := stageUploader{}
 
@@ -295,7 +295,7 @@ func TestStageUploader_CreateCatalogFails(t *testing.T) {
 func TestStageUploader_CreateStageFails(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "only.txt")
+	files := writeStageTestFiles(t, "only.txt")
 	mock := &stageClientMock{
 		catalogID:      "cat-existing",
 		createStageErr: errors.New("create stage failed"),
@@ -311,7 +311,7 @@ func TestStageUploader_CreateStageFails(t *testing.T) {
 func TestStageUploader_ParallelUploadFailsBeforeApply(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "good.txt", "bad.txt")
+	files := writeStageTestFiles(t, "good.txt", "bad.txt")
 	mock := &stageClientMock{
 		catalogID:        "cat-existing",
 		uploadErrForPath: map[string]error{"bad.txt": errors.New("stage upload failed")},
@@ -327,7 +327,7 @@ func TestStageUploader_ParallelUploadFailsBeforeApply(t *testing.T) {
 func TestStageUploader_ApplyStageFailsAfterUploads(t *testing.T) {
 	t.Parallel()
 
-	files, _ := writeStageTestFiles(t, "a.txt", "b.txt")
+	files := writeStageTestFiles(t, "a.txt", "b.txt")
 	mock := &stageClientMock{
 		catalogID:     "cat-existing",
 		applyStageErr: errors.New("apply stage failed"),

--- a/internal/artifactsource/stage_test.go
+++ b/internal/artifactsource/stage_test.go
@@ -1,0 +1,342 @@
+package artifactsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stageClientMock struct {
+	mu sync.Mutex
+
+	createCatalogCalls int
+	createStageCalls   int
+	applyStageCalls    int
+	uploadPaths        []string
+
+	createCatalogErr error
+	createStageErr   error
+	applyStageErr    error
+	uploadErrForPath map[string]error
+	uploadHook       func(name string) error
+
+	activeUploads atomic.Int32
+	maxConcurrent atomic.Int32
+
+	catalogID string
+	stageID   string
+	version   int
+}
+
+func (m *stageClientMock) CreateCatalog(context.Context) (*filesapi.CatalogResp, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createCatalogCalls++
+	if m.createCatalogErr != nil {
+		return nil, m.createCatalogErr
+	}
+	if m.catalogID == "" {
+		m.catalogID = "cat-test"
+	}
+	m.version++
+	return &filesapi.CatalogResp{CatalogID: m.catalogID, CatalogVersionID: stageVersionID(m.version)}, nil
+}
+
+func (m *stageClientMock) CreateStage(_ context.Context, catalogID string) (*filesapi.StageResp, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createStageCalls++
+	if m.createStageErr != nil {
+		return nil, m.createStageErr
+	}
+	m.stageID = "stage-test"
+	return &filesapi.StageResp{CatalogID: catalogID, StageID: m.stageID}, nil
+}
+
+func (m *stageClientMock) UploadToStage(_ context.Context, _, _, name string, _ int64, _ io.Reader) error {
+	current := m.activeUploads.Add(1)
+	defer m.activeUploads.Add(-1)
+
+	for {
+		max := m.maxConcurrent.Load()
+		if current <= max {
+			break
+		}
+		if m.maxConcurrent.CompareAndSwap(max, current) {
+			break
+		}
+	}
+
+	if m.uploadHook != nil {
+		if err := m.uploadHook(name); err != nil {
+			return err
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.uploadErrForPath[name]; ok {
+		return err
+	}
+	m.uploadPaths = append(m.uploadPaths, name)
+	return nil
+}
+
+func (m *stageClientMock) ApplyStage(_ context.Context, catalogID, _, _ string) (*filesapi.ApplyStageResp, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applyStageCalls++
+	if m.applyStageErr != nil {
+		return nil, m.applyStageErr
+	}
+	m.version++
+	return &filesapi.ApplyStageResp{CatalogID: catalogID, CatalogVersionID: stageVersionID(m.version)}, nil
+}
+
+func (m *stageClientMock) UploadFromZipNew(context.Context, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) UploadFromZipExisting(context.Context, string, string, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) PollStatus(context.Context, string) (*filesapi.StatusResp, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) AllFiles(context.Context, string, string) (map[string]filesapi.FileMeta, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) DownloadFile(context.Context, string, string, string, io.Writer) (string, int64, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) DeleteFiles(context.Context, string, []string) (*filesapi.DeleteFilesResp, error) {
+	panic("not used in stage tests")
+}
+
+func (m *stageClientMock) ListVersions(context.Context, string, int) ([]filesapi.CatalogVersion, error) {
+	panic("not used in stage tests")
+}
+
+func stageVersionID(n int) string {
+	return fmt.Sprintf("ver-%d", n)
+}
+
+func writeStageTestFiles(t *testing.T, names ...string) ([]LocalFile, string) {
+	t.Helper()
+	root := t.TempDir()
+	files := make([]LocalFile, 0, len(names))
+	for _, name := range names {
+		abs := filepath.Join(root, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte("x"), 0o644))
+		files = append(files, LocalFile{RelPath: name, AbsPath: abs, Size: 1})
+	}
+	return files, root
+}
+
+func TestUploadFilesParallel_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock := &stageClientMock{}
+	err := uploadFilesParallel(context.Background(), mock, "cat", "stage", nil)
+	require.NoError(t, err)
+	assert.Empty(t, mock.uploadPaths)
+}
+
+func TestUploadFilesParallel_AllSucceed(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "a.txt", "b.txt", "c.txt")
+	mock := &stageClientMock{}
+
+	err := uploadFilesParallel(context.Background(), mock, "cat", "stage", files)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt", "c.txt"}, mock.uploadPaths)
+}
+
+func TestUploadFilesParallel_OneUploadFails(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "ok.txt", "bad.txt", "also-ok.txt")
+	wantErr := errors.New("upload failed")
+	mock := &stageClientMock{
+		uploadErrForPath: map[string]error{"bad.txt": wantErr},
+	}
+
+	err := uploadFilesParallel(context.Background(), mock, "cat", "stage", files)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "bad.txt")
+}
+
+func TestUploadFilesParallel_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "slow-1.txt", "slow-2.txt", "slow-3.txt", "slow-4.txt", "slow-5.txt")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mock := &stageClientMock{
+		uploadHook: func(string) error {
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		},
+	}
+
+	err := uploadFilesParallel(ctx, mock, "cat", "stage", files)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestUploadFilesParallel_RespectsConcurrencyLimit(t *testing.T) {
+	t.Parallel()
+
+	names := make([]string, UploadConcurrency+2)
+	for i := range names {
+		names[i] = fmt.Sprintf("file-%02d.txt", i)
+	}
+	files, _ := writeStageTestFiles(t, names...)
+
+	started := make(chan struct{}, len(files))
+	release := make(chan struct{})
+	mock := &stageClientMock{
+		uploadHook: func(string) error {
+			started <- struct{}{}
+			<-release
+			return nil
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- uploadFilesParallel(context.Background(), mock, "cat", "stage", files)
+	}()
+
+	for range UploadConcurrency {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent uploads to start")
+		}
+	}
+
+	select {
+	case <-started:
+		t.Fatalf("expected at most %d concurrent uploads", UploadConcurrency)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-errCh)
+	assert.Len(t, mock.uploadPaths, len(files))
+}
+
+func TestStageUploader_CreatesCatalogAndAppliesStage(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "only.txt")
+	mock := &stageClientMock{}
+	up := stageUploader{}
+
+	catalogID, versionID, err := up.upload(context.Background(), mock, "", filesapi.OverwriteReplace, files)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-test", catalogID)
+	assert.Equal(t, "ver-2", versionID)
+	assert.Equal(t, 1, mock.createCatalogCalls)
+	assert.Equal(t, 1, mock.createStageCalls)
+	assert.Equal(t, 1, mock.applyStageCalls)
+	assert.Equal(t, []string{"only.txt"}, mock.uploadPaths)
+}
+
+func TestStageUploader_ExistingCatalogSkipsCreate(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "only.txt")
+	mock := &stageClientMock{catalogID: "cat-existing"}
+	up := stageUploader{}
+
+	catalogID, _, err := up.upload(context.Background(), mock, "cat-existing", filesapi.OverwriteReplace, files)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat-existing", catalogID)
+	assert.Zero(t, mock.createCatalogCalls)
+	assert.Equal(t, 1, mock.createStageCalls)
+}
+
+func TestStageUploader_CreateCatalogFails(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "only.txt")
+	mock := &stageClientMock{createCatalogErr: errors.New("create catalog failed")}
+	up := stageUploader{}
+
+	_, _, err := up.upload(context.Background(), mock, "", filesapi.OverwriteReplace, files)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create catalog")
+	assert.Zero(t, mock.createStageCalls)
+}
+
+func TestStageUploader_CreateStageFails(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "only.txt")
+	mock := &stageClientMock{
+		catalogID:      "cat-existing",
+		createStageErr: errors.New("create stage failed"),
+	}
+	up := stageUploader{}
+
+	_, _, err := up.upload(context.Background(), mock, "cat-existing", filesapi.OverwriteReplace, files)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create stage")
+	assert.Zero(t, mock.applyStageCalls)
+}
+
+func TestStageUploader_ParallelUploadFailsBeforeApply(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "good.txt", "bad.txt")
+	mock := &stageClientMock{
+		catalogID:        "cat-existing",
+		uploadErrForPath: map[string]error{"bad.txt": errors.New("stage upload failed")},
+	}
+	up := stageUploader{}
+
+	_, _, err := up.upload(context.Background(), mock, "cat-existing", filesapi.OverwriteReplace, files)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad.txt")
+	assert.Zero(t, mock.applyStageCalls)
+}
+
+func TestStageUploader_ApplyStageFailsAfterUploads(t *testing.T) {
+	t.Parallel()
+
+	files, _ := writeStageTestFiles(t, "a.txt", "b.txt")
+	mock := &stageClientMock{
+		catalogID:     "cat-existing",
+		applyStageErr: errors.New("apply stage failed"),
+	}
+	up := stageUploader{}
+
+	_, _, err := up.upload(context.Background(), mock, "cat-existing", filesapi.OverwriteReplace, files)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apply stage")
+	assert.Equal(t, 1, mock.applyStageCalls)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt"}, mock.uploadPaths)
+}

--- a/internal/artifactsource/sync.go
+++ b/internal/artifactsource/sync.go
@@ -1,0 +1,42 @@
+package artifactsource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+func applyIncrementalPush(
+	ctx context.Context,
+	client filesapi.Client,
+	catalogID, overwrite string,
+	plan *PushPlan,
+	byPath map[string]LocalFile,
+) (string, string, error) {
+	versionID := ""
+
+	if len(plan.Deletes) > 0 {
+		resp, err := client.DeleteFiles(ctx, catalogID, plan.Deletes)
+		if err != nil {
+			return "", "", fmt.Errorf("delete remote files: %w", err)
+		}
+		if resp != nil && resp.CatalogVersionID != "" {
+			versionID = resp.CatalogVersionID
+		}
+	}
+
+	if len(plan.Uploads) == 0 {
+		return catalogID, versionID, nil
+	}
+
+	uploadFiles := localFilesForPaths(byPath, plan.Uploads)
+	up := chooseUploader(uploadFiles)
+
+	catalogIDOut, versionIDOut, err := up.upload(ctx, client, catalogID, overwrite, uploadFiles)
+	if err != nil {
+		return "", "", err
+	}
+
+	return catalogIDOut, versionIDOut, nil
+}

--- a/internal/artifactsource/types.go
+++ b/internal/artifactsource/types.go
@@ -1,0 +1,34 @@
+package artifactsource
+
+// IgnoreFunc reports whether a normalized relative path should be excluded.
+// Directories are queried so subtrees can be pruned at the root.
+type IgnoreFunc func(relPath string, isDir bool) bool
+
+// LocalFile is a regular file discovered under the push root.
+type LocalFile struct {
+	RelPath string
+	AbsPath string
+	Size    int64
+	Hash    string // SHA-256 hex of file contents
+}
+
+// Options configure a PushDirectory call.
+type Options struct {
+	// Dir is the local directory to upload (absolute or relative).
+	Dir string
+	// CatalogID is an optional existing catalog; empty creates a new catalog on first push.
+	CatalogID string
+	// Overwrite is the Files API overwrite mode; defaults to REPLACE when empty.
+	Overwrite string
+	// Ignore optionally excludes paths; nil uploads all regular files.
+	Ignore IgnoreFunc
+}
+
+// Result is returned after a successful PushDirectory.
+type Result struct {
+	CatalogID        string
+	CatalogVersionID string
+	SourceHash       string
+	FileCount        int
+	TotalBytes       int64
+}

--- a/internal/artifactsource/types.go
+++ b/internal/artifactsource/types.go
@@ -18,6 +18,13 @@ type Options struct {
 	Dir string
 	// CatalogID is an optional existing catalog; empty creates a new catalog on first push.
 	CatalogID string
+	// CatalogVersionID is the catalog version from the last successful push.
+	// When set together with BaseFiles and the tree is unchanged, no API upload runs.
+	CatalogVersionID string
+	// BaseFiles is the per-file manifest from Terraform state after the last
+	// successful push. When set with CatalogID, only added/modified/deleted
+	// files are uploaded or removed remotely.
+	BaseFiles Manifest
 	// Overwrite is the Files API overwrite mode; defaults to REPLACE when empty.
 	Overwrite string
 	// Ignore optionally excludes paths; nil uploads all regular files.
@@ -29,6 +36,10 @@ type Result struct {
 	CatalogID        string
 	CatalogVersionID string
 	SourceHash       string
+	FileHashes       Manifest
 	FileCount        int
 	TotalBytes       int64
+	// Incremental is true when the push updated an existing catalog using
+	// BaseFiles rather than uploading the full tree.
+	Incremental bool
 }

--- a/internal/artifactsource/uploader.go
+++ b/internal/artifactsource/uploader.go
@@ -1,0 +1,28 @@
+package artifactsource
+
+import (
+	"context"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+type uploader interface {
+	upload(ctx context.Context, client filesapi.Client, catalogID, overwrite string, files []LocalFile) (catalogIDOut, versionID string, err error)
+}
+
+func chooseUploader(files []LocalFile) uploader {
+	if len(files) == 0 {
+		return stageUploader{}
+	}
+
+	var totalBytes int64
+	for _, f := range files {
+		totalBytes += f.Size
+	}
+
+	if len(files) <= StageVsZipFileThreshold && totalBytes <= StageVsZipBytesThreshold {
+		return stageUploader{}
+	}
+
+	return zipUploader{}
+}

--- a/internal/artifactsource/walk.go
+++ b/internal/artifactsource/walk.go
@@ -1,0 +1,100 @@
+package artifactsource
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+type walkEntry struct {
+	AbsPath string
+	RelPath string
+	Size    int64
+}
+
+// walkDirectory enumerates regular files under root. Symlinks are skipped.
+// Ignored directories are pruned. Returned entries are sorted by RelPath.
+func walkDirectory(root string, ignore IgnoreFunc) ([]walkEntry, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("abs %s: %w", root, err)
+	}
+
+	var entries []walkEntry
+
+	visit := func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk %s: %w", path, walkErr)
+		}
+
+		if path == absRoot {
+			return nil
+		}
+
+		rel, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return fmt.Errorf("relativize %s under %s: %w", path, absRoot, err)
+		}
+
+		normRel := filesapi.NormalizePath(rel)
+
+		switch {
+		case d.Type()&os.ModeSymlink != 0:
+			return nil
+		case d.IsDir():
+			if ignore != nil && ignore(normRel, true) {
+				return filepath.SkipDir
+			}
+			return nil
+		case !d.Type().IsRegular():
+			return nil
+		}
+
+		if ignore != nil && ignore(normRel, false) {
+			return nil
+		}
+
+		fi, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("info %s: %w", path, err)
+		}
+
+		entries = append(entries, walkEntry{
+			AbsPath: path,
+			RelPath: normRel,
+			Size:    fi.Size(),
+		})
+
+		return nil
+	}
+
+	if err := filepath.WalkDir(absRoot, visit); err != nil {
+		return nil, err
+	}
+
+	sortWalkEntries(entries)
+
+	return entries, nil
+}
+
+func sortWalkEntries(entries []walkEntry) {
+	// insertion sort is fine for typical tree sizes; keeps deps minimal
+	for i := 1; i < len(entries); i++ {
+		j := i
+		for j > 0 && entries[j-1].RelPath > entries[j].RelPath {
+			entries[j-1], entries[j] = entries[j], entries[j-1]
+			j--
+		}
+	}
+}

--- a/internal/artifactsource/walk_test.go
+++ b/internal/artifactsource/walk_test.go
@@ -1,0 +1,77 @@
+package artifactsource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkDirectory_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "real.txt"), []byte("ok"), 0o644))
+
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(root, "link.txt")))
+
+	entries, err := walkDirectory(root, nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "real.txt", entries[0].RelPath)
+}
+
+func TestWalkDirectory_IgnorePrunesDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "skip"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skip", "hidden.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("y"), 0o644))
+
+	ignore := func(rel string, isDir bool) bool {
+		return rel == "skip" && isDir
+	}
+
+	entries, err := walkDirectory(root, ignore)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "keep.txt", entries[0].RelPath)
+}
+
+func TestWalkDirectory_NormalizesPaths(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "file.txt"), []byte("z"), 0o644))
+
+	entries, err := walkDirectory(root, nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "a/b/file.txt", entries[0].RelPath)
+}
+
+func TestWalkDirectory_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entries, err := walkDirectory(root, nil)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestWalkDirectory_NotADirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	_, err := walkDirectory(file, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}

--- a/internal/artifactsource/zip.go
+++ b/internal/artifactsource/zip.go
@@ -1,0 +1,60 @@
+package artifactsource
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+)
+
+// buildZip writes a zip archive of files to a temp file on disk.
+func buildZip(files []LocalFile) (string, error) {
+	tmp, err := os.CreateTemp("", "artifact-push-*.zip")
+	if err != nil {
+		return "", fmt.Errorf("create zip tempfile: %w", err)
+	}
+
+	defer func() { _ = tmp.Close() }()
+
+	zw := zip.NewWriter(tmp)
+
+	for _, f := range files {
+		if err := addToZip(zw, f.AbsPath, f.RelPath); err != nil {
+			_ = os.Remove(tmp.Name())
+			return "", err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("close zip writer: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("close zip tempfile: %w", err)
+	}
+
+	return tmp.Name(), nil
+}
+
+func addToZip(zw *zip.Writer, src, archivePath string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s for zip: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	hdr := &zip.FileHeader{Name: archivePath, Method: zip.Deflate}
+
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("zip header for %s: %w", archivePath, err)
+	}
+
+	if _, err := io.Copy(w, in); err != nil {
+		return fmt.Errorf("copy %s into zip: %w", archivePath, err)
+	}
+
+	return nil
+}

--- a/internal/artifactsource/zip_test.go
+++ b/internal/artifactsource/zip_test.go
@@ -1,0 +1,64 @@
+package artifactsource
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildZip_EntryNamesAndDeflate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.py"), []byte("print(1)"), 0o644))
+	sub := filepath.Join(root, "lib")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "util.py"), []byte("pass"), 0o644))
+
+	files := []LocalFile{
+		{RelPath: "main.py", AbsPath: filepath.Join(root, "main.py")},
+		{RelPath: "lib/util.py", AbsPath: filepath.Join(root, "lib", "util.py")},
+	}
+
+	zipPath, err := buildZip(files)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(zipPath) }()
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 2)
+	assert.Equal(t, "main.py", r.File[0].Name)
+	assert.Equal(t, zip.Deflate, r.File[0].Method)
+	assert.Equal(t, "lib/util.py", r.File[1].Name)
+	assert.Equal(t, zip.Deflate, r.File[1].Method)
+
+	for _, name := range []string{r.File[0].Name, r.File[1].Name} {
+		assert.NotContains(t, name, root)
+		assert.False(t, filepath.IsAbs(name))
+	}
+}
+
+func TestBuildZip_NoExtraRootDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "only.txt"), []byte("x"), 0o644))
+
+	files := []LocalFile{{RelPath: "only.txt", AbsPath: filepath.Join(root, "only.txt")}}
+	zipPath, err := buildZip(files)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(zipPath) }()
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "only.txt", r.File[0].Name)
+}

--- a/internal/artifactsource/zip_upload.go
+++ b/internal/artifactsource/zip_upload.go
@@ -1,0 +1,81 @@
+package artifactsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+type zipUploader struct{}
+
+func (zipUploader) upload(ctx context.Context, client filesapi.Client, catalogID, overwrite string, files []LocalFile) (string, string, error) {
+	zipPath, err := buildZip(files)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = os.Remove(zipPath) }()
+
+	zipFile, err := os.Open(zipPath)
+	if err != nil {
+		return "", "", fmt.Errorf("open built zip: %w", err)
+	}
+	defer func() { _ = zipFile.Close() }()
+
+	stat, err := zipFile.Stat()
+	if err != nil {
+		return "", "", fmt.Errorf("stat built zip: %w", err)
+	}
+
+	var resp *filesapi.FromFileResp
+
+	if catalogID != "" {
+		resp, err = client.UploadFromZipExisting(ctx, catalogID, "artifact-push.zip", overwrite, stat.Size(), zipFile)
+	} else {
+		resp, err = client.UploadFromZipNew(ctx, "artifact-push.zip", stat.Size(), zipFile)
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("upload zip: %w", err)
+	}
+
+	if resp.StatusID != "" {
+		if err := waitForCompletion(ctx, client, resp.StatusID); err != nil {
+			return "", "", err
+		}
+	}
+
+	return resp.CatalogID, resp.CatalogVersionID, nil
+}
+
+func waitForCompletion(ctx context.Context, client filesapi.Client, statusID string) error {
+	deadline := time.Now().Add(filesapi.ZipPollTimeout)
+	ticker := time.NewTicker(filesapi.ZipPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if time.Now().After(deadline) {
+			return errors.New("timeout waiting for archive extract")
+		}
+
+		resp, err := client.PollStatus(ctx, statusID)
+		if err != nil {
+			return fmt.Errorf("poll status %s: %w", statusID, err)
+		}
+
+		if filesapi.IsTerminalStatus(resp.Status) {
+			if filesapi.IsErrorStatus(resp.Status) {
+				return fmt.Errorf("zip extraction failed: %s (%s)", resp.Status, resp.Message)
+			}
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/artifactsource`, a push-only directory upload orchestration layer over the Files API client from PR #334. `PushDirectory` walks a local directory, hashes files, routes uploads through the stage or zip path based on size thresholds, and supports incremental sync when Terraform state already holds a catalog manifest.

This is foundation work for upcoming `datarobot_artifact` `source { dir }` support (local directory → catalog upload → `code_ref` patch). No Terraform schema or resource wiring yet.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact

**No user-facing Terraform changes yet.** Provider behavior is unchanged for end users.

Internal additions in `internal/artifactsource`:

- **`PushDirectory`** — main entry point: walk → hash → upload → return catalog IDs + per-file manifest for Terraform state
- **Directory walk** — regular files only; skips symlinks and directories; optional `IgnoreFunc`; normalizes relative paths via `filesapi.SafeRelPath`
- **Upload routing** — stage path when ≤20 files and ≤50 MiB total; otherwise zip/fromFile with async status polling
- **Parallel stage uploads** — up to 4 concurrent `UploadToStage` calls with fail-fast cancellation
- **Incremental push** — when `CatalogID` + `BaseFiles` (previous manifest from state) are set, diffs local vs remote and uploads only added/modified files, deletes removed paths first
- **Change detection** — per-file SHA-256 hashes + directory fingerprint (`directoryFingerprint`) for no-op detection when the tree is unchanged
- **Limits** — tunables ported from `cli/internal/workload/sync/limits.go`

**Out of scope for this PR:** Terraform `source { dir }` schema on `datarobot_artifact`, `PatchArtifactCodeRef` wiring, live Files API acceptance tests.

## CHANGELOG
- [] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)

If skipped, justify here: N/A — entry added for the new internal `artifactsource` package.

## Testing

**Unit tests (mock HTTP via gomock Files API client, no real API):**

```bash
cd terraform-provider-datarobot
GOPROXY=https://proxy.golang.org,direct go test ./internal/artifactsource/... -count=1 -v
```

37 tests across 8 files covering:

| Area | Tests |
|------|-------|
| `walk.go` | symlink skip, ignore func, path normalization, empty dir |
| `hash.go` / `fingerprint.go` | file hashing, directory fingerprint, unambiguous path+hash separator |
| `diff.go` / `manifest.go` | push-only diff (uploads + deletes), manifest from files |
| `stage.go` | parallel upload, concurrency limits, failure propagation |
| `zip.go` / `zip_upload.go` | zip build with relative paths, async poll until terminal status |
| `push.go` | full push, incremental push, no-op when unchanged, error cases |

**CI-equivalent checks:**

```bash
GOPROXY=https://proxy.golang.org,direct go build -v .
make lint
go generate ./... && git diff --compact-summary --exit-code
GOPROXY=https://proxy.golang.org,direct go test ./internal/artifactsource/... ./internal/client/filesapi/... -count=1
```

**Not included:** Live Files API integration / acceptance tests (deferred to the `source { dir }` resource wiring PR).

## Release Preparation Checklist
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [x] Version impact considered (patch / minor / major) — **none for users**; internal-only until `source { dir }` lands

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes

**Stacked PR:** merge into `brunoromano-dr/RAPTOR-18360-artifact-code-source-dir-files-api-client` (PR #334), not `main`. This branch adds 21 commits on top of the Files API client.

**Architecture (review order):**
1. `types.go` + `limits.go` — options, result, tunables
2. `walk.go` + `hash.go` — local file discovery and hashing
3. `manifest.go` + `fingerprint.go` + `diff.go` — state manifest and incremental plan
4. `uploader.go` — stage vs zip routing
5. `stage.go` + `zip.go` + `zip_upload.go` — upload implementations
6. `sync.go` + `push.go` — incremental apply and public API

**CLI parity:** Upload thresholds and concurrency limits ported from `cli/internal/workload/sync/limits.go`; orchestration logic adapted from DR CLI workload sync patterns.

**Follow-up:** Wire `source { dir }` on `datarobot_artifact` — call `PushDirectory`, persist manifest in state, patch primary-container `code_ref`; add one E2E acceptance test at that point.

**Ticket:** RAPTOR-18360

<!-- rr:slack:start -->
<!-- rr:slack:C053QK4M33R:1784825634.690209 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only code with no provider resource wiring; behavior is covered by extensive unit tests and does not change end-user Terraform until a follow-up PR.
> 
> **Overview**
> Adds **`internal/artifactsource`**, an internal library (no Terraform schema yet) that will back upcoming `datarobot_artifact` **`source { dir }`** support. **`PushDirectory`** walks a local tree, SHA-256-hashes files, and uploads to the Files API catalog via **staged uploads** (≤20 files and ≤50 MiB) or **zip/fromFile** with async polling for larger sets.
> 
> When **`CatalogID`** and **`BaseFiles`** (last manifest from state) are present, **`DiffPushOnly`** drives **incremental** sync: remote deletes for removed paths, uploads only for added/changed files, and **no API calls** if the tree is unchanged. Results expose catalog IDs, per-file manifest, and a directory fingerprint for state.
> 
> **CHANGELOG** documents the new package alongside the existing `filesapi` client entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d36645848e229f66b133707bdd79b81c700892b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->