### PR TITLE
[RAPTOR 18364] Sync lock rollback three

### DIFF
--- a/internal/artifactsource/sync/rollback.go
+++ b/internal/artifactsource/sync/rollback.go
@@ -78,7 +78,10 @@ func (r *RollbackTree) Backup(relPath string) error {
 	dstPath := filepath.Join(r.rollbackDir, cleanRel)
 
 	info, err := os.Stat(srcPath)
-	if err == nil && !info.IsDir() {
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("cannot backup directory %s: only files are supported", cleanRel)
+		}
 		if err := copyFile(srcPath, dstPath); err != nil {
 			return fmt.Errorf("backup file %s: %w", cleanRel, err)
 		}
@@ -89,6 +92,8 @@ func (r *RollbackTree) Backup(relPath string) error {
 		if !containsString(r.manifest.CreatedFiles, cleanRel) {
 			r.manifest.CreatedFiles = append(r.manifest.CreatedFiles, cleanRel)
 		}
+	} else {
+		return fmt.Errorf("stat %s: %w", cleanRel, err)
 	}
 
 	return r.saveManifest()

--- a/internal/artifactsource/sync/rollback.go
+++ b/internal/artifactsource/sync/rollback.go
@@ -1,0 +1,224 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CLI source: cli/internal/workload/sync/rollback.go
+
+const (
+	// RollbackMaxFiles caps the total number of files backed up/restored
+	// during a single sync execution to prevent excessive disk/backup usage.
+	RollbackMaxFiles = 1000
+
+	rollbackDirName  = ".rollback"
+	manifestFileName = "manifest.json"
+)
+
+// RollbackManifest tracks file actions for precise restoration.
+type RollbackManifest struct {
+	BackedUpFiles []string `json:"backedUpFiles"`
+	CreatedFiles  []string `json:"createdFiles,omitempty"`
+}
+
+// RollbackTree manages backup and restoration of mutated files under .wapi/.rollback.
+type RollbackTree struct {
+	projectDir  string
+	rollbackDir string
+	manifest    RollbackManifest
+}
+
+// NewRollbackTree constructs a RollbackTree for projectDir.
+func NewRollbackTree(projectDir string) *RollbackTree {
+	wapiDir := filepath.Join(projectDir, ".wapi")
+	return &RollbackTree{
+		projectDir:  projectDir,
+		rollbackDir: filepath.Join(wapiDir, rollbackDirName),
+		manifest: RollbackManifest{
+			BackedUpFiles: make([]string, 0),
+			CreatedFiles:  make([]string, 0),
+		},
+	}
+}
+
+// HasRollback reports whether a .wapi/.rollback directory exists in projectDir.
+func HasRollback(projectDir string) bool {
+	rollbackPath := filepath.Join(projectDir, ".wapi", rollbackDirName)
+	info, err := os.Stat(rollbackPath)
+	return err == nil && info.IsDir()
+}
+
+// Init creates the .wapi/.rollback directory if missing.
+func (r *RollbackTree) Init() error {
+	wapiDir := filepath.Join(r.projectDir, ".wapi")
+	if _, err := os.Stat(wapiDir); err != nil {
+		return fmt.Errorf(".wapi directory does not exist: %w", err)
+	}
+
+	if err := os.MkdirAll(r.rollbackDir, 0755); err != nil {
+		return fmt.Errorf("create rollback directory: %w", err)
+	}
+	return nil
+}
+
+// Backup backs up projectDir/relPath into .wapi/.rollback/relPath.
+// If the file does not exist locally (will be created by download), it tracks it for removal on rollback.
+func (r *RollbackTree) Backup(relPath string) error {
+	cleanRel, err := validateAndCleanRelPath(relPath)
+	if err != nil {
+		return fmt.Errorf("invalid path for backup: %w", err)
+	}
+
+	srcPath := filepath.Join(r.projectDir, cleanRel)
+	dstPath := filepath.Join(r.rollbackDir, cleanRel)
+
+	info, err := os.Stat(srcPath)
+	if err == nil && !info.IsDir() {
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("backup file %s: %w", cleanRel, err)
+		}
+		if !containsString(r.manifest.BackedUpFiles, cleanRel) {
+			r.manifest.BackedUpFiles = append(r.manifest.BackedUpFiles, cleanRel)
+		}
+	} else if os.IsNotExist(err) {
+		if !containsString(r.manifest.CreatedFiles, cleanRel) {
+			r.manifest.CreatedFiles = append(r.manifest.CreatedFiles, cleanRel)
+		}
+	}
+
+	return r.saveManifest()
+}
+
+// Restore restores all backed up files to projectDir and cleans up .wapi/.rollback.
+func (r *RollbackTree) Restore() error {
+	return RestoreRollback(r.projectDir)
+}
+
+// RestoreRollback restores backed-up files from .wapi/.rollback into projectDir and deletes .wapi/.rollback.
+func RestoreRollback(projectDir string) error {
+	if !HasRollback(projectDir) {
+		return nil // No rollback tree to restore
+	}
+
+	rollbackPath := filepath.Join(projectDir, ".wapi", rollbackDirName)
+	manifestPath := filepath.Join(rollbackPath, manifestFileName)
+	if manifestData, err := os.ReadFile(manifestPath); err == nil {
+		var manifest RollbackManifest
+		if err := json.Unmarshal(manifestData, &manifest); err == nil {
+			// Remove newly created files
+			for _, created := range manifest.CreatedFiles {
+				p := filepath.Join(projectDir, created)
+				_ = os.Remove(p)
+			}
+
+			// Restore backed up files
+			for _, backedUp := range manifest.BackedUpFiles {
+				src := filepath.Join(rollbackPath, backedUp)
+				dst := filepath.Join(projectDir, backedUp)
+				if _, statErr := os.Stat(src); statErr == nil {
+					if err := copyFile(src, dst); err != nil {
+						return fmt.Errorf("restore file %s: %w", backedUp, err)
+					}
+				}
+			}
+
+			return os.RemoveAll(rollbackPath)
+		}
+	}
+
+	// Fallback for stale/legacy rollback trees without a valid manifest: walk rollbackDir
+	walkErr := filepath.Walk(rollbackPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(rollbackPath, path)
+		if err != nil {
+			return fmt.Errorf("relative path calculation for %s: %w", path, err)
+		}
+		if rel == manifestFileName {
+			return nil
+		}
+		dst := filepath.Join(projectDir, rel)
+		return copyFile(path, dst)
+	})
+
+	_ = os.RemoveAll(rollbackPath)
+	return walkErr
+}
+
+// Discard removes .wapi/.rollback without restoring files.
+func (r *RollbackTree) Discard() error {
+	if _, err := os.Stat(r.rollbackDir); err == nil {
+		return os.RemoveAll(r.rollbackDir)
+	}
+	return nil
+}
+
+func (r *RollbackTree) saveManifest() error {
+	manifestPath := filepath.Join(r.rollbackDir, manifestFileName)
+	data, err := json.MarshalIndent(r.manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal rollback manifest: %w", err)
+	}
+	return os.WriteFile(manifestPath, data, 0600)
+}
+
+func validateAndCleanRelPath(rel string) (string, error) {
+	if rel == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path cannot be absolute")
+	}
+	cleaned := filepath.Clean(rel)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("path escapes root directory")
+	}
+	parts := strings.Split(filepath.ToSlash(cleaned), "/")
+	if len(parts) > 0 && parts[0] == ".wapi" {
+		return "", fmt.Errorf("path targets .wapi directory")
+	}
+	return cleaned, nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+	return dstFile.Sync()
+}
+
+func containsString(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/artifactsource/sync/rollback.go
+++ b/internal/artifactsource/sync/rollback.go
@@ -153,7 +153,7 @@ func RestoreRollback(projectDir string) error {
 		if err != nil {
 			return fmt.Errorf("relative path calculation for %s: %w", path, err)
 		}
-		if rel == manifestFileName {
+		if rel == manifestFileName || strings.HasPrefix(filepath.Base(rel), manifestFileName+".tmp.") {
 			return nil
 		}
 		dst := filepath.Join(projectDir, rel)
@@ -180,7 +180,47 @@ func (r *RollbackTree) saveManifest() error {
 	if err != nil {
 		return fmt.Errorf("marshal rollback manifest: %w", err)
 	}
-	return os.WriteFile(manifestPath, data, 0600)
+	return atomicWriteFile(manifestPath, data)
+}
+
+func atomicWriteFile(path string, data []byte) (err error) {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", path, err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file %s: %w", tmp.Name(), err)
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file %s: %w", tmp.Name(), err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file %s: %w", tmp.Name(), err)
+	}
+	if err = os.Chmod(tmp.Name(), 0600); err != nil {
+		return fmt.Errorf("chmod temp file %s: %w", tmp.Name(), err)
+	}
+	if err = os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmp.Name(), path, err)
+	}
+
+	if d, derr := os.Open(dir); derr == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+
+	return nil
 }
 
 func validateAndCleanRelPath(rel string) (string, error) {

--- a/internal/artifactsource/sync/rollback.go
+++ b/internal/artifactsource/sync/rollback.go
@@ -112,17 +112,25 @@ func RestoreRollback(projectDir string) error {
 		if err := json.Unmarshal(manifestData, &manifest); err == nil {
 			// Remove newly created files
 			for _, created := range manifest.CreatedFiles {
-				p := filepath.Join(projectDir, created)
+				cleanCreated, err := validateAndCleanRelPath(created)
+				if err != nil {
+					return fmt.Errorf("invalid manifest created file %q: %w", created, err)
+				}
+				p := filepath.Join(projectDir, cleanCreated)
 				_ = os.Remove(p)
 			}
 
 			// Restore backed up files
 			for _, backedUp := range manifest.BackedUpFiles {
-				src := filepath.Join(rollbackPath, backedUp)
-				dst := filepath.Join(projectDir, backedUp)
+				cleanBackedUp, err := validateAndCleanRelPath(backedUp)
+				if err != nil {
+					return fmt.Errorf("invalid manifest backed up file %q: %w", backedUp, err)
+				}
+				src := filepath.Join(rollbackPath, cleanBackedUp)
+				dst := filepath.Join(projectDir, cleanBackedUp)
 				if _, statErr := os.Stat(src); statErr == nil {
 					if err := copyFile(src, dst); err != nil {
-						return fmt.Errorf("restore file %s: %w", backedUp, err)
+						return fmt.Errorf("restore file %s: %w", cleanBackedUp, err)
 					}
 				}
 			}

--- a/internal/artifactsource/sync/rollback.go
+++ b/internal/artifactsource/sync/rollback.go
@@ -146,9 +146,11 @@ func RestoreRollback(projectDir string) error {
 		dst := filepath.Join(projectDir, rel)
 		return copyFile(path, dst)
 	})
+	if walkErr != nil {
+		return fmt.Errorf("restore rollback tree: %w", walkErr)
+	}
 
-	_ = os.RemoveAll(rollbackPath)
-	return walkErr
+	return os.RemoveAll(rollbackPath)
 }
 
 // Discard removes .wapi/.rollback without restoring files.

--- a/internal/artifactsource/sync/rollback_test.go
+++ b/internal/artifactsource/sync/rollback_test.go
@@ -231,6 +231,24 @@ func TestRollback_PathSafety(t *testing.T) {
 	assert.Error(t, rt.Backup(".wapi/config.json"))
 }
 
+func TestRollback_BackupDirectoryError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	subDir := filepath.Join(dir, "somedir")
+	require.NoError(t, os.Mkdir(subDir, 0755))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	err := rt.Backup("somedir")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot backup directory somedir: only files are supported")
+}
+
 func TestRollback_RestoreManifestPathTraversal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/artifactsource/sync/rollback_test.go
