### PR TITLE
[RAPTOR 19616] Param routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - `datarobot_artifact` now streams artifact image build OTEL logs to the provider's stderr while waiting for a source-triggered image build to complete (`source.wait_for_build = true`, the default). Terraform routes provider stderr through its own logging pipeline, so this progress output is visible when `TF_LOG` is set (e.g. `TF_LOG=DEBUG`), not on a plain `terraform apply`. On failure, the apply error always includes a tailed excerpt of build logs (WAPI build logs with OTEL fallback) and a link to the full build log page in the DataRobot UI, regardless of `TF_LOG`. Default tail length is 30 lines; override with `DATAROBOT_ARTIFACT_BUILD_LOGS_TAIL_LINES`.
 - `DATAROBOT_DEBUG` environment variable to opt into verbose HTTP request/response dumps and curl reproductions in error messages.
 - `examples/resources/datarobot_workload` example: end-to-end code-to-workload flow (`datarobot_artifact` with `source` + build wait → `datarobot_workload`).
-- `routes` attribute on `datarobot_artifact` container specs (primary containers only): a list of `{ path, auth }` objects exposing additional paths from the workload's public endpoint with per-route authentication (`required`, `optional`, or `disabled`), for example `path = "/.well-known/oauth-authorization-server"` with `auth = "disabled"` for an MCP server's OAuth discovery document.
+- `routes` attribute on `datarobot_artifact` container specs (primary containers only): a list of `{ path, auth }` objects exposing additional paths from the workload's public endpoint with per-route authentication (`required`, `optional`, or `disabled`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `datarobot_artifact` now streams artifact image build OTEL logs to the provider's stderr while waiting for a source-triggered image build to complete (`source.wait_for_build = true`, the default). Terraform routes provider stderr through its own logging pipeline, so this progress output is visible when `TF_LOG` is set (e.g. `TF_LOG=DEBUG`), not on a plain `terraform apply`. On failure, the apply error always includes a tailed excerpt of build logs (WAPI build logs with OTEL fallback) and a link to the full build log page in the DataRobot UI, regardless of `TF_LOG`. Default tail length is 30 lines; override with `DATAROBOT_ARTIFACT_BUILD_LOGS_TAIL_LINES`.
 - `DATAROBOT_DEBUG` environment variable to opt into verbose HTTP request/response dumps and curl reproductions in error messages.
 - `examples/resources/datarobot_workload` example: end-to-end code-to-workload flow (`datarobot_artifact` with `source` + build wait → `datarobot_workload`).
+- `routes` attribute on `datarobot_artifact` container specs: a list of additional HTTP paths served by the container that are routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - `datarobot_artifact` now streams artifact image build OTEL logs to the provider's stderr while waiting for a source-triggered image build to complete (`source.wait_for_build = true`, the default). Terraform routes provider stderr through its own logging pipeline, so this progress output is visible when `TF_LOG` is set (e.g. `TF_LOG=DEBUG`), not on a plain `terraform apply`. On failure, the apply error always includes a tailed excerpt of build logs (WAPI build logs with OTEL fallback) and a link to the full build log page in the DataRobot UI, regardless of `TF_LOG`. Default tail length is 30 lines; override with `DATAROBOT_ARTIFACT_BUILD_LOGS_TAIL_LINES`.
 - `DATAROBOT_DEBUG` environment variable to opt into verbose HTTP request/response dumps and curl reproductions in error messages.
 - `examples/resources/datarobot_workload` example: end-to-end code-to-workload flow (`datarobot_artifact` with `source` + build wait → `datarobot_workload`).
-- `routes` attribute on `datarobot_artifact` container specs: a list of additional HTTP paths served by the container that are routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.
+- `routes` attribute on `datarobot_artifact` container specs (primary containers only): a list of `{ path, auth }` objects exposing additional paths from the workload's public endpoint with per-route authentication (`required`, `optional`, or `disabled`), for example `path = "/.well-known/oauth-authorization-server"` with `auth = "disabled"` for an MCP server's OAuth discovery document.
 
 ### Changed
 

--- a/docs/data-sources/artifact.md
+++ b/docs/data-sources/artifact.md
@@ -94,6 +94,7 @@ Read-Only:
 - `port` (Number) Container access port (1024-65535).
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
+- `routes` (List of String) Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.
 - `security_context` (Attributes) Container security context. (see [below for nested schema](#nestedatt--spec--container_groups--containers--security_context))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
 

--- a/docs/data-sources/artifact.md
+++ b/docs/data-sources/artifact.md
@@ -94,7 +94,7 @@ Read-Only:
 - `port` (Number) Container access port (1024-65535).
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
-- `routes` (List of String) Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.
+- `routes` (Attributes List) Routes exposed publicly from this container. (see [below for nested schema](#nestedatt--spec--container_groups--containers--routes))
 - `security_context` (Attributes) Container security context. (see [below for nested schema](#nestedatt--spec--container_groups--containers--security_context))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
 
@@ -190,6 +190,15 @@ Read-Only:
 - `scheme` (String) Scheme to use for connecting to the host (HTTP or HTTPS).
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
 - `timeout_seconds` (Number) Number of seconds after which the probe times out.
+
+
+<a id="nestedatt--spec--container_groups--containers--routes"></a>
+### Nested Schema for `spec.container_groups.containers.routes`
+
+Read-Only:
+
+- `auth` (String) Authentication applied to this route.
+- `path` (String) Route path relative to the workload root.
 
 
 <a id="nestedatt--spec--container_groups--containers--security_context"></a>

--- a/docs/data-sources/artifacts.md
+++ b/docs/data-sources/artifacts.md
@@ -105,6 +105,7 @@ Read-Only:
 - `port` (Number) Container access port (1024-65535).
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--readiness_probe))
+- `routes` (List of String) Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.
 - `security_context` (Attributes) Container security context. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--security_context))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--startup_probe))
 

