### PR TITLE
Add notifyOnFailure variable to control Slack notifications in pipelines

### DIFF
--- a/.harness/acceptnce_pipeline.yml
+++ b/.harness/acceptnce_pipeline.yml
@@ -72,24 +72,6 @@ pipeline:
                       limits:
                         memory: 4Gi
                         cpu: "6"
-              - step:
-                  name: Notify dsx-alerts
-                  identifier: Notify_dsxalerts
-                  template:
-                    templateRef: org.Send_Slack_notification
-                    versionLabel: v1
-                    templateInputs:
-                      type: Run
-                      spec:
-                        envVariables:
-                          SLACK_CHANNEL: dsx-alerts
-                          SLACK_URL: <+input>.default("")
-                          MESSAGE_TYPE: Error
-                          MESSAGE_TITLE: Declarative API Terraform Tests Failed
-                          MESSAGE_TEXT: "@here Check the pipeline logs to see more details..."
-                          MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
-                  when:
-                    stageStatus: Failure
           caching:
             enabled: false
             paths: []
@@ -206,6 +188,9 @@ pipeline:
                 type: Secret
                 default: dr_staging_api_key
                 value: <+input>.default(dr_staging_api_key).allowedValues(dr_staging_api_key,dr_app_charts_r10p2_api_key,dr_private_ca_api_key)
+              - name: notifyOnFailure
+                type: String
+                value: "false"
   variables:
     - name: endpoint
       type: String

--- a/.harness/full_suite_pipeline.yml
+++ b/.harness/full_suite_pipeline.yml
@@ -90,6 +90,7 @@ pipeline:
                               MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
                       when:
                         stageStatus: Failure
+                        condition: <+pipeline.variables.notifyOnFailure> == "true"
               caching:
                 enabled: false
               buildIntelligence:
@@ -161,6 +162,7 @@ pipeline:
                               MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
                       when:
                         stageStatus: Failure
+                        condition: <+pipeline.variables.notifyOnFailure> == "true"
               caching:
                 enabled: false
               buildIntelligence:
@@ -232,6 +234,7 @@ pipeline:
                               MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
                       when:
                         stageStatus: Failure
+                        condition: <+pipeline.variables.notifyOnFailure> == "true"
               caching:
                 enabled: false
               buildIntelligence:
@@ -303,6 +306,7 @@ pipeline:
                               MESSAGE_DETAILS_FILENAME: <+input>.default(./SLACK_MESSAGE.md)
                       when:
                         stageStatus: Failure
+                        condition: <+pipeline.variables.notifyOnFailure> == "true"
               caching:
                 enabled: false
               buildIntelligence:
@@ -320,3 +324,8 @@ pipeline:
       description: ""
       required: false
       value: <+input>.default(dr_staging_api_key).allowedValues(dr_staging_api_key,dr_app_charts_r10p2_api_key,dr_private_ca_api_key)
+    - name: notifyOnFailure
+      type: String
+      description: Set to false to suppress Slack notifications when run as the PR pipelines child.
+      required: false
+      value: <+input>.default("true")


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary
Describe what this PR changes and why.

## Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
Explain user-visible effects (provider behavior, new resources/data sources, breaking changes, deprecations).

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [ ] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here:

## Testing
Describe test coverage or add instructions.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
Anything else reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness CI YAML only; no provider runtime or release behavior changes.
> 
> **Overview**
> Introduces a **`notifyOnFailure`** pipeline variable so Harness can turn off **dsx-alerts** Slack posts when the full acceptance suite is run as a **PR child pipeline**, while keeping alerts on for standalone full-suite runs (default **`true`**).
> 
> The PR pipeline **drops** its own failure Slack step on the selective Tests stage and passes **`notifyOnFailure: "false"`** into the nested full-suite run. Each full-suite notify step now runs only on stage failure **and** when **`notifyOnFailure`** is **`true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bbe7587f7d497798c20ea83e36220b3e0d1e12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->