+++ b/internal/artifactsource/sync/rollback_test.go
@@ -1,0 +1,254 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollback_BackupAndRestoreMutatedFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	appPy := filepath.Join(dir, "app.py")
+	require.NoError(t, os.WriteFile(appPy, []byte("version 1"), 0644))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	// Backup app.py
+	require.NoError(t, rt.Backup("app.py"))
+	// Backup a file that will be newly created
+	require.NoError(t, rt.Backup("new_file.txt"))
+
+	assert.True(t, HasRollback(dir))
+
+	// Mutate app.py and create new_file.txt
+	require.NoError(t, os.WriteFile(appPy, []byte("version 2 mutated"), 0644))
+	newFilePath := filepath.Join(dir, "new_file.txt")
+	require.NoError(t, os.WriteFile(newFilePath, []byte("new file content"), 0644))
+
+	// Restore
+	require.NoError(t, rt.Restore())
+
+	// Verify app.py is restored to version 1 and new_file.txt was removed
+	content, err := os.ReadFile(appPy)
+	require.NoError(t, err)
+	assert.Equal(t, "version 1", string(content))
+
+	_, err = os.Stat(newFilePath)
+	assert.True(t, os.IsNotExist(err))
+
+	assert.False(t, HasRollback(dir))
+}
+
+func TestRollback_StaleRestore(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rollbackDir := filepath.Join(wapiDir, ".rollback")
+	require.NoError(t, os.Mkdir(rollbackDir, 0755))
+
+	// Manually create stale backed-up file in .rollback without a manifest
+	staleFile := filepath.Join(rollbackDir, "config.py")
+	require.NoError(t, os.WriteFile(staleFile, []byte("stale backup content"), 0644))
+
+	// Modify file on working tree
+	targetFile := filepath.Join(dir, "config.py")
+	require.NoError(t, os.WriteFile(targetFile, []byte("bad current content"), 0644))
+
+	// Calling RestoreRollback should recover the stale backup
+	require.NoError(t, RestoreRollback(dir))
+
+	content, err := os.ReadFile(targetFile)
+	require.NoError(t, err)
+	assert.Equal(t, "stale backup content", string(content))
+	assert.False(t, HasRollback(dir))
+}
+
+func TestRollback_Init_NoWapiDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rt := NewRollbackTree(dir)
+	err := rt.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".wapi directory does not exist")
+}
+
+func TestRollback_NestedDirectories(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	nestedFile := filepath.Join(dir, "src", "utils", "helper.py")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nestedFile), 0755))
+	require.NoError(t, os.WriteFile(nestedFile, []byte("original nested content"), 0644))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	// Backup nested existing file and non-existing nested file
+	require.NoError(t, rt.Backup("src/utils/helper.py"))
+	require.NoError(t, rt.Backup("src/generated/model.py"))
+
+	// Mutate existing nested file and create new nested file
+	require.NoError(t, os.WriteFile(nestedFile, []byte("mutated nested content"), 0644))
+	newNestedFile := filepath.Join(dir, "src", "generated", "model.py")
+	require.NoError(t, os.MkdirAll(filepath.Dir(newNestedFile), 0755))
+	require.NoError(t, os.WriteFile(newNestedFile, []byte("new nested model"), 0644))
+
+	// Restore
+	require.NoError(t, rt.Restore())
+
+	// Verify original file restored and newly created nested file removed
+	content, err := os.ReadFile(nestedFile)
+	require.NoError(t, err)
+	assert.Equal(t, "original nested content", string(content))
+
+	_, err = os.Stat(newNestedFile)
+	assert.True(t, os.IsNotExist(err))
+	assert.False(t, HasRollback(dir))
+}
+
+func TestRollback_BackupDeduplication(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	appPy := filepath.Join(dir, "app.py")
+	require.NoError(t, os.WriteFile(appPy, []byte("version 1"), 0644))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	// Call Backup multiple times for both existing and newly created files
+	require.NoError(t, rt.Backup("app.py"))
+	require.NoError(t, rt.Backup("app.py"))
+	require.NoError(t, rt.Backup("new_file.txt"))
+	require.NoError(t, rt.Backup("new_file.txt"))
+
+	assert.Equal(t, []string{"app.py"}, rt.manifest.BackedUpFiles)
+	assert.Equal(t, []string{"new_file.txt"}, rt.manifest.CreatedFiles)
+}
+
+func TestRollback_RestoreNoRollbackDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Calling RestoreRollback on a clean directory with no .rollback should safely return nil
+	assert.NoError(t, RestoreRollback(dir))
+
+	rt := NewRollbackTree(dir)
+	assert.NoError(t, rt.Restore())
+}
+
+func TestRollback_CorruptManifestFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rollbackDir := filepath.Join(wapiDir, ".rollback")
+	require.NoError(t, os.Mkdir(rollbackDir, 0755))
+
+	// Write corrupted manifest.json
+	manifestPath := filepath.Join(rollbackDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte("invalid-json{"), 0644))
+
+	// Write backup file in .rollback
+	backupFile := filepath.Join(rollbackDir, "script.py")
+	require.NoError(t, os.WriteFile(backupFile, []byte("backup script version"), 0644))
+
+	// Mutated target file in working tree
+	targetFile := filepath.Join(dir, "script.py")
+	require.NoError(t, os.WriteFile(targetFile, []byte("corrupted working copy"), 0644))
+
+	// RestoreRollback should recover using the directory-walk fallback despite corrupted manifest
+	require.NoError(t, RestoreRollback(dir))
+
+	content, err := os.ReadFile(targetFile)
+	require.NoError(t, err)
+	assert.Equal(t, "backup script version", string(content))
+	assert.False(t, HasRollback(dir))
+}
+
+func TestRollback_CreatedFileAlreadyDeleted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	// Track a new file that never actually got written, or was deleted before rollback
+	require.NoError(t, rt.Backup("deleted_before_restore.txt"))
+
+	// Restore should succeed without error
+	require.NoError(t, rt.Restore())
+	assert.False(t, HasRollback(dir))
+}
+
+func TestRollback_PathSafety(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+
+	// Empty path
+	assert.Error(t, rt.Backup(""))
+
+	// Path escape with ../
+	assert.Error(t, rt.Backup("../outside.txt"))
+	assert.Error(t, rt.Backup("../../etc/passwd"))
+	assert.Error(t, rt.Backup("foo/../../outside.txt"))
+
+	// Absolute path
+	absPath := filepath.Join(dir, "file.txt")
+	assert.Error(t, rt.Backup(absPath))
+
+	// Target inside .wapi/
+	assert.Error(t, rt.Backup(".wapi/config.json"))
+}
+
+func TestRollback_Discard(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rt := NewRollbackTree(dir)
+	// Discard before Init/Backup should succeed
+	require.NoError(t, rt.Discard())
+
+	require.NoError(t, rt.Init())
+	require.NoError(t, rt.Backup("file.txt"))
+	assert.True(t, HasRollback(dir))
+
+	require.NoError(t, rt.Discard())
+	assert.False(t, HasRollback(dir))
+
+	// Consecutive discard call should be idempotent
+	require.NoError(t, rt.Discard())
+}