--- a/docs/data-sources/artifacts.md
+++ b/docs/data-sources/artifacts.md
@@ -105,7 +105,7 @@ Read-Only:
 - `port` (Number) Container access port (1024-65535).
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--readiness_probe))
-- `routes` (List of String) Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.
+- `routes` (Attributes List) Routes exposed publicly from this container. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--routes))
 - `security_context` (Attributes) Container security context. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--security_context))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--artifacts--spec--container_groups--containers--startup_probe))
 
@@ -201,6 +201,15 @@ Read-Only:
 - `scheme` (String) Scheme to use for connecting to the host (HTTP or HTTPS).
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
 - `timeout_seconds` (Number) Number of seconds after which the probe times out.
+
+
+<a id="nestedatt--artifacts--spec--container_groups--containers--routes"></a>
+### Nested Schema for `artifacts.spec.container_groups.containers.routes`
+
+Read-Only:
+
+- `auth` (String) Authentication applied to this route.
+- `path` (String) Route path relative to the workload root.
 
 
 <a id="nestedatt--artifacts--spec--container_groups--containers--security_context"></a>

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -30,9 +30,13 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
-        # Extra paths served by the container to route from the workload's
-        # public endpoint, e.g. the OAuth discovery document for an MCP server.
-        routes = ["/.well-known/oauth-authorization-server"]
+        # Extra paths to route from the workload's public endpoint, e.g. the
+        # OAuth discovery document for an MCP server. "disabled" auth is
+        # required here since clients fetch this before they have a token.
+        routes = [{
+          path = "/.well-known/oauth-authorization-server"
+          auth = "disabled"
+        }]
       }]
     }]
   }
@@ -200,7 +204,7 @@ Optional:
 - `port` (Number) Container access port (1024-65535). Required for primary containers; omit for non-primary.
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
-- `routes` (List of String) Additional HTTP paths served by the container that should be routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.
+- `routes` (Attributes List) Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy. For example, expose an MCP server's OAuth discovery document with `path = "/.well-known/oauth-authorization-server"` and `auth = "disabled"`. (see [below for nested schema](#nestedatt--spec--container_groups--containers--routes))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
 
 Read-Only:
@@ -285,6 +289,15 @@ Optional:
 - `scheme` (String) Scheme to use for connecting to the host (HTTP or HTTPS).
 - `success_threshold` (Number) Minimum consecutive successes for the probe to be considered successful after having failed.
 - `timeout_seconds` (Number) Number of seconds after which the probe times out.
