### PR TITLE
 [RAPTOR 18364] `wapi` local base state

### DIFF
--- a/internal/artifactsource/wapi/atomic.go
+++ b/internal/artifactsource/wapi/atomic.go
@@ -1,0 +1,51 @@
+package wapi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CLI source: cli/internal/workload/wapi/atomic.go
+
+const atomicFileMode os.FileMode = 0o600
+
+func atomicWriteFile(path string, data []byte) (err error) {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", path, err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file %s: %w", tmp.Name(), err)
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file %s: %w", tmp.Name(), err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file %s: %w", tmp.Name(), err)
+	}
+	if err = os.Chmod(tmp.Name(), atomicFileMode); err != nil {
+		return fmt.Errorf("chmod temp file %s: %w", tmp.Name(), err)
+	}
+	if err = os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmp.Name(), path, err)
+	}
+
+	if d, derr := os.Open(dir); derr == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+
+	return nil
+}

--- a/internal/artifactsource/wapi/config.go
+++ b/internal/artifactsource/wapi/config.go
@@ -1,0 +1,72 @@
+package wapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// CLI source: cli/internal/workload/wapi/config.go
+//
+// JSON field names match the CLI so a mixed CLI/TF tree can share .wapi/.
+// CLIVersion is the JSON key; Initialize writes ProviderWriter.
+// The Go field is still called CLIVersion because the JSON key is cliVersion. 
+// We do not invent a providerVersion key. On init we store "terraform-provider-datarobot" in that field.
+
+const ProviderWriter = "terraform-provider-datarobot"
+
+// Config is .wapi/config.json — artifact identity and last-synced catalog pointers.
+type Config struct {
+	ArtifactID          string    `json:"artifactId"`
+	CatalogID           *string   `json:"catalogId"`
+	LastSyncedVersionID *string   `json:"lastSyncedVersionId"`
+	CreatedAt           time.Time `json:"createdAt"`
+	CLIVersion          string    `json:"cliVersion"`
+}
+
+// LoadConfig reads .wapi/config.json.
+func LoadConfig(projectDir string) (Config, error) {
+	path := configPath(projectDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Config{}, ErrNotInitialized
+		}
+		return Config{}, &CorruptedError{Path: path, Err: err}
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, &CorruptedError{Path: path, Err: err}
+	}
+
+	return cfg, nil
+}
+
+// SaveConfig atomically writes .wapi/config.json.
+func SaveConfig(projectDir string, c Config) error {
+	if err := writeConfig(projectDir, c); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrNotInitialized
+		}
+		return err
+	}
+	return nil
+}
+
+func writeConfig(projectDir string, c Config) error {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	return atomicWriteFile(configPath(projectDir), data)
+}
+
+func stringPtr(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return &v
+}

--- a/internal/artifactsource/wapi/doc.go
+++ b/internal/artifactsource/wapi/doc.go
@@ -1,0 +1,10 @@
+// Package wapi manages .wapi/ — local BASE sync state for source.dir
+// (not stored in Terraform state).
+//
+// CLI source: cli/internal/workload/wapi/doc.go
+//
+// Provider differences from CLI:
+//   - No history.log.
+//   - No validator/v10.
+//   - Initialize does not write .drignore / .wapiignore (PR2 already does).
+package wapi

--- a/internal/artifactsource/wapi/errors.go
+++ b/internal/artifactsource/wapi/errors.go
@@ -1,0 +1,28 @@
+package wapi
+
+import (
+	"errors"
+	"fmt"
+)
+
+// CLI source: cli/internal/workload/wapi/errors.go
+
+// ErrAlreadyLinked is returned by Initialize when .wapi/ already exists.
+var ErrAlreadyLinked = errors.New("project already linked: .wapi/ exists")
+
+// ErrNotInitialized is returned by Load/Save when .wapi/ is missing.
+var ErrNotInitialized = errors.New(".wapi/ not found")
+
+// CorruptedError wraps a read or parse failure for a file under .wapi/.
+type CorruptedError struct {
+	Path string
+	Err  error
+}
+
+func (e *CorruptedError) Error() string {
+	return fmt.Sprintf(".wapi/ file is corrupted at %s: %v", e.Path, e.Err)
+}
+
+func (e *CorruptedError) Unwrap() error {
+	return e.Err
+}