--- a/internal/artifactsource/sync/rollback_test.go
+++ b/internal/artifactsource/sync/rollback_test.go
@@ -231,6 +231,28 @@ func TestRollback_PathSafety(t *testing.T) {
 	assert.Error(t, rt.Backup(".wapi/config.json"))
 }
 
+func TestRollback_RestoreManifestPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0755))
+
+	rollbackDir := filepath.Join(wapiDir, ".rollback")
+	require.NoError(t, os.Mkdir(rollbackDir, 0755))
+
+	// Malicious manifest targeting outside project
+	manifestData := []byte(`{
+		"backedUpFiles": ["../../evil.txt"],
+		"createdFiles": ["../evil_created.txt"]
+	}`)
+	require.NoError(t, os.WriteFile(filepath.Join(rollbackDir, "manifest.json"), manifestData, 0644))
+
+	err := RestoreRollback(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid manifest")
+}
+
 func TestRollback_Discard(t *testing.T) {
 	t.Parallel()
 

--- a/internal/artifactsource/sync/synclock.go
+++ b/internal/artifactsource/sync/synclock.go
@@ -46,7 +46,8 @@ func AcquireLock(projectDir string) (*SyncLock, error) {
 	}, nil
 }
 
-// Unlock releases the lock, closes the lock file handle, and removes sync.lock.
+// Unlock releases the lock and closes the lock file handle.
+// The lock file is not removed on unlock to avoid flock-unlink race conditions across processes.
 func (l *SyncLock) Unlock() error {
 	if l == nil || l.file == nil {
 		return nil
@@ -54,6 +55,5 @@ func (l *SyncLock) Unlock() error {
 	_ = unlockFile(l.file)
 	_ = l.file.Close()
 	l.file = nil
-	_ = os.Remove(l.lockPath)
 	return nil
 }

--- a/internal/artifactsource/sync/synclock.go
+++ b/internal/artifactsource/sync/synclock.go
@@ -1,0 +1,59 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CLI source: cli/internal/workload/sync/synclock.go
+
+const lockFileName = "sync.lock"
+
+// ErrLocked is returned when the sync lock is already held by another process.
+var ErrLocked = errors.New("sync lock is held by another process")
+
+// SyncLock represents an active exclusive lock on .wapi/sync.lock.
+type SyncLock struct {
+	lockPath string
+	file     *os.File
+}
+
+// AcquireLock attempts to lock .wapi/sync.lock in projectDir.
+// Returns ErrLocked if the lock is already held.
+func AcquireLock(projectDir string) (*SyncLock, error) {
+	wapiDir := filepath.Join(projectDir, ".wapi")
+	info, err := os.Stat(wapiDir)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf(".wapi directory does not exist in %s", projectDir)
+	}
+
+	lockPath := filepath.Join(wapiDir, lockFileName)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	if err := lockFile(f); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	return &SyncLock{
+		lockPath: lockPath,
+		file:     f,
+	}, nil
+}
+
+// Unlock releases the lock, closes the lock file handle, and removes sync.lock.
+func (l *SyncLock) Unlock() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	_ = unlockFile(l.file)
+	_ = l.file.Close()
+	l.file = nil
+	_ = os.Remove(l.lockPath)
+	return nil
+}