+
+
+<a id="nestedatt--spec--container_groups--containers--routes"></a>
+### Nested Schema for `spec.container_groups.containers.routes`
+
+Required:
+
+- `auth` (String) Authentication applied to this route: "required" rejects unauthenticated requests, "optional" authenticates when an Authorization header is present, "disabled" never attempts authentication.
+- `path` (String) Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`, for example `/.well-known/oauth-authorization-server`.
 
 
 <a id="nestedatt--spec--container_groups--containers--startup_probe"></a>

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -30,6 +30,9 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
+        # Extra paths served by the container to route from the workload's
+        # public endpoint, e.g. the OAuth discovery document for an MCP server.
+        routes = ["/.well-known/oauth-authorization-server"]
       }]
     }]
   }
@@ -197,6 +200,7 @@ Optional:
 - `port` (Number) Container access port (1024-65535). Required for primary containers; omit for non-primary.
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
+- `routes` (List of String) Additional HTTP paths served by the container that should be routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
 
 Read-Only:

--- a/docs/resources/artifact.md
+++ b/docs/resources/artifact.md
@@ -30,11 +30,10 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
-        # Extra paths to route from the workload's public endpoint, e.g. the
-        # OAuth discovery document for an MCP server. "disabled" auth is
-        # required here since clients fetch this before they have a token.
+        # Extra paths to expose from the workload's public endpoint, each with
+        # its own auth policy: "required", "optional", or "disabled".
         routes = [{
-          path = "/.well-known/oauth-authorization-server"
+          path = "/status"
           auth = "disabled"
         }]
       }]
@@ -204,7 +203,7 @@ Optional:
 - `port` (Number) Container access port (1024-65535). Required for primary containers; omit for non-primary.
 - `primary` (Boolean) Whether this is the primary container.
 - `readiness_probe` (Attributes) Container readiness check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--readiness_probe))
-- `routes` (Attributes List) Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy. For example, expose an MCP server's OAuth discovery document with `path = "/.well-known/oauth-authorization-server"` and `auth = "disabled"`. (see [below for nested schema](#nestedatt--spec--container_groups--containers--routes))
+- `routes` (Attributes List) Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy. (see [below for nested schema](#nestedatt--spec--container_groups--containers--routes))
 - `startup_probe` (Attributes) Container startup check configuration. (see [below for nested schema](#nestedatt--spec--container_groups--containers--startup_probe))
 
 Read-Only:
@@ -297,7 +296,7 @@ Optional:
 Required:
 
 - `auth` (String) Authentication applied to this route: "required" rejects unauthenticated requests, "optional" authenticates when an Authorization header is present, "disabled" never attempts authentication.
-- `path` (String) Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`, for example `/.well-known/oauth-authorization-server`.
+- `path` (String) Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`.
 
 
 <a id="nestedatt--spec--container_groups--containers--startup_probe"></a>

--- a/examples/resources/datarobot_artifact/resource.tf
+++ b/examples/resources/datarobot_artifact/resource.tf
@@ -15,9 +15,13 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
-        # Extra paths served by the container to route from the workload's
-        # public endpoint, e.g. the OAuth discovery document for an MCP server.
-        routes = ["/.well-known/oauth-authorization-server"]
+        # Extra paths to route from the workload's public endpoint, e.g. the
+        # OAuth discovery document for an MCP server. "disabled" auth is
+        # required here since clients fetch this before they have a token.
+        routes = [{
+          path = "/.well-known/oauth-authorization-server"
+          auth = "disabled"
+        }]
       }]
     }]
   }

--- a/examples/resources/datarobot_artifact/resource.tf
+++ b/examples/resources/datarobot_artifact/resource.tf
@@ -15,6 +15,9 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
+        # Extra paths served by the container to route from the workload's
+        # public endpoint, e.g. the OAuth discovery document for an MCP server.
+        routes = ["/.well-known/oauth-authorization-server"]
       }]
     }]
   }

--- a/examples/resources/datarobot_artifact/resource.tf
+++ b/examples/resources/datarobot_artifact/resource.tf
@@ -15,11 +15,10 @@ resource "datarobot_artifact" "prebuilt" {
         image_uri = "nginx:latest"
         primary   = true
         port      = 8080
-        # Extra paths to route from the workload's public endpoint, e.g. the
-        # OAuth discovery document for an MCP server. "disabled" auth is
-        # required here since clients fetch this before they have a token.
+        # Extra paths to expose from the workload's public endpoint, each with
+        # its own auth policy: "required", "optional", or "disabled".
         routes = [{
-          path = "/.well-known/oauth-authorization-server"
+          path = "/status"
           auth = "disabled"
         }]
       }]

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -314,6 +314,20 @@ const (
 	EnvironmentVariableSourceAPIKey     = "api-key"
 )
 
+const (
+	RouteAuthRequired = "required"
+	RouteAuthOptional = "optional"
+	RouteAuthDisabled = "disabled"
+)
+
+// ArtifactContainerRoute is a workload route exposed publicly from a primary
+// container, e.g. an MCP server's OAuth discovery document. Mirrors
+// workload_api.schemas.containers.WorkloadRoute.
+type ArtifactContainerRoute struct {
+	Path string `json:"path"`
+	Auth string `json:"auth"`
+}
+
 type ArtifactEnvironmentVariable struct {
 	Source string `json:"source,omitempty"`
 	// Name is optional for the api-key source (the platform resolves an
@@ -391,7 +405,7 @@ type ArtifactContainer struct {
 	Description      string                        `json:"description,omitempty"`
 	Port             *int64                        `json:"port,omitempty"`
 	Entrypoint       []string                      `json:"entrypoint,omitempty"`
-	Routes           []string                      `json:"routes,omitempty"`
+	Routes           []ArtifactContainerRoute      `json:"routes,omitempty"`
 	EnvironmentVars  []ArtifactEnvironmentVariable `json:"environmentVars,omitempty"`
 	StartupProbe     *ArtifactProbeConfig          `json:"startupProbe,omitempty"`
 	ReadinessProbe   *ArtifactProbeConfig          `json:"readinessProbe,omitempty"`

--- a/internal/client/workloads_service.go
+++ b/internal/client/workloads_service.go
@@ -391,6 +391,7 @@ type ArtifactContainer struct {
 	Description      string                        `json:"description,omitempty"`
 	Port             *int64                        `json:"port,omitempty"`
 	Entrypoint       []string                      `json:"entrypoint,omitempty"`
+	Routes           []string                      `json:"routes,omitempty"`
 	EnvironmentVars  []ArtifactEnvironmentVariable `json:"environmentVars,omitempty"`
 	StartupProbe     *ArtifactProbeConfig          `json:"startupProbe,omitempty"`
 	ReadinessProbe   *ArtifactProbeConfig          `json:"readinessProbe,omitempty"`

--- a/pkg/provider/artifact_mapping.go
+++ b/pkg/provider/artifact_mapping.go
@@ -154,9 +154,12 @@ func loadContainerIntoDataSourceModel(c client.ArtifactContainer) ArtifactContai
 		}
 	}
 	if len(c.Routes) > 0 {
-		model.Routes = make([]types.String, len(c.Routes))
+		model.Routes = make([]ArtifactContainerRouteModel, len(c.Routes))
 		for i, r := range c.Routes {
-			model.Routes[i] = types.StringValue(r)
+			model.Routes[i] = ArtifactContainerRouteModel{
+				Path: types.StringValue(r.Path),
+				Auth: types.StringValue(r.Auth),
+			}
 		}
 	}
 	if len(c.EnvironmentVars) > 0 {

--- a/pkg/provider/artifact_mapping.go
+++ b/pkg/provider/artifact_mapping.go
@@ -153,6 +153,12 @@ func loadContainerIntoDataSourceModel(c client.ArtifactContainer) ArtifactContai
 			model.Entrypoint[i] = types.StringValue(e)
 		}
 	}
+	if len(c.Routes) > 0 {
+		model.Routes = make([]types.String, len(c.Routes))
+		for i, r := range c.Routes {
+			model.Routes[i] = types.StringValue(r)
+		}
+	}
 	if len(c.EnvironmentVars) > 0 {
 		model.EnvironmentVars = make([]ArtifactEnvironmentVariableModel, len(c.EnvironmentVars))
 		for i, ev := range c.EnvironmentVars {

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -728,6 +728,14 @@ func containersEqual(a, b ArtifactContainerModel, ignoreManagedCodeRef, ignoreIm
 			return false
 		}
 	}
+	if len(a.Routes) != len(b.Routes) {
+		return false
+	}
+	for i := range a.Routes {
+		if !a.Routes[i].Equal(b.Routes[i]) {
+			return false
+		}
+	}
 	if len(a.EnvironmentVars) != len(b.EnvironmentVars) {
 		return false
 	}
@@ -1407,6 +1415,13 @@ func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContaine
 		}
 	}
 
+	if len(c.Routes) > 0 {
+		container.Routes = make([]string, len(c.Routes))
+		for i, r := range c.Routes {
+			container.Routes[i] = r.ValueString()
+		}
+	}
+
 	if len(c.EnvironmentVars) > 0 {
 		container.EnvironmentVars = make([]client.ArtifactEnvironmentVariable, len(c.EnvironmentVars))
 		for i, ev := range c.EnvironmentVars {
@@ -1638,6 +1653,13 @@ func loadContainerFromAPI(c client.ArtifactContainer, prior *ArtifactContainerMo
 		model.Entrypoint = make([]types.String, len(c.Entrypoint))
 		for i, e := range c.Entrypoint {
 			model.Entrypoint[i] = types.StringValue(e)
+		}
+	}
+
+	if len(c.Routes) > 0 {
+		model.Routes = make([]types.String, len(c.Routes))
+		for i, r := range c.Routes {
+			model.Routes[i] = types.StringValue(r)
 		}
 	}
 

--- a/pkg/provider/artifact_resource.go
+++ b/pkg/provider/artifact_resource.go
@@ -732,7 +732,7 @@ func containersEqual(a, b ArtifactContainerModel, ignoreManagedCodeRef, ignoreIm
 		return false
 	}
 	for i := range a.Routes {
-		if !a.Routes[i].Equal(b.Routes[i]) {
+		if !a.Routes[i].Path.Equal(b.Routes[i].Path) || !a.Routes[i].Auth.Equal(b.Routes[i].Auth) {
 			return false
 		}
 	}
@@ -1416,9 +1416,12 @@ func artifactContainerToClient(c ArtifactContainerModel) client.ArtifactContaine
 	}
 
 	if len(c.Routes) > 0 {
-		container.Routes = make([]string, len(c.Routes))
+		container.Routes = make([]client.ArtifactContainerRoute, len(c.Routes))
 		for i, r := range c.Routes {
-			container.Routes[i] = r.ValueString()
+			container.Routes[i] = client.ArtifactContainerRoute{
+				Path: r.Path.ValueString(),
+				Auth: r.Auth.ValueString(),
+			}
 		}
 	}
 
@@ -1657,9 +1660,12 @@ func loadContainerFromAPI(c client.ArtifactContainer, prior *ArtifactContainerMo
 	}
 
 	if len(c.Routes) > 0 {
-		model.Routes = make([]types.String, len(c.Routes))
+		model.Routes = make([]ArtifactContainerRouteModel, len(c.Routes))
 		for i, r := range c.Routes {
-			model.Routes[i] = types.StringValue(r)
+			model.Routes[i] = ArtifactContainerRouteModel{
+				Path: types.StringValue(r.Path),
+				Auth: types.StringValue(r.Auth),
+			}
 		}
 	}
 

--- a/pkg/provider/artifact_resource_test.go
+++ b/pkg/provider/artifact_resource_test.go
@@ -4528,7 +4528,7 @@ func TestArtifactContainerToClient_routes(t *testing.T) {
 		Port:     types.Int64Value(8080),
 		Routes: []ArtifactContainerRouteModel{
 			{
-				Path: types.StringValue("/.well-known/oauth-authorization-server"),
+				Path: types.StringValue("/status"),
 				Auth: types.StringValue(client.RouteAuthDisabled),
 			},
 		},
@@ -4537,7 +4537,7 @@ func TestArtifactContainerToClient_routes(t *testing.T) {
 	if len(container.Routes) != 1 {
 		t.Fatalf("routes length: got %d, want 1", len(container.Routes))
 	}
-	if container.Routes[0].Path != "/.well-known/oauth-authorization-server" {
+	if container.Routes[0].Path != "/status" {
 		t.Fatalf("unexpected route path: %q", container.Routes[0].Path)
 	}
 	if container.Routes[0].Auth != client.RouteAuthDisabled {
@@ -4561,14 +4561,14 @@ func TestLoadContainerFromAPI_routes(t *testing.T) {
 	model := loadContainerFromAPI(client.ArtifactContainer{
 		ImageURI: "registry.example/mcp:latest",
 		Routes: []client.ArtifactContainerRoute{
-			{Path: "/.well-known/oauth-authorization-server", Auth: client.RouteAuthDisabled},
+			{Path: "/status", Auth: client.RouteAuthDisabled},
 		},
 	}, nil)
 
 	if len(model.Routes) != 1 {
 		t.Fatalf("routes length: got %d, want 1", len(model.Routes))
 	}
-	if got := model.Routes[0].Path.ValueString(); got != "/.well-known/oauth-authorization-server" {
+	if got := model.Routes[0].Path.ValueString(); got != "/status" {
 		t.Fatalf("unexpected route path: %q", got)
 	}
 	if got := model.Routes[0].Auth.ValueString(); got != client.RouteAuthDisabled {
@@ -4585,7 +4585,7 @@ func TestContainersEqual_routes(t *testing.T) {
 	changed := base
 	changed.Routes = []ArtifactContainerRouteModel{
 		{
-			Path: types.StringValue("/.well-known/oauth-authorization-server"),
+			Path: types.StringValue("/status"),
 			Auth: types.StringValue(client.RouteAuthDisabled),
 		},
 	}
@@ -4600,7 +4600,7 @@ func TestContainersEqual_routes(t *testing.T) {
 	authChanged := changed
 	authChanged.Routes = []ArtifactContainerRouteModel{
 		{
-			Path: types.StringValue("/.well-known/oauth-authorization-server"),
+			Path: types.StringValue("/status"),
 			Auth: types.StringValue(client.RouteAuthRequired),
 		},
 	}

--- a/pkg/provider/artifact_resource_test.go
+++ b/pkg/provider/artifact_resource_test.go
@@ -4521,6 +4521,94 @@ func TestArtifactNeedsNewVersion_sidecarImageChangeWithSource(t *testing.T) {
 	}
 }
 
+func TestArtifactContainerToClient_routes(t *testing.T) {
+	container := artifactContainerToClient(ArtifactContainerModel{
+		ImageURI: types.StringValue("registry.example/mcp:latest"),
+		Primary:  types.BoolValue(true),
+		Port:     types.Int64Value(8080),
+		Routes: []ArtifactContainerRouteModel{
+			{
+				Path: types.StringValue("/.well-known/oauth-authorization-server"),
+				Auth: types.StringValue(client.RouteAuthDisabled),
+			},
+		},
+	})
+
+	if len(container.Routes) != 1 {
+		t.Fatalf("routes length: got %d, want 1", len(container.Routes))
+	}
+	if container.Routes[0].Path != "/.well-known/oauth-authorization-server" {
+		t.Fatalf("unexpected route path: %q", container.Routes[0].Path)
+	}
+	if container.Routes[0].Auth != client.RouteAuthDisabled {
+		t.Fatalf("unexpected route auth: %q", container.Routes[0].Auth)
+	}
+}
+
+func TestArtifactContainerToClient_routesOmittedWhenUnset(t *testing.T) {
+	container := artifactContainerToClient(ArtifactContainerModel{
+		ImageURI: types.StringValue("registry.example/mcp:latest"),
+		Primary:  types.BoolValue(true),
+		Port:     types.Int64Value(8080),
+	})
+
+	if container.Routes != nil {
+		t.Fatalf("expected no routes, got %v", container.Routes)
+	}
+}
+
+func TestLoadContainerFromAPI_routes(t *testing.T) {
+	model := loadContainerFromAPI(client.ArtifactContainer{
+		ImageURI: "registry.example/mcp:latest",
+		Routes: []client.ArtifactContainerRoute{
+			{Path: "/.well-known/oauth-authorization-server", Auth: client.RouteAuthDisabled},
+		},
+	}, nil)
+
+	if len(model.Routes) != 1 {
+		t.Fatalf("routes length: got %d, want 1", len(model.Routes))
+	}
+	if got := model.Routes[0].Path.ValueString(); got != "/.well-known/oauth-authorization-server" {
+		t.Fatalf("unexpected route path: %q", got)
+	}
+	if got := model.Routes[0].Auth.ValueString(); got != client.RouteAuthDisabled {
+		t.Fatalf("unexpected route auth: %q", got)
+	}
+}
+
+func TestContainersEqual_routes(t *testing.T) {
+	base := ArtifactContainerModel{
+		ImageURI: types.StringValue("registry.example/mcp:latest"),
+		Primary:  types.BoolValue(true),
+		Port:     types.Int64Value(8080),
+	}
+	changed := base
+	changed.Routes = []ArtifactContainerRouteModel{
+		{
+			Path: types.StringValue("/.well-known/oauth-authorization-server"),
+			Auth: types.StringValue(client.RouteAuthDisabled),
+		},
+	}
+
+	if containersEqual(base, changed, false, false) {
+		t.Fatal("expected routes change to make containers unequal")
+	}
+	if !containersEqual(changed, changed, false, false) {
+		t.Fatal("expected identical routes to be equal")
+	}
+
+	authChanged := changed
+	authChanged.Routes = []ArtifactContainerRouteModel{
+		{
+			Path: types.StringValue("/.well-known/oauth-authorization-server"),
+			Auth: types.StringValue(client.RouteAuthRequired),
+		},
+	}
+	if containersEqual(changed, authChanged, false, false) {
+		t.Fatal("expected auth-only route change to make containers unequal")
+	}
+}
+
 func TestIntegrationArtifactDraftImageBuildConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/provider/artifact_spec_schema.go
+++ b/pkg/provider/artifact_spec_schema.go
@@ -187,6 +187,33 @@ func artifactResourceEnvironmentVarAttributes() map[string]schema.Attribute {
 	}
 }
 
+func artifactResourceRouteAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"path": schema.StringAttribute{
+			Required:            true,
+			MarkdownDescription: "Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`, for example `/.well-known/oauth-authorization-server`.",
+		},
+		"auth": schema.StringAttribute{
+			Required:            true,
+			MarkdownDescription: `Authentication applied to this route: "required" rejects unauthenticated requests, "optional" authenticates when an Authorization header is present, "disabled" never attempts authentication.`,
+			Validators:          RouteAuthValidators(),
+		},
+	}
+}
+
+func artifactDataSourceRouteAttributes() map[string]datasourceschema.Attribute {
+	return map[string]datasourceschema.Attribute{
+		"path": datasourceschema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Route path relative to the workload root.",
+		},
+		"auth": datasourceschema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Authentication applied to this route.",
+		},
+	}
+}
+
 func artifactDataSourceEnvironmentVarAttributes() map[string]datasourceschema.Attribute {
 	return map[string]datasourceschema.Attribute{
 		"source": datasourceschema.StringAttribute{
@@ -277,10 +304,12 @@ func artifactResourceContainerAttributes(probeAttributes, imageBuildConfigAttrib
 			ElementType:         types.StringType,
 			MarkdownDescription: "Container entrypoint.",
 		},
-		"routes": schema.ListAttribute{
+		"routes": schema.ListNestedAttribute{
 			Optional:            true,
-			ElementType:         types.StringType,
-			MarkdownDescription: "Additional HTTP paths served by the container that should be routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.",
+			MarkdownDescription: "Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy. For example, expose an MCP server's OAuth discovery document with `path = \"/.well-known/oauth-authorization-server\"` and `auth = \"disabled\"`.",
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: artifactResourceRouteAttributes(),
+			},
 		},
 		"environment_vars": schema.ListNestedAttribute{
 			Optional:            true,
@@ -342,10 +371,12 @@ func artifactDataSourceContainerAttributes(probeAttributes map[string]datasource
 			ElementType:         types.StringType,
 			MarkdownDescription: "Container entrypoint.",
 		},
-		"routes": datasourceschema.ListAttribute{
+		"routes": datasourceschema.ListNestedAttribute{
 			Computed:            true,
-			ElementType:         types.StringType,
-			MarkdownDescription: "Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.",
+			MarkdownDescription: "Routes exposed publicly from this container.",
+			NestedObject: datasourceschema.NestedAttributeObject{
+				Attributes: artifactDataSourceRouteAttributes(),
+			},
 		},
 		"environment_vars": datasourceschema.ListNestedAttribute{
 			Computed:            true,

--- a/pkg/provider/artifact_spec_schema.go
+++ b/pkg/provider/artifact_spec_schema.go
@@ -277,6 +277,11 @@ func artifactResourceContainerAttributes(probeAttributes, imageBuildConfigAttrib
 			ElementType:         types.StringType,
 			MarkdownDescription: "Container entrypoint.",
 		},
+		"routes": schema.ListAttribute{
+			Optional:            true,
+			ElementType:         types.StringType,
+			MarkdownDescription: "Additional HTTP paths served by the container that should be routed to it from the workload's public endpoint, for example `/.well-known/oauth-authorization-server` for an MCP server's OAuth discovery document.",
+		},
 		"environment_vars": schema.ListNestedAttribute{
 			Optional:            true,
 			MarkdownDescription: "Environment variables for the container.",
@@ -336,6 +341,11 @@ func artifactDataSourceContainerAttributes(probeAttributes map[string]datasource
 			Computed:            true,
 			ElementType:         types.StringType,
 			MarkdownDescription: "Container entrypoint.",
+		},
+		"routes": datasourceschema.ListAttribute{
+			Computed:            true,
+			ElementType:         types.StringType,
+			MarkdownDescription: "Additional HTTP paths served by the container that are routed to it from the workload's public endpoint.",
 		},
 		"environment_vars": datasourceschema.ListNestedAttribute{
 			Computed:            true,

--- a/pkg/provider/artifact_spec_schema.go
+++ b/pkg/provider/artifact_spec_schema.go
@@ -191,7 +191,7 @@ func artifactResourceRouteAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"path": schema.StringAttribute{
 			Required:            true,
-			MarkdownDescription: "Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`, for example `/.well-known/oauth-authorization-server`.",
+			MarkdownDescription: "Route path relative to the workload root, excluding the URL prefix the workload is mounted on. Must start with `/`.",
 		},
 		"auth": schema.StringAttribute{
 			Required:            true,
@@ -306,7 +306,7 @@ func artifactResourceContainerAttributes(probeAttributes, imageBuildConfigAttrib
 		},
 		"routes": schema.ListNestedAttribute{
 			Optional:            true,
-			MarkdownDescription: "Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy. For example, expose an MCP server's OAuth discovery document with `path = \"/.well-known/oauth-authorization-server\"` and `auth = \"disabled\"`.",
+			MarkdownDescription: "Routes to expose publicly from this container. Primary containers only. The workload root (`/`) is authenticated by default unless declared here with another policy.",
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: artifactResourceRouteAttributes(),
 			},

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1034,6 +1034,7 @@ type ArtifactContainerModel struct {
 	Description      types.String                       `tfsdk:"description"`
 	Port             types.Int64                        `tfsdk:"port"`
 	Entrypoint       []types.String                     `tfsdk:"entrypoint"`
+	Routes           []types.String                     `tfsdk:"routes"`
 	EnvironmentVars  []ArtifactEnvironmentVariableModel `tfsdk:"environment_vars"`
 	StartupProbe     *ArtifactProbeConfigModel          `tfsdk:"startup_probe"`
 	ReadinessProbe   *ArtifactProbeConfigModel          `tfsdk:"readiness_probe"`
@@ -1137,6 +1138,7 @@ type ArtifactContainerDSModel struct {
 	Description      types.String                       `tfsdk:"description"`
 	Port             types.Int64                        `tfsdk:"port"`
 	Entrypoint       []types.String                     `tfsdk:"entrypoint"`
+	Routes           []types.String                     `tfsdk:"routes"`
 	EnvironmentVars  []ArtifactEnvironmentVariableModel `tfsdk:"environment_vars"`
 	StartupProbe     *ArtifactProbeConfigModel          `tfsdk:"startup_probe"`
 	ReadinessProbe   *ArtifactProbeConfigModel          `tfsdk:"readiness_probe"`

--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -1034,7 +1034,7 @@ type ArtifactContainerModel struct {
 	Description      types.String                       `tfsdk:"description"`
 	Port             types.Int64                        `tfsdk:"port"`
 	Entrypoint       []types.String                     `tfsdk:"entrypoint"`
-	Routes           []types.String                     `tfsdk:"routes"`
+	Routes           []ArtifactContainerRouteModel      `tfsdk:"routes"`
 	EnvironmentVars  []ArtifactEnvironmentVariableModel `tfsdk:"environment_vars"`
 	StartupProbe     *ArtifactProbeConfigModel          `tfsdk:"startup_probe"`
 	ReadinessProbe   *ArtifactProbeConfigModel          `tfsdk:"readiness_probe"`
@@ -1067,6 +1067,11 @@ type ArtifactEnvironmentVariableModel struct {
 	Value          types.String `tfsdk:"value"`
 	DrCredentialID types.String `tfsdk:"dr_credential_id"`
 	Key            types.String `tfsdk:"key"`
+}
+
+type ArtifactContainerRouteModel struct {
+	Path types.String `tfsdk:"path"`
+	Auth types.String `tfsdk:"auth"`
 }
 
 type ArtifactProbeConfigModel struct {
@@ -1138,7 +1143,7 @@ type ArtifactContainerDSModel struct {
 	Description      types.String                       `tfsdk:"description"`
 	Port             types.Int64                        `tfsdk:"port"`
 	Entrypoint       []types.String                     `tfsdk:"entrypoint"`
-	Routes           []types.String                     `tfsdk:"routes"`
+	Routes           []ArtifactContainerRouteModel      `tfsdk:"routes"`
 	EnvironmentVars  []ArtifactEnvironmentVariableModel `tfsdk:"environment_vars"`
 	StartupProbe     *ArtifactProbeConfigModel          `tfsdk:"startup_probe"`
 	ReadinessProbe   *ArtifactProbeConfigModel          `tfsdk:"readiness_probe"`

--- a/pkg/provider/validators.go
+++ b/pkg/provider/validators.go
@@ -990,3 +990,13 @@ func ArtifactDockerfileSourceValidators() []validator.String {
 		stringvalidator.OneOf("provided", "generated"),
 	}
 }
+
+func RouteAuthValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf(
+			client.RouteAuthRequired,
+			client.RouteAuthOptional,
+			client.RouteAuthDisabled,
+		),
+	}
+}


### PR DESCRIPTION
<!-- Replace placeholders; keep checklist. -->

## Summary
Adds a `routes` attribute to `datarobot_artifact` container specs. It lets a container declare additional HTTP paths (beyond its normal traffic) that should be routed to it from the workload's public endpoint — for example an MCP server's OAuth discovery document at `/.well-known/oauth-authorization-server`. Raised as feedback that the container spec (`ArtifactSpecContainerGroupContainerArgs`) had no way to expose that path from a workload.

## Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs
- [ ] chore / refactor
- [ ] test
- [ ] ci

## Details / User Impact
- New optional `routes` (list of strings) attribute on `spec.container_groups[].containers[]` for `datarobot_artifact`, mirrored as a computed `routes` attribute on the `datarobot_artifact` and `datarobot_artifacts` data sources.
- Passed through to the Workload API as `routes` (`omitempty`) on the container payload; no changes to any other request/response shape.
- Included in the provider's container-diff check (`containersEqual`), so a `routes`-only change is detected like any other spec field and triggers the same create/update/new-version behavior as e.g. `entrypoint`.
- Purely additive — no schema breaking changes, no migration needed. Existing configs without `routes` are unaffected.
- `docs/resources/artifact.md`, `docs/data-sources/artifact.md`, `docs/data-sources/artifacts.md` regenerated via `make generate` to include the new attribute.
- `examples/resources/datarobot_artifact/resource.tf` updated with a `routes` example showing the MCP OAuth well-known path.

## CHANGELOG
- [x] Added an entry under Unreleased in CHANGELOG.md

## Testing
- `go build ./...` — passes.
- `go vet ./...` — clean.
- `make generate` — regenerated docs; diff limited to the new `routes` attribute (6 lines across 3 files).
- `go test ./pkg/provider/... -run Artifact` — no new failures introduced. Three pre-existing failures reproduce identically on the base branch without this change (`TestIntegrationWorkloadReplaceOnArtifactIDChange`, `TestIntegrationWorkloadUpdateMetadataAndArtifactChange` need `DATAROBOT_API_TOKEN`/full mock expectations for an unrelated acceptance path; `TestSyncArtifactSourceAndBuild/build_failure_wraps_artifactBuildSyncError` has an unrelated mock gap) — confirmed by comparing against the parent branch.
- No new unit test added for `routes` specifically; it follows the exact same code path as the existing `entrypoint` field (schema, model, to/from-client mapping, equality check), which is already covered by existing container tests.

## Release Preparation Checklist
Complete if this should go into next release:
- [x] CHANGELOG updated
- [ ] All CI checks green
- [ ] Reviewers assigned / approved
- [ ] Version impact considered (patch / minor / major) — suggested **minor** (new optional attribute, additive)

## After Merge (maintainers / releaser)
To cut a release:
```
git fetch origin
git checkout main
git pull
# choose next version: vX.Y.Z
git tag vX.Y.Z
git push origin vX.Y.Z
```
This triggers release workflow: .github/workflows/release.yml

## Additional Notes
- Branch: `brunoromano-dr/RAPTOR-19616-param-routes`. Parent / compare base: `brunoromano-dr/RAPTOR-19616-replacement-404-fix`.
- Diff vs parent: 10 files, +51 / −0 (`internal/client/workloads_service.go`, `pkg/provider/models.go`, `pkg/provider/artifact_spec_schema.go`, `pkg/provider/artifact_resource.go`, `pkg/provider/artifact_mapping.go`, `examples/resources/datarobot_artifact/resource.tf`, `CHANGELOG.md`, `docs/resources/artifact.md`, `docs/data-sources/artifact.md`, `docs/data-sources/artifacts.md`).
- `routes` is a flat list of path strings, matching the existing `entrypoint` field's shape/style rather than introducing a new nested object type, since no sub-fields (e.g. per-route port/method) were requested.
- Jira: [RAPTOR-19616](https://datarobot.atlassian.net/browse/RAPTOR-19616)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on artifact containers with pass-through to the Workload API; no auth, migration, or breaking schema changes.
> 
> **Overview**
> Adds an optional **`routes`** list on `datarobot_artifact` container specs so containers can declare extra HTTP paths (e.g. `/.well-known/oauth-authorization-server` for MCP OAuth discovery) that the platform routes from the workload’s public endpoint.
> 
> The attribute is wired end-to-end: Terraform resource schema (optional), **`datarobot_artifact`** / **`datarobot_artifacts`** data sources (computed), API client **`routes`** field, plan/state mapping, and **`containersEqual`** so route-only changes trigger the same draft patch or new locked version behavior as other spec fields. Docs, CHANGELOG, and the prebuilt-image example are updated; existing configs without **`routes`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6015a771bc280ebedad8066893af90235cc29523. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->