### PR TITLE
Evaluate feature flags via the entitlements API

### DIFF
--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -1105,11 +1105,21 @@ func (s *ServiceImpl) GetUserInfo(ctx context.Context) (*UserInfo, error) {
 }
 
 func (s *ServiceImpl) IsFeatureFlagEnabled(ctx context.Context, flagName string) (bool, error) {
-	userInfo, err := s.GetUserInfo(ctx)
+	// Evaluate through the entitlements API: it resolves the effective value
+	// (user, group, and organization level), whereas /account/info/ only
+	// carries flags set directly on the user record.
+	resp, err := Post[EvaluateEntitlementsResponse](s.client, ctx, "/entitlements/evaluate/", &EvaluateEntitlementsRequest{
+		Entitlements: []Entitlement{{Name: flagName}},
+	})
 	if err != nil {
-		return false, fmt.Errorf("failed to fetch user info for feature flag %q: %w", flagName, err)
+		return false, fmt.Errorf("failed to evaluate feature flag %q: %w", flagName, err)
 	}
-	return userInfo.Permissions[flagName], nil
+	for _, entitlement := range resp.Entitlements {
+		if entitlement.Name == flagName {
+			return entitlement.Value, nil
+		}
+	}
+	return false, fmt.Errorf("feature flag %q missing from entitlements evaluation response", flagName)
 }
 
 // User MCP Tool Metadata Service Implementation.

--- a/internal/client/user_service.go
+++ b/internal/client/user_service.go
@@ -9,3 +9,20 @@ type UserInfo struct {
 	TenantID    string          `json:"tenantId"`
 	Permissions map[string]bool `json:"permissions"`
 }
+
+type Entitlement struct {
+	Name string `json:"name"`
+}
+
+type EntitlementEvaluation struct {
+	Name  string `json:"name"`
+	Value bool   `json:"value"`
+}
+
+type EvaluateEntitlementsRequest struct {
+	Entitlements []Entitlement `json:"entitlements"`
+}
+
+type EvaluateEntitlementsResponse struct {
+	Entitlements []EntitlementEvaluation `json:"entitlements"`
+}

--- a/internal/client/user_service_test.go
+++ b/internal/client/user_service_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newEntitlementsTestService(t *testing.T, handler http.HandlerFunc) (Service, func()) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	cfg := NewConfiguration("fake-token")
+	cfg.Endpoint = server.URL
+	return NewService(NewClient(cfg)), server.Close
+}
+
+func TestIsFeatureFlagEnabledEvaluatesEntitlements(t *testing.T) {
+	svc, closeServer := newEntitlementsTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/entitlements/evaluate/" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		var req EvaluateEntitlementsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if len(req.Entitlements) != 1 || req.Entitlements[0].Name != "ENABLE_AGENTIC_MEMORY_API" {
+			t.Fatalf("unexpected request entitlements: %+v", req.Entitlements)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EvaluateEntitlementsResponse{
+			Entitlements: []EntitlementEvaluation{
+				{Name: "ENABLE_AGENTIC_MEMORY_API", Value: true},
+			},
+		})
+	})
+	defer closeServer()
+
+	enabled, err := svc.IsFeatureFlagEnabled(context.Background(), "ENABLE_AGENTIC_MEMORY_API")
+	if err != nil {
+		t.Fatalf("IsFeatureFlagEnabled returned error: %v", err)
+	}
+	if !enabled {
+		t.Error("expected flag to be enabled")
+	}
+}
+
+func TestIsFeatureFlagEnabledDisabledFlag(t *testing.T) {
+	svc, closeServer := newEntitlementsTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EvaluateEntitlementsResponse{
+			Entitlements: []EntitlementEvaluation{
+				{Name: "SOME_FLAG", Value: false},
+			},
+		})
+	})
+	defer closeServer()
+
+	enabled, err := svc.IsFeatureFlagEnabled(context.Background(), "SOME_FLAG")
+	if err != nil {
+		t.Fatalf("IsFeatureFlagEnabled returned error: %v", err)
+	}
+	if enabled {
+		t.Error("expected flag to be disabled")
+	}
+}
+
+func TestIsFeatureFlagEnabledMissingFromResponse(t *testing.T) {
+	svc, closeServer := newEntitlementsTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EvaluateEntitlementsResponse{})
+	})
+	defer closeServer()
+
+	if _, err := svc.IsFeatureFlagEnabled(context.Background(), "SOME_FLAG"); err == nil {
+		t.Error("expected error when flag is missing from the response")
+	}
+}


### PR DESCRIPTION
## Problem

`IsFeatureFlagEnabled` reads the `permissions` map from `GET /api/v2/account/info/`. That endpoint only returns flags set explicitly on the user record; flags inherited from the user's organization or groups are absent from the map. In Go a missing map key reads as `false`, so the provider reports such flags as disabled even though the feature is effectively enabled and the underlying API calls would succeed.

Concrete case: creating a `datarobot_memory_space` with a user whose `ENABLE_AGENTIC_MEMORY_API` flag comes from its organization fails with:

```
error: Feature not enabled: The ENABLE_AGENTIC_MEMORY_API feature flag is not enabled.
```

while `POST /api/v2/entitlements/evaluate/` returns `{"name": "ENABLE_AGENTIC_MEMORY_API", "value": true}` for the same user, and `account/info` shows `"permissions": {}`. 

## Fix

Point `IsFeatureFlagEnabled` at `POST /api/v2/entitlements/evaluate/` (public API since v2.35), which resolves the effective flag value across user, group, and organization levels. This is the same endpoint `datarobot-pulumi-utils` uses for its `check_feature_flags` validation. A flag missing from the evaluation response is now an explicit error instead of silently reading as disabled.

`GetUserInfo` / `UserInfo.Permissions` are left untouched.

## Testing

- New httptest-based unit tests in `internal/client/user_service_test.go` cover enabled, disabled, and missing-from-response cases.
- `go build ./...`, `go vet`, `gofmt`, and the `internal/client` suite pass.
- Verified the endpoint behavior against staging: a token whose flag is org-inherited gets `"permissions": {}` from `account/info` but `value: true` from `entitlements/evaluate`.

<!-- rr:slack:start -->
<!-- rr:slack:C053QK4M33R:1785947369.659869 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all provider feature-gate decisions are resolved; behavior shifts for org-inherited flags and failures surface as errors instead of silent false.
> 
> **Overview**
> **`IsFeatureFlagEnabled`** no longer reads `UserInfo.Permissions` from `GET /account/info/`. It now **`POST`s to `/entitlements/evaluate/`** so flags inherited from org or group resolve correctly instead of appearing disabled when the key is missing from the user-only permissions map.
> 
> Request/response types for entitlements evaluation are added in `user_service.go`. A flag absent from the evaluation response returns an **explicit error** rather than `false`. **`GetUserInfo` is unchanged.**
> 
> New httptest coverage exercises enabled, disabled, and missing-from-response behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba57a7da1b5f942a77c31ececc95a1e08ad8ebf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->