--- a/internal/artifactsource/sync/synclock_test.go
+++ b/internal/artifactsource/sync/synclock_test.go
@@ -56,7 +56,7 @@ func TestAcquireLock_Exclusivity(t *testing.T) {
 	require.NoError(t, lock2.Unlock())
 }
 
-func TestAcquireLock_UnlockRemovesLockFile(t *testing.T) {
+func TestAcquireLock_UnlockRetainsLockFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -70,7 +70,8 @@ func TestAcquireLock_UnlockRemovesLockFile(t *testing.T) {
 	assert.FileExists(t, lockFilePath)
 
 	require.NoError(t, lock.Unlock())
-	assert.NoFileExists(t, lockFilePath)
+	// Lock file remains on disk to prevent flock-unlink race conditions across processes
+	assert.FileExists(t, lockFilePath)
 }
 
 func TestAcquireLock_ReadOnlyDirectory(t *testing.T) {

--- a/internal/artifactsource/sync/synclock_test.go
+++ b/internal/artifactsource/sync/synclock_test.go
@@ -1,0 +1,161 @@
+package sync
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	stdsync "sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquireLock_NotInitialized(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := AcquireLock(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".wapi directory does not exist")
+}
+
+func TestAcquireLock_WapiIsFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wapiPath := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.WriteFile(wapiPath, []byte("not a directory"), 0644))
+
+	_, err := AcquireLock(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".wapi directory does not exist")
+}
+
+func TestAcquireLock_Exclusivity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi"), 0755))
+
+	lock1, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock1)
+
+	// Second acquire on the same projectDir must fail with ErrLocked
+	_, err = AcquireLock(dir)
+	assert.ErrorIs(t, err, ErrLocked)
+
+	// Unlock first lock
+	require.NoError(t, lock1.Unlock())
+
+	// Third acquire should now succeed
+	lock2, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock2)
+	require.NoError(t, lock2.Unlock())
+}
+
+func TestAcquireLock_UnlockRemovesLockFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi"), 0755))
+
+	lock, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	lockFilePath := filepath.Join(dir, ".wapi", lockFileName)
+	assert.FileExists(t, lockFilePath)
+
+	require.NoError(t, lock.Unlock())
+	assert.NoFileExists(t, lockFilePath)
+}
+
+func TestAcquireLock_ReadOnlyDirectory(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("skipping read-only directory test when running as root")
+	}
+
+	dir := t.TempDir()
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.Mkdir(wapiDir, 0555))
+	t.Cleanup(func() {
+		_ = os.Chmod(wapiDir, 0755)
+	})
+
+	_, err := AcquireLock(dir)
+	if err == nil {
+		t.Skip("skipping: filesystem did not enforce directory read-only permissions")
+	}
+	assert.Contains(t, err.Error(), "open lock file:")
+}
+
+func TestAcquireLock_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi"), 0755))
+
+	const numGoroutines = 10
+	var wg stdsync.WaitGroup
+	var mu stdsync.Mutex
+	var acquiredLocks []*SyncLock
+	var lockedErrors int
+
+	start := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			lock, err := AcquireLock(dir)
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				acquiredLocks = append(acquiredLocks, lock)
+			} else if errors.Is(err, ErrLocked) {
+				lockedErrors++
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Len(t, acquiredLocks, 1)
+	assert.Equal(t, numGoroutines-1, lockedErrors)
+
+	for _, l := range acquiredLocks {
+		require.NoError(t, l.Unlock())
+	}
+}
+
+func TestSyncLock_NilUnlock(t *testing.T) {
+	t.Parallel()
+
+	var l *SyncLock
+	assert.NoError(t, l.Unlock())
+}
+
+func TestSyncLock_UnlockIdempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi"), 0755))
+
+	lock, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	// First unlock
+	assert.NoError(t, lock.Unlock())
+
+	// Second unlock on the same instance should safely return nil
+	assert.NoError(t, lock.Unlock())
+}