--- a/internal/artifactsource/wapi/init.go
+++ b/internal/artifactsource/wapi/init.go
@@ -1,0 +1,54 @@
+package wapi
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// CLI source: cli/internal/workload/wapi/init.go
+//
+// Provider differences: no history.log; no .drignore write (PR2).
+
+// InitOptions are persisted to config.json. Empty catalog/version become JSON null.
+type InitOptions struct {
+	ArtifactID          string
+	CatalogID           string
+	LastSyncedVersionID string
+}
+
+// Initialize creates .wapi/ with config.json, empty BASE manifest.json, and
+// .gitignore "*". Returns ErrAlreadyLinked if .wapi/ already exists.
+func Initialize(projectDir string, opts InitOptions) error {
+	if opts.ArtifactID == "" {
+		return fmt.Errorf("artifactId is required")
+	}
+
+	if err := os.Mkdir(wapiDir(projectDir), 0o755); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrAlreadyLinked
+		}
+		return fmt.Errorf("create .wapi/ directory: %w", err)
+	}
+
+	now := time.Now().UTC()
+	cfg := Config{
+		ArtifactID:          opts.ArtifactID,
+		CatalogID:           stringPtr(opts.CatalogID),
+		LastSyncedVersionID: stringPtr(opts.LastSyncedVersionID),
+		CreatedAt:           now,
+		CLIVersion:          ProviderWriter,
+	}
+	if err := writeConfig(projectDir, cfg); err != nil {
+		return err
+	}
+	if err := writeManifest(projectDir, Manifest{Version: ManifestVersion}); err != nil {
+		return err
+	}
+	if err := atomicWriteFile(gitignorePath(projectDir), []byte(gitignoreContents)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/artifactsource/wapi/manifest.go
+++ b/internal/artifactsource/wapi/manifest.go
@@ -1,0 +1,69 @@
+package wapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// CLI source: cli/internal/workload/wapi/manifest.go
+
+// FileMeta is one BASE file: SHA-256 hex hash and size.
+type FileMeta struct {
+	Hash string `json:"hash"`
+	Size int64  `json:"size"`
+}
+
+// Manifest is .wapi/manifest.json — BASE from the last successful sync.
+type Manifest struct {
+	Version         int                 `json:"version"`
+	SyncedAt        *time.Time          `json:"syncedAt"`
+	SyncedVersionID *string             `json:"syncedVersionId"`
+	Files           map[string]FileMeta `json:"files"`
+}
+
+// LoadManifest reads .wapi/manifest.json. Nil Files becomes an empty map.
+func LoadManifest(projectDir string) (Manifest, error) {
+	path := manifestPath(projectDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Manifest{}, ErrNotInitialized
+		}
+		return Manifest{}, &CorruptedError{Path: path, Err: err}
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, &CorruptedError{Path: path, Err: err}
+	}
+	if m.Files == nil {
+		m.Files = map[string]FileMeta{}
+	}
+
+	return m, nil
+}
+
+// SaveManifest atomically writes .wapi/manifest.json.
+func SaveManifest(projectDir string, m Manifest) error {
+	if err := writeManifest(projectDir, m); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrNotInitialized
+		}
+		return err
+	}
+	return nil
+}
+
+func writeManifest(projectDir string, m Manifest) error {
+	if m.Files == nil {
+		m.Files = map[string]FileMeta{}
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	return atomicWriteFile(manifestPath(projectDir), data)
+}

--- a/internal/artifactsource/wapi/paths.go
+++ b/internal/artifactsource/wapi/paths.go
@@ -1,0 +1,42 @@
+package wapi
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CLI source: cli/internal/workload/wapi/paths.go
+//
+// History, checkouts, and .wapiignore paths are not ported.
+
+const (
+	DirName         = ".wapi"
+	ManifestVersion = 1
+
+	configFile        = "config.json"
+	manifestFile      = "manifest.json"
+	gitignoreFile     = ".gitignore"
+	gitignoreContents = "*\n"
+)
+
+func wapiDir(projectDir string) string {
+	return filepath.Join(projectDir, DirName)
+}
+
+func configPath(projectDir string) string {
+	return filepath.Join(wapiDir(projectDir), configFile)
+}
+
+func manifestPath(projectDir string) string {
+	return filepath.Join(wapiDir(projectDir), manifestFile)
+}
+
+func gitignorePath(projectDir string) string {
+	return filepath.Join(wapiDir(projectDir), gitignoreFile)
+}
+
+// Exists reports whether projectDir contains a .wapi/ directory.
+func Exists(projectDir string) bool {
+	info, err := os.Stat(wapiDir(projectDir))
+	return err == nil && info.IsDir()
+}

--- a/internal/artifactsource/wapi/wapi_test.go
+++ b/internal/artifactsource/wapi/wapi_test.go
@@ -1,0 +1,126 @@
+package wapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialize_CreatesLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := Initialize(dir, InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-1",
+		LastSyncedVersionID: "ver-1",
+	})
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(dir, DirName))
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.ElementsMatch(t, []string{gitignoreFile, configFile, manifestFile}, names)
+
+	gi, err := os.ReadFile(gitignorePath(dir))
+	require.NoError(t, err)
+	assert.Equal(t, "*\n", string(gi))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "art-1", cfg.ArtifactID)
+	require.NotNil(t, cfg.CatalogID)
+	assert.Equal(t, "cat-1", *cfg.CatalogID)
+	require.NotNil(t, cfg.LastSyncedVersionID)
+	assert.Equal(t, "ver-1", *cfg.LastSyncedVersionID)
+	assert.Equal(t, ProviderWriter, cfg.CLIVersion)
+
+	raw, err := os.ReadFile(manifestPath(dir))
+	require.NoError(t, err)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	assert.EqualValues(t, 1, parsed["version"])
+	assert.Nil(t, parsed["syncedAt"])
+	assert.Nil(t, parsed["syncedVersionId"])
+	files, ok := parsed["files"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, files)
+}
+
+func TestInitialize_AlreadyLinked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, Initialize(dir, InitOptions{ArtifactID: "art-1"}))
+
+	err := Initialize(dir, InitOptions{ArtifactID: "art-2"})
+	assert.ErrorIs(t, err, ErrAlreadyLinked)
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "art-1", cfg.ArtifactID)
+}
+
+func TestConfigManifest_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, Initialize(dir, InitOptions{ArtifactID: "art-1"}))
+
+	catalog := "cat-9"
+	version := "ver-9"
+	created := time.Date(2026, 4, 10, 9, 15, 0, 0, time.UTC)
+	require.NoError(t, SaveConfig(dir, Config{
+		ArtifactID:          "art-1",
+		CatalogID:           &catalog,
+		LastSyncedVersionID: &version,
+		CreatedAt:           created,
+		CLIVersion:          ProviderWriter,
+	}))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "art-1", cfg.ArtifactID)
+	require.NotNil(t, cfg.CatalogID)
+	assert.Equal(t, catalog, *cfg.CatalogID)
+	require.NotNil(t, cfg.LastSyncedVersionID)
+	assert.Equal(t, version, *cfg.LastSyncedVersionID)
+	assert.True(t, created.Equal(cfg.CreatedAt))
+
+	synced := time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC)
+	require.NoError(t, SaveManifest(dir, Manifest{
+		Version:         ManifestVersion,
+		SyncedAt:        &synced,
+		SyncedVersionID: &version,
+		Files: map[string]FileMeta{
+			"app.py": {Hash: "aaa", Size: 12},
+		},
+	}))
+
+	m, err := LoadManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, ManifestVersion, m.Version)
+	require.NotNil(t, m.SyncedAt)
+	assert.True(t, synced.Equal(*m.SyncedAt))
+	require.NotNil(t, m.SyncedVersionID)
+	assert.Equal(t, version, *m.SyncedVersionID)
+	assert.Equal(t, FileMeta{Hash: "aaa", Size: 12}, m.Files["app.py"])
+}
+
+func TestLoad_NotInitialized(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := LoadConfig(dir)
+	assert.ErrorIs(t, err, ErrNotInitialized)
+	_, err = LoadManifest(dir)
+	assert.ErrorIs(t, err, ErrNotInitialized)
+}

