### PR TITLE
chore: prepare release v0.10.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## [Unreleased]
 
+## [0.10.46] - 2026-08-20
+
 ### Added
 
 - `source` block on `datarobot_artifact`: upload a local directory (`source.dir`) to the DataRobot catalog on create and update, auto-populate the primary container's `image_build_config.code_ref`, and track changes via computed `source.dir_hash`. Requires a primary container with `image_build_config`. On draft artifacts, uploads are applied in-place; on locked artifacts, source changes clone to a new draft version, upload, patch `code_ref`, and lock the new version. Manual `code_ref` and `source` are mutually exclusive.
 - Documentation and examples for in-place `datarobot_workload` replacement: operator guide in `docs/resources/workload.md` (WAPI rolling replacement vs legacy destroy/create, artifact dual-ID wiring, update-trigger table, apply duration), registry example at `examples/resources/datarobot_workload/`, and runnable workflow at `examples/workflows/workload_replacement/`.
 - Plan-time handling for provider-managed `image_build_config.code_ref` when `source` is set: unknown values are decoded as null on create and restored from the primary container's state on update (including container reorder), so Terraform plan/apply stays consistent with computed catalog references.
+
 ### Fixed
 
 - `datarobot_memory_space` updates no longer fail with `422 Unprocessable Entity` on `llmBaseUrl`. The provider sent an empty string for every attribute the config does not set, and the API parses `llmBaseUrl` as a URL, so any update to a memory space without `llm_base_url` was rejected. Unset attributes are now sent as null, which is also what the API requires to clear a stored value: it applies only the keys present in the request body, so an omitted key would leave the old value in place.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=datarobot-community
 NAME=datarobot
 BINARY=terraform-provider-${NAME}
-VERSION=0.10.43
+VERSION=0.10.46
 
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))


### PR DESCRIPTION
Release prep for **v0.10.46**. No provider code changes — CHANGELOG and version metadata only.

## Changes

- Promote the `[Unreleased]` CHANGELOG section to `## [0.10.46] - 2026-08-20` and open a fresh empty `[Unreleased]`.
- Bump `Makefile` `VERSION` to `0.10.46`. It had drifted at `0.10.43` across the `0.10.44` and `0.10.45` releases.
- Add the missing blank line before `### Fixed` so the section matches the formatting of the rest of the file.

The release contents are 3 `Added` entries (artifact `source` block, workload replacement docs/examples, plan-time `code_ref` handling) and 6 `Fixed` entries (two `datarobot_memory_space` fixes, entitlement-based feature flag evaluation, gRPC and Go toolchain vulnerability bumps).

## Pre-flight

| Check | Result |
|---|---|
| `make lint` | 0 issues |
| `make generate` | no doc diff |
| `bash scripts/changelog-section.sh v0.10.46` | extracts the section cleanly |

## Known issues (pre-existing, not from this release)

`go test ./...` fails on three tests that also fail at the released tag `v0.10.45`, so they are not regressions:

- `TestWaitForDeploymentStatusErroredIncludesLogsAndUIURL` — mock `BaseURL` exceeds its expected call count
- `TestWaitForDeploymentStatusErroredLogRetrievalFailure` — same cause
- `TestUnitDeploymentModelReplacementSuccess` — hangs until the test timeout

CI does not catch these because `build-and-test.yml:140` runs a narrow `-run` filter that excludes all three. Separately, `make test` is a silent no-op: the `test` target is shadowed by the `test/` directory because the Makefile declares no `.PHONY`. Both worth follow-up issues, neither blocks this release.

## After merge

Tag `v0.10.46` on the merge commit to trigger `release.yml` (GoReleaser build, signed artifacts, GitHub release, Slack notification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 04787d383fb0f431d5026d495833a98bba0977f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->