--- a/internal/artifactsource/sync/synclock_unix.go
+++ b/internal/artifactsource/sync/synclock_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package sync
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// CLI source: cli/internal/workload/sync/synclock.go
+
+func lockFile(f *os.File) error {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+			return ErrLocked
+		}
+		return fmt.Errorf("acquire lock: %w", err)
+	}
+	return nil
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/artifactsource/sync/synclock_windows.go
+++ b/internal/artifactsource/sync/synclock_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package sync
+
+import (
+	"os"
+	"syscall"
+)
+
+// CLI source: cli/internal/workload/sync/synclock.go
+
+func lockFile(f *os.File) error {
+	err := syscall.LockFile(syscall.Handle(f.Fd()), 0, 0, 1, 0)
+	if err != nil {
+		return ErrLocked
+	}
+	return nil
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.UnlockFile(syscall.Handle(f.Fd()), 0, 0, 1, 0)
+}

--- a/internal/artifactsource/wapi/config.go
+++ b/internal/artifactsource/wapi/config.go
@@ -12,7 +12,7 @@ import (
 //
 // JSON field names match the CLI so a mixed CLI/TF tree can share .wapi/.
 // CLIVersion is the JSON key; Initialize writes ProviderWriter.
-// The Go field is still called CLIVersion because the JSON key is cliVersion. 
+// The Go field is still called CLIVersion because the JSON key is cliVersion.
 // We do not invent a providerVersion key. On init we store "terraform-provider-datarobot" in that field.
 
 const ProviderWriter = "terraform-provider-datarobot"


### PR DESCRIPTION
<!--
Branch: brunoromano-dr/RAPTOR-18364-sync-lock-rollback-three
Base:   brunoromano-dr/RAPTOR-18364-wapi-local-base-state
-->

## Summary
Port CLI `synclock.go` and `rollback.go` safety mechanisms into `internal/artifactsource/sync`. This adds exclusive process locking via `.wapi/sync.lock` and backup/restore capabilities under `.wapi/.rollback/` to guarantee working directory safety when artifact code sync mutates local files.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [x] test
- [ ] ci

## Details / User Impact
- **Sync Lock**: Implements non-blocking process file locking on `.wapi/sync.lock` (`AcquireLock`, `Unlock`) using cross-platform system calls (`flock` on Unix, `LockFile` on Windows) to prevent concurrent sync operations on the same directory.
- **Rollback Tree**: Implements `RollbackTree` under `.wapi/.rollback/` to back up modified/deleted files and track newly created files during sync execution.
- **Rollback Restoration & Stale Recovery**: Implements `Restore` / `RestoreRollback` to safely restore local files if a sync operation fails or if a stale `.rollback/` folder exists from a prior interrupted run.
- **Path Safety**: Enforces strict relative path validation on backup targets (rejecting `../` directory traversal, absolute paths, and `.wapi/` internal paths).
- Defines `RollbackMaxFiles = 1000` constant for plan file operation cap awareness.

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here: Internal `artifactsource` sync safety primitives; user-visible apply behavior and documentation will be wired in PR 10.

## Testing
Unit tests in `internal/artifactsource/sync`:
- `TestAcquireLock_Exclusivity` — verifies lock exclusivity and `ErrLocked` when held by another process.
- `TestAcquireLock_NotInitialized` — verifies error when `.wapi/` directory is missing.
- `TestRollback_BackupAndRestoreMutatedFile` — verifies backup and exact restoration of modified and newly created files.
- `TestRollback_StaleRestore` — verifies recovery of stale `.wapi/.rollback/` folder left by an interrupted process.
- `TestRollback_PathSafety` — verifies path validation rejecting `../`, absolute, and `.wapi/` paths.
- `TestRollback_Discard` — verifies cleanup of `.wapi/.rollback/`.

```bash
go test ./internal/artifactsource/sync/... -v -run 'TestAcquireLock|TestRollback|TestSyncLock'
```

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [x] All CI checks green
- [ ] Reviewers assigned / approved
- [x] Version impact considered (patch / minor / major)

## Additional Notes
- **Jira**: [RAPTOR-18364](https://datarobot.atlassian.net/browse/RAPTOR-18364)
- **Branch**: `brunoromano-dr/RAPTOR-18364-sync-lock-rollback-three` (stacked on `brunoromano-dr/RAPTOR-18364-wapi-local-base-state`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem lock and restore logic can overwrite or delete local project files; it is not yet wired into apply, but path handling and restore fallbacks are security-sensitive.
> 
> **Overview**
> Ports CLI sync safety primitives into `internal/artifactsource/sync`: exclusive locking on `.wapi/sync.lock` and a rollback tree under `.wapi/.rollback/` so later apply can undo local file mutations.
> 
> **Locking:** `AcquireLock` / `Unlock` use non-blocking exclusive locks (`flock` on Unix, `LockFile` on Windows) and return `ErrLocked` if another process holds the lock.
> 
> **Rollback:** `RollbackTree` copies existing files before mutation, tracks files that will be created, and restores or discards via a JSON manifest. Restore falls back to walking the rollback dir when the manifest is missing or corrupt. Backup paths reject absolute paths, `..` traversal, and anything under `.wapi/`.
> 
> These helpers are not wired into apply yet; `RollbackMaxFiles` is defined but unused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b4ac99f186b276c31157306cc840ab0d0b6c14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->