--- a/internal/artifactsource/wapi/wapi_test.go
+++ b/internal/artifactsource/wapi/wapi_test.go
@@ -124,3 +124,60 @@ func TestLoad_NotInitialized(t *testing.T) {
 	_, err = LoadManifest(dir)
 	assert.ErrorIs(t, err, ErrNotInitialized)
 }
+
+func TestInitialize_NullsForEmptyOptionals(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, Initialize(dir, InitOptions{ArtifactID: "art-1"}))
+
+	raw, err := os.ReadFile(configPath(dir))
+	require.NoError(t, err)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	assert.Nil(t, parsed["catalogId"])
+	assert.Nil(t, parsed["lastSyncedVersionId"])
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.CatalogID)
+	assert.Nil(t, cfg.LastSyncedVersionID)
+}
+
+func TestLoad_CorruptedJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, Initialize(dir, InitOptions{ArtifactID: "art-1"}))
+	require.NoError(t, os.WriteFile(configPath(dir), []byte("not json"), 0o600))
+	require.NoError(t, os.WriteFile(manifestPath(dir), []byte("not json"), 0o600))
+
+	_, err := LoadConfig(dir)
+	var cfgErr *CorruptedError
+	require.ErrorAs(t, err, &cfgErr)
+	assert.Equal(t, configPath(dir), cfgErr.Path)
+
+	_, err = LoadManifest(dir)
+	var manErr *CorruptedError
+	require.ErrorAs(t, err, &manErr)
+	assert.Equal(t, manifestPath(dir), manErr.Path)
+}
+
+func TestSave_NotInitialized(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := SaveConfig(dir, Config{ArtifactID: "art-1"})
+	assert.ErrorIs(t, err, ErrNotInitialized)
+	err = SaveManifest(dir, Manifest{Version: ManifestVersion})
+	assert.ErrorIs(t, err, ErrNotInitialized)
+}
+
+func TestInitialize_EmptyArtifactID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := Initialize(dir, InitOptions{})
+	require.Error(t, err)
+	assert.False(t, Exists(dir))
+}


