### PR TITLE
[RAPTOR 18364] Engine plan

### DIFF
--- a/internal/artifactsource/push.go
+++ b/internal/artifactsource/push.go
@@ -75,6 +75,17 @@ func canIncrementalPush(opts Options) bool {
 	return opts.CatalogID != "" && len(opts.BaseFiles) > 0
 }
 
+// CollectLocalFiles walks dir, applies ignore, and hashes every included
+// regular file. Exported for internal/artifactsource/sync's Engine, which
+// builds the three-way sync LOCAL manifest from the same walk+hash
+// primitives PushDirectory and FingerprintDirectory use. An empty (or
+// fully ignored) directory returns an empty slice rather than an error, so
+// Plan succeeds on a source.dir with no files yet.
+func CollectLocalFiles(dir string, ignore IgnoreFunc) ([]LocalFile, error) {
+	files, _, err := collectLocalFiles(dir, ignore, true)
+	return files, err
+}
+
 func collectLocalFiles(dir string, ignore IgnoreFunc, allowEmpty bool) ([]LocalFile, int64, error) {
 	entries, err := walkDirectory(dir, ignore)
 	if err != nil {

--- a/internal/artifactsource/sync/casecollision.go
+++ b/internal/artifactsource/sync/casecollision.go
@@ -1,0 +1,54 @@
+package sync
+
+// CLI source: cli/internal/workload/fileops/paths.go
+// (DetectCaseCollisions, FormatCaseCollisions). Ported as unexported
+// helpers since Engine.Plan is the only caller in this package.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// caseCollision groups paths that differ only in case — they would
+// silently overwrite each other on a case-insensitive filesystem (macOS,
+// Windows default).
+type caseCollision struct {
+	lowered string
+	paths   []string
+}
+
+// detectCaseCollisions returns groups of paths that collide under
+// case-insensitive comparison, sorted for deterministic error output.
+func detectCaseCollisions(paths map[string]struct{}) []caseCollision {
+	groups := make(map[string][]string, len(paths))
+	for p := range paths {
+		key := strings.ToLower(p)
+		groups[key] = append(groups[key], p)
+	}
+
+	var collisions []caseCollision
+	for key, ps := range groups {
+		if len(ps) < 2 {
+			continue
+		}
+		sort.Strings(ps)
+		collisions = append(collisions, caseCollision{lowered: key, paths: ps})
+	}
+
+	sort.Slice(collisions, func(i, j int) bool { return collisions[i].lowered < collisions[j].lowered })
+
+	return collisions
+}
+
+// formatCaseCollisions renders collisions as a multi-line error message.
+func formatCaseCollisions(cs []caseCollision) string {
+	var b strings.Builder
+
+	b.WriteString("case-only path collisions detected (would silently overwrite on a case-insensitive filesystem):\n")
+	for _, c := range cs {
+		fmt.Fprintf(&b, "  - %s\n", strings.Join(c.paths, " vs "))
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/artifactsource/sync/casecollision_test.go
+++ b/internal/artifactsource/sync/casecollision_test.go
@@ -1,0 +1,47 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func pathSet(paths ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+func TestDetectCaseCollisions_NoCollisions(t *testing.T) {
+	t.Parallel()
+
+	got := detectCaseCollisions(pathSet("agent.py", "utils/helper.py"))
+	assert.Empty(t, got)
+}
+
+func TestDetectCaseCollisions_SingleCollision(t *testing.T) {
+	t.Parallel()
+
+	got := detectCaseCollisions(pathSet("Config.yaml", "config.yaml"))
+	assert.Equal(t, []caseCollision{{lowered: "config.yaml", paths: []string{"Config.yaml", "config.yaml"}}}, got)
+}
+
+func TestDetectCaseCollisions_MultiCollision(t *testing.T) {
+	t.Parallel()
+
+	got := detectCaseCollisions(pathSet("a.py", "A.py", "b.py", "B.py"))
+	assert.Equal(t, []caseCollision{
+		{lowered: "a.py", paths: []string{"A.py", "a.py"}},
+		{lowered: "b.py", paths: []string{"B.py", "b.py"}},
+	}, got)
+}
+
+func TestFormatCaseCollisions_ListsEachGroup(t *testing.T) {
+	t.Parallel()
+
+	msg := formatCaseCollisions([]caseCollision{{lowered: "config.yaml", paths: []string{"Config.yaml", "config.yaml"}}})
+	assert.Contains(t, msg, "case-only path collisions")
+	assert.Contains(t, msg, "Config.yaml vs config.yaml")
+}

--- a/internal/artifactsource/sync/engine.go
+++ b/internal/artifactsource/sync/engine.go
@@ -1,0 +1,166 @@
+package sync
+
+// CLI source: cli/internal/workload/sync/engine.go
+//
+// Provider differences from CLI:
+//   - Plan only (phases 0-4, see phase.go). Execute (phases 5-6: downloads,
+//     conflict copies, uploads, remote deletes, persisting BASE) ships in a later PR.
+//   - No Options{DryRun, ShowDiffs, Yes}: terraform apply has no TTY and is
+//     always non-interactive, remote-wins-on-conflict (see the plan's
+//     "Non-interactive policy" section) — there is nothing to gate on yet
+//     since Plan never mutates anything.
+//   - ArtifactStore is a narrow interface over the caller's own artifact
+//     client (Locked/CatalogID/CatalogVersionID) instead of the CLI's
+//     workload.Artifact, so this package stays independent of
+//     internal/client. The resource adapts client.Artifact to it in a later PR.
+//   - Missing .wapi/ auto-initializes instead of erroring "not linked":
+//     there is no `dr workload code init` step in a Terraform-managed tree.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource/wapi"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+// ErrLockedArtifact is returned by Plan when the bound artifact is locked.
+// Locked artifacts are immutable; cloning to a new draft artifact remains
+// the resource's job before Plan runs again (mirrors CLI phase1_gather.go).
+var ErrLockedArtifact = errors.New("artifact is locked (immutable); cannot sync in place, clone to a draft first")
+
+// ArtifactInfo is the minimal artifact view Plan needs: whether the
+// artifact is locked, and its current code_ref (empty CatalogID /
+// CatalogVersionID before any code has ever been uploaded).
+type ArtifactInfo struct {
+	Locked           bool
+	CatalogID        string
+	CatalogVersionID string
+}
+
+// ArtifactStore fetches ArtifactInfo for the artifact backing this sync.
+// The resource adapts its own client.Artifact to this interface.
+type ArtifactStore interface {
+	Get(ctx context.Context, artifactID string) (ArtifactInfo, error)
+}
+
+// Engine runs the CLI three-way sync pipeline (BASE / LOCAL / REMOTE)
+// against a single source.dir. Construct with New, call Plan, then Close
+// to release the .wapi/sync.lock acquired during preflight.
+type Engine struct {
+	projectDir string
+	artifactID string
+	files      filesapi.Client
+	artifacts  ArtifactStore
+
+	config    wapi.Config
+	base      BaseManifest
+	local     LocalManifest
+	remote    RemoteManifest
+	catalogID string
+	remoteVer string
+	drifted   bool
+	plan      *SyncPlan
+	lock      *SyncLock
+	staleNote bool
+}
+
+// New constructs an Engine bound to projectDir. artifactID seeds .wapi/ on
+// the very first Plan call, when no .wapi/config.json exists yet; once
+// initialized, later Plan calls trust config.json's own ArtifactID.
+func New(projectDir, artifactID string, files filesapi.Client, artifacts ArtifactStore) (*Engine, error) {
+	if projectDir == "" {
+		return nil, errors.New("sync.New: projectDir is required")
+	}
+	if artifactID == "" {
+		return nil, errors.New("sync.New: artifactID is required")
+	}
+	if files == nil {
+		return nil, errors.New("sync.New: files API client is required")
+	}
+	if artifacts == nil {
+		return nil, errors.New("sync.New: artifact store is required")
+	}
+
+	return &Engine{
+		projectDir: projectDir,
+		artifactID: artifactID,
+		files:      files,
+		artifacts:  artifacts,
+	}, nil
+}
+
+// Plan runs phases 0-4 (preflight, gather, manifests, diff, sort) and
+// returns the resulting SyncPlan without mutating the remote catalog or
+// the local working tree (beyond acquiring the lock / recovering a stale
+// rollback). The lock is held until Close releases it.
+func (e *Engine) Plan(ctx context.Context) (*SyncPlan, error) {
+	if err := e.preflight(); err != nil {
+		return nil, e.joinReleaseErr(err)
+	}
+	if err := e.gather(ctx); err != nil {
+		return nil, e.joinReleaseErr(err)
+	}
+	if err := e.buildManifests(ctx); err != nil {
+		return nil, e.joinReleaseErr(err)
+	}
+
+	plan := Diff(e.base, e.local, e.remote)
+	plan.OldVersionShort = ShortVer(ptrOrEmpty(e.config.LastSyncedVersionID))
+	plan.Sort()
+	e.plan = plan
+
+	return plan, nil
+}
+
+// StaleRollbackRestored reports whether preflight restored a stale
+// .wapi/.rollback/ tree left by a previously interrupted sync.
+func (e *Engine) StaleRollbackRestored() bool { return e.staleNote }
+
+// Close releases the sync lock. Idempotent; safe to call even if Plan
+// never ran or returned an error (which already releases the lock).
+func (e *Engine) Close() error {
+	return e.releaseLock()
+}
+
+func (e *Engine) releaseLock() error {
+	if e.lock == nil {
+		return nil
+	}
+
+	err := e.lock.Unlock()
+	e.lock = nil
+
+	return err
+}
+
+// joinReleaseErr releases the lock and joins any release failure with err
+// so a caller sees both instead of silently losing the lock error.
+func (e *Engine) joinReleaseErr(err error) error {
+	if relErr := e.releaseLock(); relErr != nil {
+		return errors.Join(err, fmt.Errorf("release lock: %w", relErr))
+	}
+
+	return err
+}
+
+func ptrOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
+}
+
+// ShortVer truncates a hex version ID to 8 chars for display.
+// CLI source: cli/internal/workload/sync/phase3_diff.go.
+func ShortVer(s string) string {
+	const shortLen = 8
+
+	if len(s) > shortLen {
+		return s[:shortLen]
+	}
+
+	return s
+}

--- a/internal/artifactsource/sync/engine_test.go
+++ b/internal/artifactsource/sync/engine_test.go
@@ -1,0 +1,547 @@
+package sync
+
+// CLI source: cli/internal/workload/sync/engine_test.go — scenarios ported
+// (fast path / drift / first sync / locked artifact); fakes rewritten
+// against this package's ArtifactStore/filesapi.Client instead of CLI's
+// workload.Artifact / cli/internal/drapi/filesapi.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource/wapi"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeArtifactStore is the in-memory ArtifactStore used by engine tests.
+type fakeArtifactStore struct {
+	GetFn func(ctx context.Context, artifactID string) (ArtifactInfo, error)
+}
+
+func (f *fakeArtifactStore) Get(ctx context.Context, artifactID string) (ArtifactInfo, error) {
+	if f.GetFn == nil {
+		return ArtifactInfo{}, errors.New("fakeArtifactStore.Get: no GetFn configured")
+	}
+	return f.GetFn(ctx, artifactID)
+}
+
+// fakeFilesAPI is the in-memory filesapi.Client fake used by engine
+// tests. Unexpected methods error loudly so off-happy-path drift fails
+// tests instead of silently returning zero values.
+type fakeFilesAPI struct {
+	allFiles       map[string]filesapi.FileMeta
+	allFilesErr    error
+	allFilesCalled bool
+	lastCatalogID  string
+	lastVersionID  string
+}
+
+func (f *fakeFilesAPI) CreateCatalog(context.Context) (*filesapi.CatalogResp, error) {
+	return nil, errors.New("fakeFilesAPI: CreateCatalog not expected")
+}
+
+func (f *fakeFilesAPI) CreateStage(context.Context, string) (*filesapi.StageResp, error) {
+	return nil, errors.New("fakeFilesAPI: CreateStage not expected")
+}
+
+func (f *fakeFilesAPI) UploadToStage(context.Context, string, string, string, int64, io.Reader) error {
+	return errors.New("fakeFilesAPI: UploadToStage not expected")
+}
+
+func (f *fakeFilesAPI) ApplyStage(context.Context, string, string, string) (*filesapi.ApplyStageResp, error) {
+	return nil, errors.New("fakeFilesAPI: ApplyStage not expected")
+}
+
+func (f *fakeFilesAPI) UploadFromZipNew(context.Context, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	return nil, errors.New("fakeFilesAPI: UploadFromZipNew not expected")
+}
+
+func (f *fakeFilesAPI) UploadFromZipExisting(context.Context, string, string, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	return nil, errors.New("fakeFilesAPI: UploadFromZipExisting not expected")
+}
+
+func (f *fakeFilesAPI) PollStatus(context.Context, string) (*filesapi.StatusResp, error) {
+	return nil, errors.New("fakeFilesAPI: PollStatus not expected")
+}
+
+func (f *fakeFilesAPI) AllFiles(_ context.Context, catalogID, versionID string) (map[string]filesapi.FileMeta, error) {
+	f.allFilesCalled = true
+	f.lastCatalogID = catalogID
+	f.lastVersionID = versionID
+	if f.allFilesErr != nil {
+		return nil, f.allFilesErr
+	}
+	return f.allFiles, nil
+}
+
+func (f *fakeFilesAPI) DownloadFile(context.Context, string, string, string, io.Writer) (string, int64, error) {
+	return "", 0, errors.New("fakeFilesAPI: DownloadFile not expected")
+}
+
+func (f *fakeFilesAPI) DeleteFiles(context.Context, string, []string) (*filesapi.DeleteFilesResp, error) {
+	return nil, errors.New("fakeFilesAPI: DeleteFiles not expected")
+}
+
+func (f *fakeFilesAPI) ListVersions(context.Context, string, int) ([]filesapi.CatalogVersion, error) {
+	return nil, errors.New("fakeFilesAPI: ListVersions not expected")
+}
+
+func writeProjectFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+}
+
+func hashContent(body string) (string, int64) {
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:]), int64(len(body))
+}
+
+func draftInfo(catalogID, versionID string) ArtifactInfo {
+	return ArtifactInfo{CatalogID: catalogID, CatalogVersionID: versionID}
+}
+
+func TestEngine_New_ValidatesArgs(t *testing.T) {
+	t.Parallel()
+
+	_, err := New("", "art-1", &fakeFilesAPI{}, &fakeArtifactStore{})
+	assert.ErrorContains(t, err, "projectDir")
+
+	_, err = New(t.TempDir(), "", &fakeFilesAPI{}, &fakeArtifactStore{})
+	assert.ErrorContains(t, err, "artifactID")
+
+	_, err = New(t.TempDir(), "art-1", nil, &fakeArtifactStore{})
+	assert.ErrorContains(t, err, "files API")
+
+	_, err = New(t.TempDir(), "art-1", &fakeFilesAPI{}, nil)
+	assert.ErrorContains(t, err, "artifact store")
+}
+
+func TestEngine_Plan_AutoInitsWapiWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "print('hi')\n"})
+
+	assert.False(t, wapi.Exists(dir))
+
+	e, err := New(dir, "art-abc-123", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	_, err = e.Plan(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, wapi.Exists(dir))
+
+	cfg, err := wapi.LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "art-abc-123", cfg.ArtifactID)
+}
+
+func TestEngine_Plan_FirstSyncEmptyRemote(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{
+		"agent.py":        "print('hi')\n",
+		"utils/helper.py": "def help(): pass\n",
+	})
+
+	files := &fakeFilesAPI{}
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+
+	uploadPaths := make([]string, 0, len(plan.Uploads))
+	for _, fa := range plan.Uploads {
+		uploadPaths = append(uploadPaths, fa.Path)
+	}
+	assert.ElementsMatch(t, []string{"agent.py", "utils/helper.py"}, uploadPaths)
+	assert.Empty(t, plan.Downloads)
+	assert.Empty(t, plan.Deletes)
+	assert.Empty(t, plan.Conflicts)
+	assert.False(t, files.allFilesCalled, "AllFiles must not be called when remote catalog version is empty")
+}
+
+func TestEngine_Plan_EmptyWhenNotDrifted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-1",
+		LastSyncedVersionID: "ver-1",
+	}))
+
+	hash, size := hashContent("x")
+	require.NoError(t, wapi.SaveManifest(dir, wapi.Manifest{
+		Version: wapi.ManifestVersion,
+		Files:   map[string]wapi.FileMeta{"agent.py": {Hash: hash, Size: size}},
+	}))
+
+	files := &fakeFilesAPI{}
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("cat-1", "ver-1"), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+	assert.True(t, plan.IsEmpty(), "plan should be empty when local == base == remote: %+v", plan)
+	assert.False(t, files.allFilesCalled, "AllFiles must not be called when not drifted")
+	assert.Equal(t, "ver-1", plan.OldVersionShort)
+}
+
+func TestEngine_Plan_DriftedFetchesAllFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "local content"})
+
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-1",
+		LastSyncedVersionID: "ver-1",
+	}))
+
+	baseHash, baseSize := hashContent("base content")
+	require.NoError(t, wapi.SaveManifest(dir, wapi.Manifest{
+		Version: wapi.ManifestVersion,
+		Files:   map[string]wapi.FileMeta{"agent.py": {Hash: baseHash, Size: baseSize}},
+	}))
+
+	// Remote moved on to ver-2 without us: drifted, so Plan must call
+	// AllFiles(ver-2) instead of reusing BASE.
+	remoteHash, remoteSize := hashContent("remote content")
+	files := &fakeFilesAPI{allFiles: map[string]filesapi.FileMeta{
+		"agent.py":     {Hash: remoteHash, Size: remoteSize},
+		"new-file.txt": {Hash: "aaa", Size: 3},
+	}}
+
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("cat-1", "ver-2"), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+	assert.True(t, files.allFilesCalled, "AllFiles must be called when drifted")
+
+	require.True(t, plan.HasConflicts())
+	assert.Equal(t, "agent.py", plan.Conflicts[0].Path, "local and remote both changed agent.py from BASE")
+
+	require.Len(t, plan.Downloads, 1)
+	assert.Equal(t, "new-file.txt", plan.Downloads[0].Path)
+}
+
+func TestEngine_Plan_IgnoredFilesAbsentFromLocal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{
+		"agent.py":        "print('hi')\n",
+		".venv/site.py":   "should be ignored\n",
+		".datarobot.yaml": "spec: {}\n",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".drignore"), []byte(".venv\n"), 0o644))
+
+	e, err := New(dir, "art-1", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+
+	uploadPaths := make([]string, 0, len(plan.Uploads))
+	for _, fa := range plan.Uploads {
+		uploadPaths = append(uploadPaths, fa.Path)
+	}
+	// .venv is excluded by the user's .drignore; .datarobot.yaml is a
+	// hardcoded system exclude regardless of .drignore contents.
+	assert.ElementsMatch(t, []string{"agent.py", ".drignore"}, uploadPaths)
+}
+
+func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	e, err := New(dir, "art-1", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) {
+			return ArtifactInfo{Locked: true}, nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	_, err = e.Plan(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLockedArtifact)
+	assert.Contains(t, err.Error(), "locked")
+
+	// The lock must be released so a later Plan (after the resource
+	// clones to a draft) is not blocked by this failed attempt.
+	assert.NoError(t, e.Close())
+}
+
+func TestEngine_Plan_AllFilesErrorReleasesLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-1",
+		LastSyncedVersionID: "ver-1",
+	}))
+
+	files := &fakeFilesAPI{allFilesErr: errors.New("boom")}
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("cat-1", "ver-2"), nil },
+	})
+	require.NoError(t, err)
+
+	_, err = e.Plan(context.Background())
+	require.ErrorContains(t, err, "boom")
+
+	// A second Engine must be able to acquire the lock immediately: the
+	// failed Plan above must have released it.
+	e2, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("cat-1", "ver-2"), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e2.Close() })
+
+	lock, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NoError(t, lock.Unlock())
+}
+
+func TestEngine_Plan_FetchArtifactErrorReleasesLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	e, err := New(dir, "art-1", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) {
+			return ArtifactInfo{}, errors.New("network down")
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = e.Plan(context.Background())
+	require.ErrorContains(t, err, "network down")
+
+	// A fetch failure in gather (phase 1) must still release the lock
+	// acquired during preflight (phase 0), same as an AllFiles failure in
+	// manifests (phase 2, covered above).
+	lock, err := AcquireLock(dir)
+	require.NoError(t, err)
+	require.NoError(t, lock.Unlock())
+}
+
+func TestEngine_Plan_LockContentionAcrossEngines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	artifacts := &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	}
+
+	e1, err := New(dir, "art-1", &fakeFilesAPI{}, artifacts)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e1.Close() })
+
+	_, err = e1.Plan(context.Background())
+	require.NoError(t, err) // e1 now holds .wapi/sync.lock and never closes it
+
+	e2, err := New(dir, "art-1", &fakeFilesAPI{}, artifacts)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e2.Close() })
+
+	// A second Engine (e.g. a concurrent apply, or a retry that
+	// constructed a fresh Engine after a prior one leaked its lock) must
+	// not be able to plan while e1 still holds the lock.
+	_, err = e2.Plan(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLocked)
+
+	require.NoError(t, e1.Close())
+
+	// Once e1 releases, e2 (or a third Engine) can proceed.
+	_, err = e2.Plan(context.Background())
+	require.NoError(t, err)
+}
+
+func TestEngine_Plan_RecoversStaleRollback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-1"}))
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "original content\n"})
+
+	// Simulate a sync that crashed mid-execute: it backed up agent.py
+	// before mutating it, but never reached Restore/Discard.
+	rt := NewRollbackTree(dir)
+	require.NoError(t, rt.Init())
+	require.NoError(t, rt.Backup("agent.py"))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.py"), []byte("mid-sync-mutation\n"), 0o644))
+	require.True(t, HasRollback(dir))
+
+	e, err := New(dir, "art-1", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	_, err = e.Plan(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, e.StaleRollbackRestored())
+	assert.False(t, HasRollback(dir), "preflight must remove .wapi/.rollback/ after restoring it")
+
+	restored, err := os.ReadFile(filepath.Join(dir, "agent.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "original content\n", string(restored), "phase0 must restore the pre-crash content")
+}
+
+func TestEngine_Plan_NoStaleRollbackToRestore(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	e, err := New(dir, "art-1", &fakeFilesAPI{}, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("", ""), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	_, err = e.Plan(context.Background())
+	require.NoError(t, err)
+	assert.False(t, e.StaleRollbackRestored())
+}
+
+func TestEngine_Plan_ConfigCatalogIDWinsOverArtifactCatalogID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{"agent.py": "x"})
+
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-config",
+		LastSyncedVersionID: "ver-1",
+	}))
+
+	hash, size := hashContent("x")
+	require.NoError(t, wapi.SaveManifest(dir, wapi.Manifest{
+		Version: wapi.ManifestVersion,
+		Files:   map[string]wapi.FileMeta{"agent.py": {Hash: hash, Size: size}},
+	}))
+
+	files := &fakeFilesAPI{allFiles: map[string]filesapi.FileMeta{"agent.py": {Hash: hash, Size: size}}}
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) {
+			// The artifact's live code_ref reports a different catalog
+			// than the one pinned in .wapi/config.json; config must win
+			// (it stays pinned for the artifact's draft lifetime).
+			return draftInfo("cat-other-live", "ver-2"), nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	_, err = e.Plan(context.Background())
+	require.NoError(t, err)
+
+	require.True(t, files.allFilesCalled)
+	assert.Equal(t, "cat-config", files.lastCatalogID)
+	assert.Equal(t, "ver-2", files.lastVersionID)
+}
+
+func TestEngine_Plan_LocalAndRemoteDeletesDetected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeProjectFiles(t, dir, map[string]string{
+		"keep.py":           "keep",
+		"remote-deleted.py": "still-here-locally",
+	})
+
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{
+		ArtifactID:          "art-1",
+		CatalogID:           "cat-1",
+		LastSyncedVersionID: "ver-1",
+	}))
+
+	keepHash, keepSize := hashContent("keep")
+	remoteDeletedHash, remoteDeletedSize := hashContent("still-here-locally")
+	localDeletedHash, localDeletedSize := hashContent("was-here-in-base")
+
+	require.NoError(t, wapi.SaveManifest(dir, wapi.Manifest{
+		Version: wapi.ManifestVersion,
+		Files: map[string]wapi.FileMeta{
+			"keep.py":           {Hash: keepHash, Size: keepSize},
+			"remote-deleted.py": {Hash: remoteDeletedHash, Size: remoteDeletedSize},
+			"local-deleted.py":  {Hash: localDeletedHash, Size: localDeletedSize},
+		},
+	}))
+
+	// Drifted remote manifest: local-deleted.py is still there remotely
+	// (matches BASE, so it downloads-over-delete... no: local removed it
+	// and remote didn't touch it -> LOCAL_DELETED); remote-deleted.py is
+	// gone remotely while local left it untouched -> REMOTE_DELETED.
+	files := &fakeFilesAPI{allFiles: map[string]filesapi.FileMeta{
+		"keep.py":          {Hash: keepHash, Size: keepSize},
+		"local-deleted.py": {Hash: localDeletedHash, Size: localDeletedSize},
+	}}
+
+	e, err := New(dir, "art-1", files, &fakeArtifactStore{
+		GetFn: func(context.Context, string) (ArtifactInfo, error) { return draftInfo("cat-1", "ver-2"), nil },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+
+	deletePaths := make([]string, 0, len(plan.Deletes))
+	for _, fa := range plan.Deletes {
+		deletePaths = append(deletePaths, fa.Path)
+	}
+	assert.ElementsMatch(t, []string{"local-deleted.py", "remote-deleted.py"}, deletePaths)
+	assert.Empty(t, plan.Uploads)
+	assert.Empty(t, plan.Conflicts)
+	assert.Empty(t, plan.Downloads)
+}

--- a/internal/artifactsource/sync/phase.go
+++ b/internal/artifactsource/sync/phase.go
@@ -1,0 +1,149 @@
+package sync
+
+// CLI source: cli/internal/workload/sync/phase0_preflight.go,
+// phase1_gather.go, phase2_manifests.go.
+//
+// Provider differences from CLI: phase0 auto-initializes .wapi/ instead
+// of failing with "not linked" (see engine.go doc comment); phase1/phase2
+// read from ArtifactInfo/filesapi.Client instead of workload.Artifact /
+// cli/internal/drapi/filesapi.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource/ignore"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/artifactsource/wapi"
+	"github.com/datarobot-community/terraform-provider-datarobot/internal/client/filesapi"
+)
+
+// preflight (phase 0) recovers a stale rollback tree left by a crashed
+// prior sync, auto-initializes .wapi/ on the very first Plan call, and
+// acquires the exclusive sync lock. Recovery runs before the lock so a
+// crashed-mid-sync process gets cleaned up by whoever runs next.
+func (e *Engine) preflight() error {
+	restored := HasRollback(e.projectDir)
+	if err := RestoreRollback(e.projectDir); err != nil {
+		return fmt.Errorf("recover stale rollback: %w", err)
+	}
+	e.staleNote = restored
+
+	if !wapi.Exists(e.projectDir) {
+		if err := wapi.Initialize(e.projectDir, wapi.InitOptions{ArtifactID: e.artifactID}); err != nil {
+			return fmt.Errorf("auto-init .wapi/: %w", err)
+		}
+	}
+
+	lock, err := AcquireLock(e.projectDir)
+	if err != nil {
+		return err
+	}
+	e.lock = lock
+
+	return nil
+}
+
+// gather (phase 1) loads on-disk .wapi/ state, fetches the artifact, and
+// computes the drift flag phase2 uses to decide whether to call AllFiles.
+func (e *Engine) gather(ctx context.Context) error {
+	cfg, err := wapi.LoadConfig(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("read .wapi/config.json: %w", err)
+	}
+	e.config = cfg
+
+	manifest, err := wapi.LoadManifest(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("read .wapi/manifest.json: %w", err)
+	}
+	e.base = baseFromManifest(manifest)
+
+	info, err := e.artifacts.Get(ctx, cfg.ArtifactID)
+	if err != nil {
+		return fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
+	}
+	if info.Locked {
+		return ErrLockedArtifact
+	}
+
+	// Config's catalog ID is pinned for the artifact's draft lifetime and
+	// wins over the artifact's live code_ref, which may have been bumped
+	// by another writer.
+	e.catalogID = info.CatalogID
+	if cfg.CatalogID != nil && *cfg.CatalogID != "" {
+		e.catalogID = *cfg.CatalogID
+	}
+	e.remoteVer = info.CatalogVersionID
+	e.drifted = e.remoteVer != "" && e.remoteVer != ptrOrEmpty(cfg.LastSyncedVersionID)
+
+	return nil
+}
+
+// buildManifests (phase 2) walks + hashes source.dir into LOCAL, then
+// either fast-paths REMOTE from BASE (not drifted — the solo-developer
+// path) or fetches it from the Files API (drifted).
+func (e *Engine) buildManifests(ctx context.Context) error {
+	matcher, err := ignore.New(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("load ignore rules: %w", err)
+	}
+
+	files, err := artifactsource.CollectLocalFiles(e.projectDir, matcher.Match)
+	if err != nil {
+		return fmt.Errorf("walk project directory: %w", err)
+	}
+
+	local := make(LocalManifest, len(files))
+	paths := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		local[f.RelPath] = FileEntry{Hash: f.Hash, Size: f.Size}
+		paths[f.RelPath] = struct{}{}
+	}
+	e.local = local
+
+	if collisions := detectCaseCollisions(paths); len(collisions) > 0 {
+		return errors.New(formatCaseCollisions(collisions))
+	}
+
+	if !e.drifted {
+		e.remote = copyManifest(e.base)
+		return nil
+	}
+
+	remote, err := e.files.AllFiles(ctx, e.catalogID, e.remoteVer)
+	if err != nil {
+		return fmt.Errorf("fetch remote manifest: %w", err)
+	}
+	e.remote = fromFilesAPI(remote)
+
+	return nil
+}
+
+func baseFromManifest(m wapi.Manifest) BaseManifest {
+	out := make(BaseManifest, len(m.Files))
+	for k, v := range m.Files {
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+	}
+
+	return out
+}
+
+func copyManifest(in BaseManifest) BaseManifest {
+	out := make(BaseManifest, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+func fromFilesAPI(in map[string]filesapi.FileMeta) RemoteManifest {
+	out := make(RemoteManifest, len(in))
+	for k, v := range in {
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+	}
+
+	return out
+}


### PR DESCRIPTION
<!--
Branch: brunoromano-dr/RAPTOR-18364-engine-plan
Base:   brunoromano-dr/RAPTOR-18364-sync-lock-rollback-three
-->

## Summary
Add the CLI three-way sync `Engine`'s `Plan` phases (0-4: preflight, gather, manifests, diff, sort) to `internal/artifactsource/sync`. `Engine.Plan` builds a `SyncPlan` from `.wapi/` BASE, the local `source.dir` walk, and (only when the remote catalog version has drifted) the Files API `AllFiles` manifest — without mutating the remote catalog or the local working tree beyond acquiring the sync lock and recovering a stale rollback. Execute (phases 5-6: downloads, conflict copies, uploads, remote deletes, persisting BASE) ships in later prs; wiring this into `datarobot_artifact` ships last.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [x] test
- [ ] ci

## Details / User Impact
No user-visible behavior yet — `Engine` is not wired into `datarobot_artifact` until last PR. This PR is purely internal `artifactsource/sync` plumbing:
- **`Engine`** (`engine.go`) wires the pipeline: `New(projectDir, artifactID, files, artifacts)` constructs it; `Plan(ctx)` runs preflight → gather → manifests → diff → sort and returns a `*SyncPlan`; `Close()` releases the `.wapi/sync.lock` acquired during preflight (idempotent, safe after a failed `Plan`, which already releases the lock via `joinReleaseErr`).
- **`ArtifactStore`** is a narrow interface (`Get(ctx, artifactID) (ArtifactInfo, error)`) over the caller's own artifact client instead of a concrete `client.Artifact`, so `internal/artifactsource/sync` stays independent of `internal/client`. The resource will adapt `client.Artifact` to this interface in a later PR.
- **Preflight (phase 0, `phase.go`)**: recovers a stale `.wapi/.rollback/` tree from a previously crashed sync (reusing  `HasRollback`/`RestoreRollback`), then acquires `.wapi/sync.lock` (`AcquireLock`). Unlike the CLI, a missing `.wapi/` **auto-initializes** via `wapi.Initialize` instead of erroring "not linked" — Terraform has no `dr workload code init` step, so the first `Plan` call against a fresh `source.dir` links it using the artifact ID passed to `New`.
- **Gather (phase 1, `phase.go`)**: loads `.wapi/config.json` + `manifest.json` (BASE), fetches `ArtifactInfo` for the bound artifact, and rejects with `ErrLockedArtifact` when the artifact is locked (cloning to a draft remains the resource's job, per the existing `artifactLockedSourceCloneNeeded` flow). Resolves which catalog ID to compare against — `.wapi/config.json`'s pinned `CatalogID` wins over the artifact's live one, since the artifact's code_ref reporting a *different* catalog is not normal drift (that would mean the local BASE is anchored to a catalog we're no longer tracking) — and computes the `drifted` flag from the artifact's live `CatalogVersionID` vs. `.wapi/`'s `LastSyncedVersionID`.
- **Manifests (phase 2, `phase.go`)**: walks and hashes `source.dir` into LOCAL via the exported `artifactsource.CollectLocalFiles` (new thin wrapper around the existing `collectLocalFiles`/`walkDirectory`/`hashFile`, reused as-is — no new walk/hash logic) combined with the `.drignore` matcher. Rejects case-only path collisions (ported from CLI `fileops.DetectCaseCollisions`, kept as unexported helpers in `casecollision.go` since only `Plan` calls them). REMOTE is either copied from BASE (not drifted — the fast path) or fetched via `filesapi.Client.AllFiles` (drifted); first sync against an empty artifact falls out of the same not-drifted fast path since an empty `CatalogVersionID` can't be "drifted", so BASE (empty) is reused with no network call.
- **Diff + sort (phases 3-4)**: calls the existing `Diff(base, local, remote)`, stamps `SyncPlan.OldVersionShort` (new `ShortVer` helper, 8-char prefix), and sorts.
- `internal/artifactsource.CollectLocalFiles` is the only change outside the `sync` package: an exported wrapper around the already-private `collectLocalFiles(dir, ignore, allowEmpty=true)` so the Engine reuses the exact same walk+hash code path as `PushDirectory`/`FingerprintDirectory` instead of duplicating it.

## CHANGELOG
- [ ] Added an entry under Unreleased in CHANGELOG.md
- [x] Not needed (label `skip changelog` applied and no user impact)
If skipped, justify here: Internal `artifactsource/sync` planning engine; not wired into `datarobot_artifact` until last, which will carry the CHANGELOG entry for the user-visible apply behavior.

## Testing
Unit tests in `internal/artifactsource/sync` (`engine_test.go`, `casecollision_test.go`):
- `TestEngine_New_ValidatesArgs` — `projectDir` / `artifactID` / files client / artifact store are all required.
- `TestEngine_Plan_AutoInitsWapiWhenMissing` — first `Plan` against a `source.dir` with no `.wapi/` creates it, bound to the given artifact ID.
- `TestEngine_Plan_FirstSyncEmptyRemote` — brand-new artifact (no catalog yet): every local file plans as an upload, `AllFiles` is never called.
- `TestEngine_Plan_EmptyWhenNotDrifted` — BASE == LOCAL == REMOTE and the artifact's live catalog version matches `.wapi/`'s `LastSyncedVersionID`: empty plan, `AllFiles` not called (fast path).
- `TestEngine_Plan_DriftedFetchesAllFiles` — artifact's live catalog version differs from `.wapi/`'s `LastSyncedVersionID`: `AllFiles` is called and its result drives the diff (asserts both a conflict and a remote-added download).
- `TestEngine_Plan_IgnoredFilesAbsentFromLocal` — `.drignore`-matched and system-excluded (`.datarobot.yaml`) files never enter the LOCAL manifest or the plan.
- `TestEngine_Plan_LockedArtifactRejected` — `Plan` returns `ErrLockedArtifact` and still releases the lock.
- `TestEngine_Plan_AllFilesErrorReleasesLock` — a Files API failure during manifests (phase 2) still releases `.wapi/sync.lock` so a subsequent `Plan` isn't blocked.
- `TestEngine_Plan_FetchArtifactErrorReleasesLock` — same guarantee for an `ArtifactStore.Get` failure during gather (phase 1).
- `TestEngine_Plan_LockContentionAcrossEngines` — a second `Engine` on the same `source.dir` gets `ErrLocked` while the first still holds `.wapi/sync.lock`, and can proceed once the first `Close()`s.
- `TestEngine_Plan_RecoversStaleRollback` / `TestEngine_Plan_NoStaleRollbackToRestore` — preflight restores a `.wapi/.rollback/` tree left by a crashed prior sync (built via `NewRollbackTree`/`Backup`) and reports it via `StaleRollbackRestored()`; the negative case reports `false` on a normal run.
- `TestEngine_Plan_ConfigCatalogIDWinsOverArtifactCatalogID` — when `.wapi/config.json`'s pinned `CatalogID` differs from the artifact's live one, `AllFiles` is called with the *config's* catalog ID, not the artifact's.
- `TestEngine_Plan_LocalAndRemoteDeletesDetected` — a drifted plan with one file deleted locally and a different file deleted remotely puts both in `plan.Deletes` (delete classifications had no prior end-to-end coverage through `Plan`).
- `TestDetectCaseCollisions_*` / `TestFormatCaseCollisions_ListsEachGroup` — case-only collision detection ported from CLI `fileops.DetectCaseCollisions`, tested as a pure function (not through real on-disk files, which would collide for real on this repo's case-insensitive dev filesystem).

```bash
go test ./internal/artifactsource/sync/... -v -run TestEngine
go test ./internal/artifactsource/... -v -run 'TestEngine|TestDetectCaseCollisions|TestFormatCaseCollisions'
go build ./...
golangci-lint run ./internal/artifactsource/...
```
Note: `go test ./...` in this environment also reports pre-existing failures in `pkg/provider` (`TestAcc*` data source tests hitting the live DataRobot API, and one `workload_resource_test.go` mock-expectation gap) unrelated to this change — no file under `pkg/provider` was touched.

## Release Preparation Checklist
Complete if this should go into next release:
- [ ] CHANGELOG updated
- [x] All CI checks green
- [ ] Reviewers assigned / approved
- [x] Version impact considered (patch / minor / major)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

Not expected for this PR: internal-only change, not on its own worth a release (see CHANGELOG note above).

## Additional Notes
- **Jira**: [RAPTOR-18364](https://datarobot.atlassian.net/browse/RAPTOR-18364)
- **Branch**: `brunoromano-dr/RAPTOR-18364-engine-plan` (stacked on `brunoromano-dr/RAPTOR-18364-sync-lock-rollback-three`).
- Ported with CLI source-file comments per the plan's "Hard rules for every PR", pointing to `cli/internal/workload/sync/engine.go`, `phase0_preflight.go`, `phase1_gather.go`, `phase2_manifests.go`, `phase3_diff.go`, `phase4_preview.go`, and `cli/internal/workload/fileops/paths.go`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal planning-only code not wired to the provider yet; changes are isolated under `artifactsource/sync` with extensive unit tests and no remote or working-tree mutations during Plan.
> 
> **Overview**
> Introduces an internal **three-way sync `Engine`** in `internal/artifactsource/sync` that runs **plan-only** phases 0–4 (preflight → gather → manifests → diff/sort) and returns a `SyncPlan` without applying uploads, downloads, or remote deletes. **Execute** and Terraform resource wiring are explicitly deferred.
> 
> **`Engine.Plan`** acquires `.wapi/sync.lock`, can recover a stale `.wapi/.rollback/` tree, and **auto-initializes `.wapi/`** on first use (unlike the CLI’s “not linked” error). It loads BASE from `.wapi/`, walks `source.dir` into LOCAL via newly exported **`artifactsource.CollectLocalFiles`** (same walk/hash as push/fingerprint, allows empty dirs), and builds REMOTE from BASE when the artifact catalog version matches `LastSyncedVersionID`, otherwise via **`AllFiles`**. Locked artifacts fail with **`ErrLockedArtifact`**; pinned **`.wapi` catalog ID** wins over the artifact’s live `code_ref`. **Case-only path collisions** are rejected with ported CLI helpers.
> 
> An **`ArtifactStore`** interface decouples the package from `internal/client`. Failed plans release the lock via **`joinReleaseErr`**; **`Close`** is idempotent. Broad unit coverage includes drift, first sync, ignore rules, lock contention, and catalog ID pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdea13c3a03784c13769c8cd6fffc5275194f52c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->