### PR DESCRIPTION
<!-- Base: brunoromano-dr/RAPTOR-18364-diff-base-local-remote → brunoromano-dr/RAPTOR-18364-wapi-local-base-state -->

## Summary
Persist three-way BASE on disk under `source.dir/.wapi/` (`config.json` + `manifest.json`), not in Terraform state. Auto-init creates an empty BASE and `.wapi/.gitignore` = `*`.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [x] test
- [ ] ci

## Details / User Impact
None yet. Library-only; `datarobot_artifact` still uses the push-only upload. `.wapi/` is not created on apply until Engine is wired. No schema or changelog.

JSON field names match the CLI so a mixed CLI/TF tree can share `.wapi/`. `Initialize` does not write `.drignore and does not write `history.log`.

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here: Internal `.wapi/` helpers only; apply does not create the directory yet.

## Testing
```bash
go test ./internal/artifactsource/wapi/ -count=1
```

Coverage:
- `Initialize` creates `.wapi/` with `config.json`, empty `manifest.json` (`files: {}`, null sync pointers), and `.gitignore` `*`
- Second `Initialize` returns `ErrAlreadyLinked` and does not overwrite config
- Config + manifest load/save round-trip
- Load without `.wapi/` returns `ErrNotInitialized`

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [x] Version impact considered (patch / minor / major)

Suggested version impact: **none** (internal; skip changelog). Ships with later Engine PRs.

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
- Parent / compare base: `brunoromano-dr/RAPTOR-18364-diff-base-local-remote`.
- New package: `internal/artifactsource/wapi/` (paths, atomic write, config, manifest, Initialize).
- CLI source: `cli/internal/workload/wapi/{paths,atomic,config,manifest,init,errors}.go`. No lock, rollback, Engine, or resource wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal filesystem helpers only; not called from the Terraform resource path yet. Writes are local, atomic, and mode-restricted.
> 
> **Overview**
> Adds an internal `wapi` package to persist three-way **BASE** sync state on disk under `source.dir/.wapi/` instead of Terraform state. This is library-only: apply still does not create `.wapi/`.
> 
> `Initialize` creates `config.json`, an empty `manifest.json`, and `.wapi/.gitignore` (`*`). JSON keys match the CLI so mixed CLI/TF trees can share the directory. `cliVersion` is written as `terraform-provider-datarobot`. Load/save use atomic temp-file writes (mode `0600`). Missing `.wapi/` is `ErrNotInitialized`; a second init is `ErrAlreadyLinked`. No `history.log` or ignore-file writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9887475886a6ad4b85dd473bb8eef0785c1af15b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->